### PR TITLE
refs qorelanguage/qore#984 fixed handling of empty complexType declarations of elements

### DIFF
--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1136,12 +1136,7 @@ public class WSDL::XsdSimpleType inherits WSDL::XsdAbstractType {
             WSDL::XsdBase::removeNS(\r);
 
             if (r.enumeration)
-                map enum.($1."^attributes^".value) = True, r.enumeration;
-            #enum = map $1."^attributes^".value, r.enumeration;
-            /*
-            else
-                throw "XSD-SIMPLETYPE-ERROR", sprintf("missing enumeration element in simpleType %y restriction", name);
-            */
+                enum = map {$1."^attributes^".value: True}, r.enumeration;
         }
         else
             throw "XSD-SIMPLETYPE-ERROR", sprintf("missing restriction element in simpleType %y", name);
@@ -1196,7 +1191,6 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
     }
 
     private {
-
         #! type of complexType object
         string cx_type;
 
@@ -1207,7 +1201,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         const XET_NONE     = "NONE";
     }
 
-    constructor(hash ct, Namespaces nsc, XsdLateResolverHelper unresolved, *string desc_name) : XsdAbstractType(\ct, nsc, desc_name) {
+    constructor(*hash ct, Namespaces nsc, XsdLateResolverHelper unresolved, *string desc_name) : XsdAbstractType(\ct, nsc, desc_name) {
         #any a = ct."^attributes^";
         delete ct."^attributes^";
 

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1018,16 +1018,23 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
     any serialize(any h, *softbool omit_type, *softbool omit_ns, string key, string typename) {
         if (type.typeCode() == NT_HASH)
             printf("ERROR: %y\n", self);
-        return serializeAsIntern(type, h, omit_type, omit_ns, key, typename);
-    }
 
-    any serializeAs(XsdAbstractType type, any h, *softbool omit_type, *softbool omit_ns, string key, string typename) {
-        type.checkExtends(type, name);
-        return serializeAsIntern(type, h, omit_type, omit_ns, key, name);
+        if (h."^type^" && h."^type^" instanceof XsdAbstractType && h.hasKey("^val^")) {
+            XsdAbstractType ntype = cast<XsdAbstractType>(h."^type^");
+            ntype.checkExtends(type, name);
+            return serializeAsIntern(ntype, h."^val^", omit_type, omit_ns, key, name);
+        }
+
+        return serializeAsIntern(type, h, omit_type, omit_ns, key, typename);
     }
 
     private any serializeAsIntern(XsdAbstractType type, any h, *softbool omit_type, *softbool omit_ns, string key, string typename) {
         #printf("DEBUG: XsdElement::serializeAsIntern() name: %y h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);
+
+        # XXX
+        if (type.getNameWithNS() == "ns1:string")
+            throw "ERROR", sprintf("type: %N", type);
+
         int tc = h.typeCode();
         if (tc == NT_LIST && h.size() == 1)
             h = h[0];
@@ -1038,7 +1045,7 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
 
             if (nillable || type.isNillable()) {
                 hash rh = ("xsi:nil" : "true");
-                if (!omit_type)
+                if (!omit_type || type != self)
                     rh += ("xsi:type" : type.getNameWithNS());
                 return ("^attributes^" : rh);
             }
@@ -1050,7 +1057,7 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
         }
 
         *hash pf;
-        if (omit_type && type != type)
+        if (!omit_type || type != self)
             pf = ("^attributes^": ("xsi:type": omit_ns ? type.getName() : type.getNameWithNS()));
 
         if (tc == NT_LIST) {
@@ -1310,8 +1317,9 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         }
     }
 
+    #! throws an exception if the types are not compatible
     checkExtends(XsdAbstractType t, string ename) {
-        if (extension == t.name)
+        if (extension == t.name || t == self)
             return;
         throw SOAP_SERIALIZATION_ERROR, sprintf("explicit type %y given for element %y, type %y, however the types are not compatible%s", name, ename, t.name, extension ? sprintf("; %y extends %y", name, extension) : "");
     }
@@ -1412,16 +1420,10 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
     }
 
     private *hash serializeElement(string key, XsdElement element, any h, *softbool omit_type, *softbool omit_ns) {
-        any e;
         any v = h{key};
         string e_ons;
         #printf("DEBUG: XsdComplexType::serializeElement() key: %y v: %y h: %y ns: %y\n", key, v, h, nsc.getTargetNamespaceUri());
-        if (v."^type^" && v."^type^" instanceof XsdAbstractType && v.hasKey("^val^")) {
-            #printf("DBG: type: %s: %y val: %y\n", v."^type^".className(), v."^type^".name, v."^val^");
-            e = element.serializeAs(v."^type^", v."^val^", omit_type, omit_ns, key, name);
-        }
-        else
-            e = element.serialize(v, omit_type, omit_ns, key, name);
+        any e = element.serialize(v, omit_type, omit_ns, key, name);
 
         if (!exists e && !element.isRequired())
             return;
@@ -1558,13 +1560,13 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
             # ensure types match
             *string tn = attr."xsi:type";
             if (exists tn) {
-                (*string ns, *string name) = tn =~ x/(.*):(.*)/;
-                if (exists name)
-                    tn = name;
+                (*string ns, *string tname) = tn =~ x/(.*):(.*)/;
+                if (exists tname)
+                    tn = tname;
                 if (tn != name) {
-                    #printf("DEBUG: %y: %s\n", tn, types{tn} ? types{tn}.className() : "n/a");
                     # check for compatible extension
                     *XsdAbstractType t = tmap.tryGet(tn);
+                    #printf("DEBUG: type provided %y: %y\n", tn, t.name);
                     if (t) {
                         t.checkExtends(self, en);
                         return t.deserialize(en, tmap, mrh, oval);
@@ -2152,22 +2154,14 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         foreach any p in (m.part) {
             any arg = p."^attributes^";
             if (arg.element) {
-                (*string ns, *string name) = arg.element =~ x/(\w+):(\w+)/;
-                if (!name)
-                    name = arg.element;
+                (*string ns, *string ename) = arg.element =~ x/(\w+):(\w+)/;
+                if (!ename)
+                    ename = arg.element;
 
-                if (arg.name && arg.name != name)
-                    pmap{name} = arg.name;
+                if (arg.name && arg.name != ename)
+                    pmap{ename} = arg.name;
 
-                args{name}.element = emap.get(nsc.getNamespaceUri(ns), name);
-
-                /*
-                if (!elementmap{name}) {
-                    #printf("DEBUG: WSMessage::constructor() message %y element %y (%y)\n", name, arg.element, keys elementmap);
-                    throw WSDL_ERROR, sprintf("message %y references unknown element %y (known elements: %y)", name, name, elementmap.keys());
-                }
-                args{name}.element = elementmap{name};
-                */
+                args{ename}.element = emap.get(nsc.getNamespaceUri(ns), ename);
             }
             else {
                 args{arg.name} = arg;
@@ -2198,6 +2192,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
 
             any hv;
             #printf("DEBUG: arg %y with %y\n", k, args{k});
+            #printf("DEBUG: arg %y with %y\n", k, v."^val^" ?? v);
             string ons;
             if (args{k}.element) {
                 hv = args{k}.element.serialize(v, !encoded, NOTHING, k, name);
@@ -2823,14 +2818,14 @@ public class WSDL::Namespaces {
         if (!type) {
             #printf("DEBUG: XsdBase::doType(%y) xsd: %y\n", t, default_ns);
             if (default_ns == XSD_NS)
-                return new XsdBaseType(t, self, getTargetNamespaceInputPrefix());
+                return new XsdBaseType(t, self);
 
             return ("val": t);
         }
 
         # if this is in the XML Schema namespace, then it's a base type
         if (xsd_schema{ns})
-            return new XsdBaseType(type, self, getTargetNamespaceInputPrefix());
+            return new XsdBaseType(type, self);
 
         return ("ns": getOutputNamespacePrefix(getInputNamespaceUri(ns)), "val": type);
     }

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1031,10 +1031,6 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
     private any serializeAsIntern(XsdAbstractType type, any h, *softbool omit_type, *softbool omit_ns, string key, string typename) {
         #printf("DEBUG: XsdElement::serializeAsIntern() name: %y h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);
 
-        # XXX
-        if (type.getNameWithNS() == "ns1:string")
-            throw "ERROR", sprintf("type: %N", type);
-
         int tc = h.typeCode();
         if (tc == NT_LIST && h.size() == 1)
             h = h[0];
@@ -1208,6 +1204,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         const XET_NONE     = "NONE";
     }
 
+    # ct can be NOTHING in case of an empty complex type
     constructor(*hash ct, Namespaces nsc, XsdLateResolverHelper unresolved, *string desc_name) : XsdAbstractType(\ct, nsc, desc_name) {
         #any a = ct."^attributes^";
         delete ct."^attributes^";

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -123,6 +123,9 @@ class SoapTest inherits QUnit::Test {
             <sim:issue560_2>A</sim:issue560_2>
             <sim:issue560_3>A</sim:issue560_3>
          </sim:issue560>
+         <sim:issue984>
+            <sim:i984_empty/>
+         </sim:issue984>
          <logo>dGVzdA==</logo>
       </sim:setInfo>
    </soap:Body>
@@ -155,7 +158,7 @@ class SoapTest inherits QUnit::Test {
     }
 
     soapTestCase() {
-        WebService ws = new WebService(ReadOnlyFile::readTextFile(get_script_dir() + "/test.wsdl"));
+        WebService ws(ReadOnlyFile::readTextFile(get_script_dir() + "/test.wsdl"));
         WSOperation op = ws.getOperation("setInfo");
 
         hash req = (
@@ -183,6 +186,7 @@ class SoapTest inherits QUnit::Test {
                 "issue560_2": "A",
                 "issue560_3": "A",
             ),
+            "issue984": NOTHING,
             "logo": binary("test"),
             );
 

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -126,6 +126,10 @@ class SoapTest inherits QUnit::Test {
          <sim:issue984>
             <sim:i984_empty/>
          </sim:issue984>
+         <sim:issue985 xsi:type=\"sim:i985_2\">
+            <sim:i985_e1>test</sim:i985_e1>
+            <sim:i985_e2>test</sim:i985_e2>
+         </sim:issue985>
          <logo>dGVzdA==</logo>
       </sim:setInfo>
    </soap:Body>
@@ -187,6 +191,7 @@ class SoapTest inherits QUnit::Test {
                 "issue560_3": "A",
             ),
             "issue984": NOTHING,
+            "issue985": ws.getType("i985_2", ("i985_e1": "test", "i985_e2": "test",)),
             "logo": binary("test"),
             );
 
@@ -205,7 +210,13 @@ class SoapTest inherits QUnit::Test {
         h = parse_xml(h.body);
         h = op.deserializeRequest(h);
 
-        testAssertionValue("attr-deser-our", h, req);
+        hash req_r = req + (
+            "issue985": (
+                "i985_e1": "test", "i985_e2": "test",
+            ),
+            );
+
+        assertEq(req_r, h, "attr-deser-our");
 
         # do negative tests to ensure that namespace handling is correct in our test code
         {
@@ -249,7 +260,7 @@ class SoapTest inherits QUnit::Test {
         h = parse_xml(SoapUiReq_1);
         h = op.deserializeRequest(h);
 
-        testAssertionValue("attr-deser-soapui", h, req);
+        assertEq(req_r, h, "attr-deser-soapui");
 
         h = op.serializeResponse(Res_1);
         xh = parse_xml(h.body);

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -16,12 +16,18 @@
       <s:element name="Test">
 	<s:complexType>
 	  <s:simpleContent>
-            <s:extension base="s:string">
+            <s:extension base="tns:testEnum">
               <s:attribute name="info" type="s:string" use="required"/>
             </s:extension>
           </s:simpleContent>
 	</s:complexType>
       </s:element>
+      <s:simpleType name="testEnum">
+	<restriction base="xsd:string">
+	  <enumeration value="test"/>
+	  <enumeration value="other"/>
+        </restriction>
+      </s:simpleType>
       <s:complexType name="issue86">
 	<s:sequence>
 	  <s:element maxOccurs="1" minOccurs="1" ref="tns:issue86"/>
@@ -82,8 +88,7 @@
       <s:element name="issue468">
 	<s:complexType>
 	  <s:sequence>
-	    <s:element name="issue468_1" nillable="true"
-		       type="s:string"/>
+	    <s:element name="issue468_1" nillable="true" type="s:string"/>
 	  </s:sequence>
 	</s:complexType>
       </s:element>
@@ -128,6 +133,29 @@
           <s:element maxOccurs="1" minOccurs="1" name="i663element_3" type="s:string"/>
         </s:sequence>
       </s:complexType>
+      <s:complexType name="i975">
+	<s:simpleContent>
+          <s:extension base="tns:i975_1">
+            <s:attribute name="info" type="s:string" use="required"/>
+          </s:extension>
+        </s:simpleContent>
+      </s:complexType>
+      <s:simpleType name="i975_1">
+	<restriction base="xsd:string">
+	  <!-- "length" and "pattern" restrictions not yet supported -->
+          <length value="18"/>
+          <pattern value='[a-zA-Z0-9]{18}'/>
+        </restriction>
+      </s:simpleType>
+      <s:complexType name="i984">
+        <s:sequence>
+          <s:element name="i984_empty">
+	    <s:complexType>
+	    </s:complexType>
+	  </s:element>
+        </s:sequence>
+      </s:complexType>
+      <s:element name="issue984" type="tns:i984"/>
     </s:schema>
     <s:schema xmlns:tns1="http://qore.org/simpletest1" elementFormDefault="qualified" targetNamespace="http://qore.org/simpletest1">
       <s:element name="issue86" type="tns1:issue86_1"/>
@@ -157,6 +185,7 @@
     <wsdl:part name="issue97" element="tns:issue97"/>
     <wsdl:part name="issue468" element="tns:issue468"/>
     <wsdl:part name="issue560" element="tns:issue560"/>
+    <wsdl:part name="issue984" element="tns:issue984"/>
     <wsdl:part name="logo" type="s:base64Binary"/>
   </wsdl:message>
 

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -156,6 +156,21 @@
         </s:sequence>
       </s:complexType>
       <s:element name="issue984" type="tns:i984"/>
+      <s:complexType name="i985_2">
+	<s:complexContent>
+          <s:extension base="tns:i985_1">
+            <s:sequence>
+              <s:element maxOccurs="1" minOccurs="1" name="i985_e2" type="s:string"/>
+            </s:sequence>
+	  </s:extension>
+	</s:complexContent>
+      </s:complexType>
+      <s:complexType name="i985_1">
+	<s:sequence>
+	  <s:element name="i985_e1" nillable="true" type="s:string"/>
+	</s:sequence>
+      </s:complexType>
+      <s:element name="issue985" type="tns:i985_1"/>
     </s:schema>
     <s:schema xmlns:tns1="http://qore.org/simpletest1" elementFormDefault="qualified" targetNamespace="http://qore.org/simpletest1">
       <s:element name="issue86" type="tns1:issue86_1"/>
@@ -186,6 +201,7 @@
     <wsdl:part name="issue468" element="tns:issue468"/>
     <wsdl:part name="issue560" element="tns:issue560"/>
     <wsdl:part name="issue984" element="tns:issue984"/>
+    <wsdl:part name="issue985" element="tns:issue985"/>
     <wsdl:part name="logo" type="s:base64Binary"/>
   </wsdl:message>
 


### PR DESCRIPTION
refs qorelanguage/qore#975 added a test for the late resolution of complexTypes
added a test for simpleType enum handling

also addresses qorelanguage/qore#985

@tethal please do not delete this branch after merging; I need to prepare it for the merge with develop (relnotes, etc)
