### PR TITLE
refs #313 use the qore binary instead of qr since qr will be removed …

### DIFF
--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -1,4 +1,4 @@
-#!/usr/bin/env qr
+#!/usr/bin/env qore
 # -*- mode: qore; indent-tabs-mode: nil -*-
 
 # requires at least this qore version to run
@@ -6,6 +6,8 @@
 
 %new-style
 %require-types
+%strict-args
+%enable-all-warnings
 
 %requires QUnit
 


### PR DESCRIPTION
…from qore until %strict-types has been implemented
