### PR TITLE
refs #1226 respect the WSDL's declaration of the SOAPAction intent, a…

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,4 +1,19 @@
 *************
+version 1.3.2
+*************
+
+* WSDL module updates:
+  + supress emitting a SOAPAction header in requests if the binding gives an
+    empty string (issue 1226)
+  + updated WSOperation::serializeRequest() to allow the SOAPAction header to
+    be overridden in each request (issue 1226)
+  + respect XML generation flags in request generation
+* SoapClient update:
+  + added the SoapClient::callOperation() method to provide a more flexible
+    API for SOAP request message generating including overriding the
+    SOAPAction header on a per-request basis (issue 1226)
+
+*************
 version 1.3.1
 *************
 

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -3,7 +3,7 @@ version 1.3.2
 *************
 
 * WSDL module updates:
-  + supress emitting a SOAPAction header in requests if the binding gives an
+  + suppress emitting a SOAPAction header in requests if the binding gives an
     empty string (issue 1226)
   + updated WSOperation::serializeRequest() to allow the SOAPAction header to
     be overridden in each request (issue 1226)

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -8,6 +8,7 @@ version 1.3.2
   + updated WSOperation::serializeRequest() to allow the SOAPAction header to
     be overridden in each request (issue 1226)
   + respect XML generation flags in request generation
+  + fixed parsing empty base64Binary and hexBinary elements (issue 1227)
 * SoapClient update:
   + added the SoapClient::callOperation() method to provide a more flexible
     API for SOAP request message generating including overriding the

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 # AC_PREREQ(2.59)
-AC_INIT([qore-xml-module], [1.3.1],
+AC_INIT([qore-xml-module], [1.3.2],
         [David Nichols <david@qore.org>],
         [qore-xml-module])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-bzip2])

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -261,6 +261,15 @@ printf("%s\n", make_xml($h, XGF_ADD_FORMATTING));@endcode
 
     @section xmlreleasenotes Release Notes
 
+    @subsection xml132 xml Module Version 1.3.2
+    <b>Changes and Bug Fixes in This Release</b>
+    - <a href="../../WSDL/html/index.html">WSDL</a> fixes and enhancements:
+      - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
+      - updated \c WSOperation::serializeRequest() to allow the SOAPAction header to be overridden in each request (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
+      - respect XML generation flags in request generation
+    - <a href="../../SoapClient/html/index.html">SoapClient</a> fixes and enhancements:
+      - added the \c SoapClient::callOperation() method (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
+
     @subsection xml131 xml Module Version 1.3.1
     <b>Changes and Bug Fixes in This Release</b>
     - fixed a memory leak in XML-RPC parsing (<a href="https://github.com/qorelanguage/qore/issues/1214">issue 1214</a>)

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -267,6 +267,7 @@ printf("%s\n", make_xml($h, XGF_ADD_FORMATTING));@endcode
       - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
       - updated \c WSOperation::serializeRequest() to allow the SOAPAction header to be overridden in each request (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
       - respect XML generation flags in request generation
+      - fixed parsing empty base64Binary and hexBinary elements (<a href="https://github.com/qorelanguage/qore/issues/1227">issue 1227</a>)
     - <a href="../../SoapClient/html/index.html">SoapClient</a> fixes and enhancements:
       - added the \c SoapClient::callOperation() method (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
 

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -337,9 +337,9 @@ public namespace SoapClient {
         }
 
         #! makes the call to the SOAP server and ensures that SOAP fault responses returned with a 500-series status code are processed as a SOAP fault so that error information is returned in the resulting exception
-        private any makeCallIntern(*reference info, string operation, any args, *hash header, *hash nsh, *int xml_opts, *string override_soapaction) {
+        private any makeCallIntern(*reference info, string operation, any args, *hash header, *hash nsh, *int xml_opts, *string soapaction) {
             WSOperation op;
-            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, override_soapaction);
+            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction);
             hash hdr = headers + msg.hdr;
 
             # we have to write the request key after the HTTPClient::post() call

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file SoapClient.qm SOAP Client module implementation based on the WSDL classes
 
-/*  SoapClient.qm Copyright (C) 2012 - 2016 David Nichols
+/*  SoapClient.qm Copyright (C) 2012 - 2016 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -38,7 +38,7 @@
 %new-style
 
 module SoapClient {
-    version = "0.2.4";
+    version = "0.2.4.1";
     desc = "SoapClient module";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -91,6 +91,9 @@ any result = sc.call("SubmitDocument", msg);
     - \c "timeout"
 
     @section soapclientrelnotes SoapClient Release Notes
+
+    @subsection soapclient_0_2_4_1 SoapClient v0.2.4.1
+    - added the @ref SoapClient::SoapClient::callOperation() method (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
 
     @subsection soapclient_0_2_4 SoapClient v0.2.4
     - handle SOAP fault messages returned with 500-series error codes as Fault messages
@@ -254,6 +257,9 @@ public namespace SoapClient {
             @param args the arguments to the SOAP operation
             @param header data structure for the SOAP header, if required by the message
             @param op a reference to return the @ref WSDL::WSOperation "WSOperation" object found
+            @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
+            @param xml_opts an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
+            @param soapaction an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
 
             @return a hash with the following keys:
             - \c hdr: a hash of message headers
@@ -263,19 +269,41 @@ public namespace SoapClient {
 
             @note content encoding is not applied here but rather internally by the call() methods
         */
-        hash getMsg(string operation, any args, *hash header, reference op, *hash nsh) {
+        hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
             op = wsdl.getOperation(operation);
-            hash msg = op.serializeRequest(args, header, getEncoding(), nsh);
+            hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction);
             if (msg.hdr."Content-Type" !~ /charset=/i)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
 
             return msg;
         }
 
+        #! makes a server call with the given operation, arguments, options, and optional info hash reference and returns the result
+        /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
+            @param args the arguments to the SOAP operation
+            @param opts an optional hash of options for the call as follows:
+            - \c soap_header: a hash giving SOAP header information, if required by the message
+            - \c http_header: a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
+            - \c xml_opts: an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
+            - \c soapaction: an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
+            @param info an optional reference to return a hash of technical information about the SOAP call (raw message info and headers)
+
+            @return a hash with the following keys:
+            - \c hdr: a hash of message headers
+            - \c body: the serialized message body
+
+            @since %SoapClient 0.2.4.1
+         */
+        any callOperation(string operation, any args, *hash opts, *reference info) {
+            return makeCallIntern(\info, operation, args, opts.soap_header, opts.http_header, opts.xml_opts, opts.soapaction);
+        }
+
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
+            @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
+            @param xml_opts an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
 
             @return the deserialized result of the SOAP call to the SOAP server
         */
@@ -300,6 +328,7 @@ public namespace SoapClient {
             @param operation the operation name for the SOAP call
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
+            @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
 
             @return the deserialized result of the SOAP call to the SOAP server
         */
@@ -308,9 +337,9 @@ public namespace SoapClient {
         }
 
         #! makes the call to the SOAP server and ensures that SOAP fault responses returned with a 500-series status code are processed as a SOAP fault so that error information is returned in the resulting exception
-        private any makeCallIntern(*reference info, string operation, any args, *hash header, *hash nsh) {
+        private any makeCallIntern(*reference info, string operation, any args, *hash header, *hash nsh, *int xml_opts, *string override_soapaction) {
             WSOperation op;
-            hash msg = getMsg(operation, args, header, \op, nsh);
+            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, override_soapaction);
             hash hdr = headers + msg.hdr;
 
             # we have to write the request key after the HTTPClient::post() call

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -116,7 +116,7 @@ public namespace SoapClient {
     #! SOAP client class implementation, publically inherits qore's HTTPClient class
     public class SoapClient inherits HTTPClient {
         #! version of the implementation of this class
-        const Version = "0.2.4";
+        const Version = "0.2.4.1";
 
         #! default HTTP headers
         const Headers = ("Accept": (MimeTypeSoapXml + "," + MimeTypeXml + "," + MimeTypeXmlApp), "User-Agent": ("Qore-Soap-Client/" + SoapClient::Version));

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -37,7 +37,7 @@
 %disable-warning unreferenced-variable
 
 module WSDL {
-    version = "0.3.6";
+    version = "0.3.5.1";
     desc = "WSDL module providing functionality for SOAP";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -111,7 +111,7 @@ module WSDL {
 #! main WSDL namespace
 public namespace WSDL {
     #! this WSDL implementation version
-    public const version     = "0.3.5";
+    public const version     = "0.3.5.1";
 
     #! SOAP 1.1 envelope URI
     public const SOAP_11_ENV  = "http://schemas.xmlsoap.org/soap/envelope/";

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file WSDL.qm WSDL: Web Services Description Language: http://www.w3.org/TR/wsdl
 
-/*  WSDL.qm Copyright (C) 2012 - 2016 David Nichols
+/*  WSDL.qm Copyright (C) 2012 - 2016 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -37,7 +37,7 @@
 %disable-warning unreferenced-variable
 
 module WSDL {
-    version = "0.3.5";
+    version = "0.3.6";
     desc = "WSDL module providing functionality for SOAP";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -71,6 +71,11 @@ module WSDL {
     - <a href="../../SoapHandler/html/index.html">SoapHandler user module</a>
 
     @section wsdlrelnotes WSDL Module Release Notes
+
+    @subsection wsdl_0_3_5_1 WSDL v0.3.5.1
+    - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
+    - updated @ref WSDL::WSOperation::serializeRequest() to allow the SOAPAction header to be overridden in each request (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
+    - respect XML generation flags in request generation
 
     @subsection wsdl_0_3_5 WSDL v0.3.5
     - fixed many message serialization and deserialization issues
@@ -1774,14 +1779,18 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh an optional namespace hash for the output message
         @param xml_opts optional XML generation options
+        @param req_soapaction if present will override any SOAPAction value for the request
 
         @return a hash with keys:
         - \c body: XML string in the SOAP request format
         - \c hdr: hash of HTTP headers
         */
-    hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts) {
+    hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
         # setup namespaces for SOAP envelope
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
+
+        if (!exists req_soapaction)
+            req_soapaction = soapAction;
 
         rh."soapenv:Envelope"."^attributes^" += nsc.getOutputNamespaceHash(nsh);
 
@@ -1815,16 +1824,16 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         else if (exists h)
             throw SOAP_SERIALIZATION_ERROR, sprintf("request value provided for operation %y with no input message (%y)", name, h);
 
-        string body = make_xml(rh, xml_opts | XGF_ADD_FORMATTING, enc);
+        string body = make_xml(rh, xml_opts, enc);
 
         if (mpm) {
             mpm.splicePart(body, sprintf("<%s>", inp.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
 
             hash rv = mpm.getMsgAndHeaders();
-            if (soapAction) {
+            if (req_soapaction) {
                 if (nsc.hasSoap12())
-                    rv.hdr."Content-Type" += sprintf(";action: %s", soapAction);
-                rv.hdr += ("SOAPAction": soapAction);
+                    rv.hdr."Content-Type" += sprintf(";action: %s", req_soapaction);
+                rv.hdr += ("SOAPAction": req_soapaction);
             }
 
             rv.hdr."Content-Type" += sprintf(";charset=%s", exists enc ? enc : get_default_encoding());
@@ -1834,19 +1843,21 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         string ct;
         if (nsc.hasSoap12()) {
             ct = MimeTypeSoapXml;
-            if (soapAction)
-                ct += sprintf(";action: %s", soapAction);
+            if (req_soapaction)
+                ct += sprintf(";action: %s", req_soapaction);
         }
         else
             ct = MimeTypeXml;
 
         ct += sprintf(";charset=%s", exists enc ? enc : get_default_encoding());
 
-        hash rv = ("hdr": ("Content-Type": ct),
-                       "body": body );
+        hash rv = (
+            "hdr": ("Content-Type": ct),
+            "body": body,
+            );
 
-        if (soapAction)
-            rv.hdr += ("SOAPAction": soapAction);
+        if (req_soapaction)
+            rv.hdr += ("SOAPAction": req_soapaction);
 
         return rv;
     }
@@ -2465,7 +2476,7 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
             *string sa = ophash.operation."^attributes^".soapAction;
             if (exists sa) {
                 #printf("GOT: %s sa: %y\n", opname, sa);
-                op.soapAction = sa ? sa : opname + "Action";
+                op.soapAction = sa;
             }
 
             if (docStyle || ophash.operation."^attributes^".style == "document") {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -76,6 +76,7 @@ module WSDL {
     - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
     - updated @ref WSDL::WSOperation::serializeRequest() to allow the SOAPAction header to be overridden in each request (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
     - respect XML generation flags in request generation
+    - fixed parsing empty base64Binary and hexBinary elements (<a href="https://github.com/qorelanguage/qore/issues/1227">issue 1227</a>)
 
     @subsection wsdl_0_3_5 WSDL v0.3.5
     - fixed many message serialization and deserialization issues
@@ -849,10 +850,10 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
                 return float(val);
 
             case "base64Binary":
-                return parse_base64_string(val);
+                return val.empty() ? binary() : parse_base64_string(val);
 
             case "hexBinary":
-                return parse_hex_string(val);
+                return val.empty() ? binary() : parse_hex_string(val);
 
             default: {
                 if (name == "anyType")  {

--- a/qore-xml-module.spec
+++ b/qore-xml-module.spec
@@ -1,4 +1,4 @@
-%global mod_ver 1.3.1
+%global mod_ver 1.3.2
 
 %{?_datarootdir: %global mydatarootdir %_datarootdir}
 %{!?_datarootdir: %global mydatarootdir /usr/share}
@@ -103,6 +103,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc COPYING.LGPL COPYING.MIT README RELEASE-NOTES AUTHORS
 
 %changelog
+* Thu Sep 8 2016 David Nichols <david@qore.org> - 1.3.2
+- updated to version 1.3.2
+
 * Mon Sep 5 2016 David Nichols <david@qore.org> - 1.3.1
 - updated to version 1.3.1
 

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -1,0 +1,113 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+# make sure we have the right version of qore
+%requires qore >= 0.8.12
+
+%new-style
+%require-types
+%strict-args
+%enable-all-warnings
+%no-child-restrictions
+%require-our
+
+# test deprecated functions as well
+%disable-warning deprecated
+
+%requires QUnit
+%requires HttpServer
+%requires ../qlib/WSDL.qm
+%requires ../qlib/SoapHandler.qm
+%requires ../qlib/SoapClient.qm
+
+%requires Util
+%requires xml
+
+const DefaultPort = 8088;
+
+%exec-class SoapClientTest
+
+const ResponseBody = ("result": 99.9);
+
+class TestSoapServer inherits HttpServer {
+    public {}
+
+    private {
+        int verbose;
+    }
+
+    constructor(WebService ws, int port, int verbose = 0) : HttpServer(\self.log(), \TestSoapServer::errlog(), verbose > 2) {
+        self.verbose = verbose;
+
+        # setup SOAP handler
+        SoapHandler soap(new PermissiveAuthenticator(), NOTHING, verbose > 2);
+        setDefaultHandler("soap", soap);
+
+        # setup operation handler
+        soap.addMethod(ws, ws.getOperation("getInfo"), \getInfo());
+
+        addListener(port);
+    }
+
+    hash getInfo(hash cx, hash h) {
+        return (
+            "body": ResponseBody,
+            "docs": h.tickerSymbol,
+            "logo": binary(cx.http_header.soapaction),
+            );
+    }
+
+    static errlog(string fmt) {
+        vprintf(fmt + "\n", argv);
+    }
+
+    log(string fmt) {
+        if (verbose > 2)
+            vprintf(fmt + "\n", argv);
+    }
+}
+
+class SoapClientTest inherits QUnit::Test {
+    public {
+    }
+
+    private {
+        const WsdlUrl = "file://" + get_script_dir() + "/test.wsdl";
+
+        #! command-line options
+        const MyOpts = Opts + (
+            "port": "p,port=i",
+            );
+
+        const OptionColumn = 25;
+    }
+
+    constructor() : QUnit::Test("SoapClientTest", "1.0", \ARGV, MyOpts) {
+        WebService ws(WSDLLib::getFileFromURL(WsdlUrl));
+
+        # start SOAP server server
+        TestSoapServer server(ws, m_options.port ?? DefaultPort, m_options.verbose);
+        on_exit server.stop();
+
+        # add test cases
+        addTestCase("SoapClientTest", \soapClientTest());
+        # execute tests
+        set_return_value(main());
+    }
+
+    soapClientTest() {
+        string url = sprintf("http://%s:%d", gethostname(), m_options.port ?? DefaultPort);
+        #printf("url: %y\n", url);
+        SoapClient sc(("wsdl": WsdlUrl, "url": url));
+
+        hash h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
+        assertEq(99.9, h.body.result);
+        assertEq("ABC", h.docs);
+        assertEq(binary(), h.logo);
+
+        h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "QOR")), ("soapaction": "TestAction"));
+        assertEq(99.9, h.body.result);
+        assertEq("QOR", h.docs);
+        assertEq(binary("TestAction"), h.logo);
+    }
+}

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -301,11 +301,13 @@ class SoapTest inherits QUnit::Test {
             "code": 1,
             );
 
-        hash h = op.serializeRequest(req, NOTHING, NOTHING, NOTHING, XGF_ADD_FORMATTING);
+        hash h = op.serializeRequest(req, NOTHING, NOTHING, NOTHING, XGF_ADD_FORMATTING, "TEST");
+        assertEq("TEST", h.hdr.SOAPAction);
         hash xh = parse_xml(h.body);
         compareSoapMsgs("attr-ser", Req_1, xh);
 
         h = op.deserializeRequest(xh);
+        assertEq(NOTHING, h.hdr.SOAPAction);
 
         hash req_r = req + (
             "issue985": (


### PR DESCRIPTION
…dded SoapClient::callOperation() for more control over the messages generated with the SoapClient including the possibility to override the SOAPAction value if necessary
