### PR TITLE
Feature/1116 wsdl http bindings

### DIFF
--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -339,6 +339,7 @@ printf("%s\n", make_xml(h, XGF_ADD_FORMATTING));
     - <a href="../../SoapClient/html/index.html">SoapClient</a> module changes:
       - added support for logging messages
       - added the \c SoapConnection class
+      - added API support for specifying the SOAP bindings in the WSDL to use (a href="https://github.com/qorelanguage/qore/issues/1116">issue 1116</a>)
     - <a href="../../SoapHandler/html/index.html">SoapHandler</a> module changes:
       - added support for logging messages
     - <a href="../../WSDL/html/index.html">WSDL</a> module changes:
@@ -349,9 +350,7 @@ printf("%s\n", make_xml(h, XGF_ADD_FORMATTING));
       - fixed a bug where \c xsi:type information was serialized when not necessary (<a href="https://github.com/qorelanguage/qore/issues/1120">issue 1120</a>)
       - added a more user-friendly exception when WSDLs are encountered with unsupported bindings (ex: HTTP verb-based bindings, issue <a href="https://github.com/qorelanguage/qore/issues/1116">issue 1116</a>)
       - added \c WSDL::WSMessageHelper to generate sample messages
-      - added multiple binding support
-      - added HTTP binding support and extended SOAP binding support
-
+      - added support for multiple SOAP bindings in the WSDL including HTTP \c GET/POST bindings (a href="https://github.com/qorelanguage/qore/issues/1116">issue 1116</a>)
 
     @subsection xml131 xml Module Version 1.3.1
     <b>Changes and Bug Fixes in This Release</b>

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -349,6 +349,8 @@ printf("%s\n", make_xml(h, XGF_ADD_FORMATTING));
       - fixed a bug where \c xsi:type information was serialized when not necessary (<a href="https://github.com/qorelanguage/qore/issues/1120">issue 1120</a>)
       - added a more user-friendly exception when WSDLs are encountered with unsupported bindings (ex: HTTP verb-based bindings, issue <a href="https://github.com/qorelanguage/qore/issues/1116">issue 1116</a>)
       - added \c WSDL::WSMessageHelper to generate sample messages
+      - added multiple binding support
+      - added HTTP binding support and extended SOAP binding support
 
 
     @subsection xml131 xml Module Version 1.3.1

--- a/qlib/SalesforceSoapClient.qm
+++ b/qlib/SalesforceSoapClient.qm
@@ -394,7 +394,7 @@ public namespace SalesforceSoapClient {
     #! class for SOAP connections to the Salesforce.com SOAP API; returns an object of class @ref SalesforceSoapClient
     /** supports the following static initialization options:
         - \c "connect_timeout": connection timeout to use in milliseconds
-        - \c "content_encoding": this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding; for possible values, see @ref SoapClient::EncodingSupport "EncodingSupport"
+        - \c "content_encoding": this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding; for possible values, see @ref SoapClient::SoapClient::EncodingSupport "EncodingSupport"
         - \c "force_logout": forces a logout when the SalesforceSoapClient object is destroyed; this should normally be @ref Qore::False "False" to allow for the session to remain valid
         - \c "http_version": HTTP version to use (\c "1.0" or \c "1.1", defaults to \c "1.1")
         - \c "max_redirects": maximum redirects to support
@@ -402,8 +402,8 @@ public namespace SalesforceSoapClient {
         - \c "port": in case multiple port entries are found in the WSDL, give the one to be used here
         - \c "portType": in case multiple portType entries are found in the WSDL, give the one to be used here
         - \c "proxy": proxy URL to use
-        - \c "send_encoding": a @ref SoapClient::EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies
-        - \c "target_url": overrides the URL in the WSDL (mapped to \c "url" in the @ref SoapClient::constructor(hash) "SoapClient::constructor()" argument)
+        - \c "send_encoding": a @ref SoapClient::SoapClient::EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies
+        - \c "target_url": overrides the URL in the WSDL (mapped to \c "url" in the @ref SoapClient::SoapClient::constructor(hash) "SoapClient::constructor()" argument)
         - \c "token": Salesforce.com user API token
         - \c "timeout": transfer timeout to use in milliseconds
         - \c "username": Salesforce.com username

--- a/qlib/SalesforceSoapClient.qm
+++ b/qlib/SalesforceSoapClient.qm
@@ -282,7 +282,6 @@ public namespace SalesforceSoapClient {
             if (sessionid)
                 opts.soap_header.sessionId = sessionid;
             opts.soapaction = soapaction;
-#printf("callintern oper: operation: %y, args: %y, opts: %y\n", operation, args, opts);
             return SoapClient::callOperation(operation, args, opts, \info);
         }
 
@@ -380,7 +379,6 @@ public namespace SalesforceSoapClient {
             lh = callIntern("login", lh).result;
             serverurl = lh.serverUrl;
             sessionid = lh.sessionId;
-#printf("loginintern 2, %y\n", lh);
 
             log("logged in to %y: serverurl: %y sessionid: %y", url, serverurl, sessionid);
             logged_in = True;

--- a/qlib/SalesforceSoapClient.qm
+++ b/qlib/SalesforceSoapClient.qm
@@ -282,7 +282,7 @@ public namespace SalesforceSoapClient {
             if (sessionid)
                 opts.soap_header.Header.SessionHeader.sessionId = sessionid;
             opts.soapaction = soapaction;
-
+printf("callintern oper: %y, %y, %y\n", operation, args, opts);
             return SoapClient::callOperation(operation, args, opts, \info);
         }
 
@@ -374,20 +374,24 @@ public namespace SalesforceSoapClient {
 
         # must be called with the lock held
         private loginIntern() {
-            hash lh = self.("username", "password");
-            lh.password += token;
+            hash lh.login = self.("username", "password");
+            lh.login.password += token;
+printf("loginintern callintern. %y\n", lh);
 
             lh = callIntern("login", lh).result;
             serverurl = lh.serverUrl;
             sessionid = lh.sessionId;
+printf("loginintern 2, %y\n", lh);
 
             log("logged in to %y: serverurl: %y sessionid: %y", url, serverurl, sessionid);
             logged_in = True;
+printf("loginintern disc\n");
 
             # disconnect and set new URL
             SoapClient::disconnect();
             url = serverurl;
             setURL(serverurl);
+printf("loginintern ret\n");
         }
     }
 

--- a/qlib/SalesforceSoapClient.qm
+++ b/qlib/SalesforceSoapClient.qm
@@ -280,9 +280,9 @@ public namespace SalesforceSoapClient {
         private any callIntern(string operation, any args, *hash opts, *reference info) {
             # add session ID to SOAP call header
             if (sessionid)
-                opts.soap_header.Header.SessionHeader.sessionId = sessionid;
+                opts.soap_header.sessionId = sessionid;
             opts.soapaction = soapaction;
-printf("callintern oper: %y, %y, %y\n", operation, args, opts);
+#printf("callintern oper: operation: %y, args: %y, opts: %y\n", operation, args, opts);
             return SoapClient::callOperation(operation, args, opts, \info);
         }
 
@@ -374,24 +374,21 @@ printf("callintern oper: %y, %y, %y\n", operation, args, opts);
 
         # must be called with the lock held
         private loginIntern() {
-            hash lh.login = self.("username", "password");
-            lh.login.password += token;
-printf("loginintern callintern. %y\n", lh);
+            hash lh = self.("username", "password");
+            lh.password += token;
 
             lh = callIntern("login", lh).result;
             serverurl = lh.serverUrl;
             sessionid = lh.sessionId;
-printf("loginintern 2, %y\n", lh);
+#printf("loginintern 2, %y\n", lh);
 
             log("logged in to %y: serverurl: %y sessionid: %y", url, serverurl, sessionid);
             logged_in = True;
-printf("loginintern disc\n");
 
             # disconnect and set new URL
             SoapClient::disconnect();
             url = serverurl;
             setURL(serverurl);
-printf("loginintern ret\n");
         }
     }
 

--- a/qlib/SalesforceSoapClient.qm
+++ b/qlib/SalesforceSoapClient.qm
@@ -280,7 +280,7 @@ public namespace SalesforceSoapClient {
         private any callIntern(string operation, any args, *hash opts, *reference info) {
             # add session ID to SOAP call header
             if (sessionid)
-                opts.soap_header.sessionId = sessionid;
+                opts.soap_header.Header.SessionHeader.sessionId = sessionid;
             opts.soapaction = soapaction;
 
             return SoapClient::callOperation(operation, args, opts, \info);

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -356,7 +356,8 @@ public namespace SoapClient {
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
-            @param binding SOAP binding name, if not provided use the first binding assigned to operation
+            @param binding SOAP binding name, if not provi
+            ed us he first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
@@ -484,9 +485,9 @@ public namespace SoapClient {
 
             hash rmsg = WSDLLib::parseMultiPartSOAPMessage(rh);
             msglog(('reason': 'response', 'header': rmsg.header, 'body': rmsg.body));
-            hash xmldata = WSDLLib::parseSOAPMessage(rmsg);
+            hash pdata = op.parseSOAPMessage(rmsg, binding);
             #printf("DEBUG ans: %s\n", rh);
-            return op.deserializeResponse(xmldata, binding);
+            return op.deserializeResponse(pdata, binding);
         }
 
         #! uses SoapClient::call() to transparently serialize the argument and make a call to the given operation and return the deserialized results

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -83,7 +83,7 @@ module SoapClient {
 %requires SoapClient
 SoapClient sc = new SoapClient(("wsdl" : "http://soap.server.org:8080/my-service?wsdl"));
 hash msg = getMessage();
-any result = sc.call("SubmitDocument", msg);
+any result = sc.call("SubmitDocument", NOTHING, msg);
     @endcode
 
     The SoapClient::constructor() takes named arguments in the form of a hash; valid arguments are:
@@ -281,9 +281,11 @@ public namespace SoapClient {
 
         #! returns a hash representing the serialized SOAP request for a given @ref WSDL::WSOperation "WSOperation"
         /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
+            @param binding SOAP binding, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header data structure for the SOAP header, if required by the message
             @param op a reference to return the @ref WSDL::WSOperation "WSOperation" object found
+            @param b a reference to return the @ref WSDL::Binding "Binding" object found
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
             @param xml_opts an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
             @param soapaction an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
@@ -293,20 +295,25 @@ public namespace SoapClient {
             - \c body: the serialized message body
 
             @throw WSDL-OPERATION-ERROR the operation is not defined in the WSDL
+            @throw WSDL-BINDING-ERROR the binding is not assigned to operation in the WSDL
 
             @note content encoding is not applied here but rather internally by the call() methods
         */
-        hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
+        hash getMsg(string operation, *string binding, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
             op = wsdl.getOperation(operation);
-            hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction);
+            hash msg = op.serializeRequest(args, op.getBinding(binding), header, getEncoding(), nsh, xml_opts, soapaction);
             if (msg.hdr."Content-Type" !~ /charset=/i)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
 
             return msg;
         }
+        deprecated hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
+            return getMsg(operation, NOTHING, args, header, \op, nsh, xml_opts, soapaction);
+        }
 
         #! makes a server call with the given operation, arguments, options, and optional info hash reference and returns the result
         /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
+            @param binding SOAP binding, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param opts an optional hash of options for the call as follows:
             - \c soap_header: a hash giving SOAP header information, if required by the message
@@ -330,18 +337,24 @@ public namespace SoapClient {
             - \c body: the serialized message body
 
             @throw WSDL-OPERATION-ERROR the operation is not defined in the WSDL
+            @throw WSDL-BINDING-ERROR the binding is not assigned to operation in the WSDL
             @throw HTTP-CLIENT-RECEIVE-ERROR this exception is thrown when the SOAP server returns an HTTP error code; if a SOAP fault is returned, then it is deserialized and returned in the \a arg key of the exception hash
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
 
             @since %SoapClient 0.2.4.1
          */
-        any callOperation(string operation, any args, *hash opts, *reference info) {
-            return makeCallIntern(\info, operation, args, opts.soap_header, opts.http_header, opts.xml_opts, opts.soapaction);
+        any callOperation(string operation, *string binding, any args, *hash opts, *reference info) {
+            return makeCallIntern(\info, operation, binding, args, opts.soap_header, opts.http_header, opts.xml_opts, opts.soapaction);
+        }
+
+        deprecated any callOperation(string operation, any args, *hash opts, *reference info) {
+            return callOperation(operation, NOTHING, args, opts, \info);
         }
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
+            @param binding SOAP binding, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
@@ -350,17 +363,23 @@ public namespace SoapClient {
             @return the deserialized result of the SOAP call to the SOAP server
 
             @throw WSDL-OPERATION-ERROR the operation is not defined in the WSDL
+            @throw WSDL-BINDING-ERROR the binding is not assigned to operation in the WSDL
             @throw HTTP-CLIENT-RECEIVE-ERROR this exception is thrown when the SOAP server returns an HTTP error code; if a SOAP fault is returned, then it is deserialized and returned in the \a arg key of the exception hash
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(string operation, any args, *hash header, *hash nsh) {
+        any call(string operation, *string binding, any args, *hash header, *hash nsh) {
             hash info;
-            return makeCallIntern(\info, operation, args, header, nsh);
+            return makeCallIntern(\info, operation, binding, args, header, nsh);
+        }
+
+        deprecated any call(string operation, any args, *hash header, *hash nsh) {
+            return call(operation, NOTHING, args, header, nsh);
         }
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
+            @param binding SOAP binding, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param info an optional reference to return a hash of technical information about the SOAP call (raw message info and headers); the following keys are present in this hash:
             - \c "headers": a hash of HTTP request headers
@@ -377,12 +396,16 @@ public namespace SoapClient {
             @return the deserialized result of the SOAP call to the SOAP server
 
             @throw WSDL-OPERATION-ERROR the operation is not defined in the WSDL
+            @throw WSDL-BINDING-ERROR the binding is not assigned to operation in the WSDL
             @throw HTTP-CLIENT-RECEIVE-ERROR this exception is thrown when the SOAP server returns an HTTP error code; if a SOAP fault is returned, then it is deserialized and returned in the \a arg key of the exception hash
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(string operation, any args, *reference info) {
-            return makeCallIntern(\info, operation, args);
+        any call(string operation, *string binding, any args, *reference info) {
+            return makeCallIntern(\info, operation, binding, args);
+        }
+        deprecated any call(string operation, any args, *reference info) {
+            return call(operation, NOTHING, args, \info);
         }
 
         #! makes a server call with the given operation and arguments and returns the deserialized result with an output argument giving technical information about the call
@@ -398,6 +421,7 @@ public namespace SoapClient {
             - \c "request-body": the raw XML request body
             - \c "request-soap-headers": an optional hash of SOAP headers used in the request (if applicable)
             @param operation the operation name for the SOAP call
+            @param binding SOAP binding, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
@@ -405,18 +429,22 @@ public namespace SoapClient {
             @return the deserialized result of the SOAP call to the SOAP server
 
             @throw WSDL-OPERATION-ERROR the operation is not defined in the WSDL
+            @throw WSDL-BINDING-ERROR the binding is not assigned to operation in the WSDL
             @throw HTTP-CLIENT-RECEIVE-ERROR this exception is thrown when the SOAP server returns an HTTP error code; if a SOAP fault is returned, then it is deserialized and returned in the \a arg key of the exception hash
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(reference info, string operation, any args, *hash header, *hash nsh) {
-            return makeCallIntern(\info, operation, args, header, nsh);
+        any call(reference info, string operation, *string binding, any args, *hash header, *hash nsh) {
+            return makeCallIntern(\info, operation, binding, args, header, nsh);
+        }
+        deprecated any call(reference info, string operation, any args, *hash header, *hash nsh) {
+            return call(\info, operation, NOTHING, args, header, nsh);
         }
 
         #! makes the call to the SOAP server and ensures that SOAP fault responses returned with a 500-series status code are processed as a SOAP fault so that error information is returned in the resulting exception
-        private any makeCallIntern(*reference info, string operation, any args, *hash header, *hash nsh, *int xml_opts, *string soapaction) {
+        private any makeCallIntern(*reference info, string operation, *string binding, any args, *hash header, *hash nsh, *int xml_opts, *string soapaction) {
             WSOperation op;
-            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction);
+            hash msg = getMsg(operation, binding, args, header, \op, nsh, xml_opts, soapaction);
             hash hdr = headers + msg.hdr;
 
             date now = now_us();
@@ -456,7 +484,7 @@ public namespace SoapClient {
             msglog(('reason': 'response', 'header': rmsg.header, 'body': rmsg.body));
             hash xmldata = WSDLLib::parseSOAPMessage(rmsg);
             #printf("DEBUG ans: %s\n", rh);
-            return op.deserializeResponse(xmldata);
+            return op.deserializeResponse(xmldata, op.getBinding(binding));
         }
 
         #! uses SoapClient::call() to transparently serialize the argument and make a call to the given operation and return the deserialized results
@@ -471,7 +499,7 @@ public namespace SoapClient {
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
         any methodGate(string op, any arg) {
-            return call(op, arg);
+            return call(op, NOTHING, arg);
         }
 
         #! returns a hash that can be used to ensure serialization with the XSD type given as the \a type argument

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -311,9 +311,7 @@ public namespace SoapClient {
             @note content encoding is not applied here but rather internally by the call() methods
         */
         hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
-printf("getbinding\n");
             op = wsdl.getBindingOperation(binding, operation);
-printf("serreq\n");
             hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction, binding);
             if (msg.hdr."Content-Type" !~ /charset=/i && msg.body.typeCode != NT_BINARY)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
@@ -443,11 +441,11 @@ printf("serreq\n");
             *hash nsh = opts.http_header;
             *int xml_opts = opts.xml_opts;
             *string soapaction = opts.soapaction;
-printf("sc.makecall: %y, %y, %y\n", operation, header);
+printf("sc.makecall: %y, %y, %y\n", operation, header, args);
 
             WSOperation op;
             hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction);
-printf("sc.getmsg: %y\n", msg);
+#printf("sc.getmsg: %y\n", msg);
             hash hdr = headers + msg.hdr;
 
             date now = now_us();

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -441,11 +441,11 @@ public namespace SoapClient {
             *hash nsh = opts.http_header;
             *int xml_opts = opts.xml_opts;
             *string soapaction = opts.soapaction;
-printf("sc.makecall: %y, %y, %y\n", operation, header, args);
+            #printf("DEBUG: makeCallIntern: info: %y, operation: %y, args: %y, opts: %y\n", operation, header, args, opts);
 
             WSOperation op;
             hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction);
-#printf("sc.getmsg: %y\n", msg);
+            #printf("DEBUG: msg: %y\n", msg);
             hash hdr = headers + msg.hdr;
 
             date now = now_us();
@@ -665,7 +665,7 @@ private nothing msglog(hash msg) {
         */
         private nothing msglog(hash msg) {
             # implement functionality in derived class
-    printf(sprintf("%N\n", msg));
+            #printf(sprintf("%N\n", msg));
         }
     }
 

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -304,7 +304,7 @@ public namespace SoapClient {
         hash getMsg(string operation, *string binding, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
             op = wsdl.getOperation(operation);
             hash msg = op.serializeRequest(args, binding, header, getEncoding(), nsh, xml_opts, soapaction);
-            if (msg.hdr."Content-Type" !~ /charset=/i)
+            if (msg.hdr."Content-Type" !~ /charset=/i && msg.body.typeCode != NT_BINARY)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
 
             return msg;

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -485,7 +485,7 @@ public namespace SoapClient {
 
             hash rmsg = WSDLLib::parseMultiPartSOAPMessage(rh);
             msglog(('reason': 'response', 'header': rmsg.header, 'body': rmsg.body));
-            hash pdata = op.parseSOAPMessage(rmsg, binding);
+            hash pdata = op.parseSOAPMessage(rmsg, binding, True);
             #printf("DEBUG ans: %s\n", rh);
             return op.deserializeResponse(pdata, binding);
         }

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -717,11 +717,7 @@ private nothing msglog(hash msg) {
         */
         constructor(string name, string desc, string url, bool monitor, *hash n_opts, hash urlh) : HttpBasedConnection(name, desc, url, monitor, n_opts, urlh) {
             # do environment variable substitution in wsdl option if applicable
-            if (opts.wsdl) {
-                if (opts.wsdl.typeCode() == NT_STRING)
-                    doEnvOptions("wsdl");
-            }
-            else {
+            if (!opts.wsdl) {
                 # check if we have a local path to the WSDL
                 hash h = parse_url(real_url);
                 if (h.protocol == "http" && h.size() == 2 && h.path)

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -90,7 +90,8 @@ any result = sc.call("SubmitDocument", msg);
     - required keys: one of:
       - \c "wsdl" or \c "wsdl_file": a string defining the WSDL or the URL of the WSDL
     - optional keys:
-      - \c "service": the name of the "portType" to use (if more than 1 portType is defined in the WSDL then this key is mandatory
+      - \c "service": the name of the "service" to use (if more than 1 service is defined in the WSDL then this key is mandatory
+      - \c "port": in case multiple port entries are found in the WSDL, give the one to be used here
       - \c "url": to override the URL defined in the WSDL
       - \c "headers": to override any HTTP headers sent in outgoing messages
       - \c "event_queue": to set an I/O event queue on the HTTPClient
@@ -310,7 +311,9 @@ public namespace SoapClient {
             @note content encoding is not applied here but rather internally by the call() methods
         */
         hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
+printf("getbinding\n");
             op = wsdl.getBindingOperation(binding, operation);
+printf("serreq\n");
             hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction, binding);
             if (msg.hdr."Content-Type" !~ /charset=/i && msg.body.typeCode != NT_BINARY)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
@@ -440,9 +443,11 @@ public namespace SoapClient {
             *hash nsh = opts.http_header;
             *int xml_opts = opts.xml_opts;
             *string soapaction = opts.soapaction;
+printf("sc.makecall: %y, %y, %y\n", operation, header);
 
             WSOperation op;
             hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction);
+printf("sc.getmsg: %y\n", msg);
             hash hdr = headers + msg.hdr;
 
             date now = now_us();
@@ -662,6 +667,7 @@ private nothing msglog(hash msg) {
         */
         private nothing msglog(hash msg) {
             # implement functionality in derived class
+    printf(sprintf("%N\n", msg));
         }
     }
 
@@ -671,8 +677,8 @@ private nothing msglog(hash msg) {
         - \c "content_encoding": this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding; for possible values, see @ref SoapClient::EncodingSupport  "EncodingSupport"
         - \c "http_version": HTTP version to use (\c "1.0" or \c "1.1", defaults to \c "1.1")
         - \c "max_redirects": maximum redirects to support
+        - \c "service": the name of the "service" to use (if more than 1 service is defined in the WSDL then this key is mandatory
         - \c "port": in case multiple port entries are found in the WSDL, give the one to be used here
-        - \c "portType": in case multiple portType entries are found in the WSDL, give the one to be used here
         - \c "proxy": proxy URL to use
         - \c "send_encoding": a @ref SoapClient::EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies
         - \c "target_url": overrides the URL in the WSDL (mapped to \c "url" in the @ref SoapClient::constructor(hash) "SoapClient::constructor()" argument)
@@ -693,8 +699,8 @@ private nothing msglog(hash msg) {
         public {
             const Options = HttpConnection::Options + (
                 "content_encoding": True,
+                "service": True,
                 "port": True,
-                "portType": True,
                 "send_encoding": True,
                 "target_url": True,
                 "wsdl": True,

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -485,7 +485,7 @@ public namespace SoapClient {
 
             hash rmsg = WSDLLib::parseMultiPartSOAPMessage(rh);
             msglog(('reason': 'response', 'header': rmsg.header, 'body': rmsg.body));
-            hash pdata = op.parseSOAPMessage(rmsg, binding, True);
+            *hash pdata = WSDLLib::parseSOAPMessage(rmsg);
             #printf("DEBUG ans: %s\n", rh);
             return op.deserializeResponse(pdata, binding);
         }

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -142,7 +142,7 @@ public namespace SoapClient {
         const Version = "0.2.5";
 
         #! default HTTP headers
-        const Headers = ("Accept": (MimeTypeSoapXml + "," + MimeTypeXml + "," + MimeTypeXmlApp), "User-Agent": ("Qore-Soap-Client/" + SoapClient::Version));
+        const Headers = ("User-Agent": ("Qore-Soap-Client/" + SoapClient::Version));
 
         #! option keys passed to the HTTPClient constructor
         const HTTPOptions = ("connect_timeout", "http_version", "max_redirects", "proxy", "timeout");
@@ -262,10 +262,6 @@ public namespace SoapClient {
 
             headers += h.headers;
             # setup default headers
-            if (wsdl.isSoap12())
-                headers += ("Content-Type": MimeTypeSoapXml);
-            else
-                headers += ("Content-Type": MimeTypeXml);
 
             if (h.send_encoding)
                 setSendEncoding(h.send_encoding);
@@ -275,7 +271,7 @@ public namespace SoapClient {
                     setSendEncoding(h.content_encoding);
                 else if (!EncodingSupport.(h.content_encoding))
                     throw "SOAPCLIENT-ERROR", sprintf("content encoding option %y is unknown; valid options: %y", h.content_encoding, EncodingSupport.keys());
-                h.headers."Accept-Encoding" = h.content_encoding;
+                headers."Accept-Encoding" = h.content_encoding;
             }
 
             # unconditionally set the encoding to utf-8
@@ -313,9 +309,6 @@ public namespace SoapClient {
         hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
             op = wsdl.getBindingOperation(binding, operation);
             hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction, binding);
-            if (msg.hdr."Content-Type" !~ /charset=/i && msg.body.typeCode != NT_BINARY)
-                msg.hdr."Content-Type" += ";charset=" + getEncoding();
-
             return msg;
         }
 
@@ -465,7 +458,7 @@ public namespace SoapClient {
                 }
                 msg.path = url_path + msg.path;
             }
-            msglog(('reason': 'request', 'method': msg.method, 'path': msg.path, 'header': hdr, 'body': msg.body));
+            msglog(('reason': 'request', 'method': msg.method, 'path': msg.path, 'header': hdr, 'content-type': msg."content-type", 'accept': msg.accept, 'body': msg.body));
             # apply content encoding here
             data body = msg.body ?? "";
             if (seh.ce && body.size() > CompressionThreshold) {
@@ -477,9 +470,11 @@ public namespace SoapClient {
             try {
                 rh = send(body, msg.method, msg.path, hdr, True, \info);
                 info."response-body" = rh.body;
+                #printf("response: %y\n", rh);
             }
             catch (hash ex) {
                 # allow fault responses returned with a 500-series status code to be processed as a SOAP fault so that error information is returned in the exception
+                #printf("response exception: %y\n", ex);
                 if (ex.err == "HTTP-CLIENT-RECEIVE-ERROR") {
                     if (ex.arg.status_code >= 500 && ex.arg.status_code < 600 && ex.arg.body =~ /<\?xml.*Fault/) {
                         info."response-body" = ex.arg.body;
@@ -488,9 +483,8 @@ public namespace SoapClient {
                 }
                 rethrow;
             }
-
             hash rmsg = WSDLLib::parseMultiPartSOAPMessage(rh);
-            msglog(('reason': 'response', 'header': rmsg.header, 'body': rmsg.body));
+            msglog(('reason': 'response', 'header': rmsg.header, 'content-type': rmsg."content-type", 'body': rmsg.body));
             *hash pdata = WSDLLib::parseSOAPMessage(rmsg);
             #printf("DEBUG ans: %s\n", rh);
             return op.deserializeResponse(pdata, binding);

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -293,6 +293,8 @@ public namespace SoapClient {
             @return a hash with the following keys:
             - \c hdr: a hash of message headers
             - \c body: the serialized message body
+            - \c path: the path part of URL
+            - \c method: the HTTP request method
 
             @throw WSDL-OPERATION-ERROR the operation is not defined in the WSDL
             @throw WSDL-BINDING-ERROR the binding is not assigned to operation in the WSDL
@@ -456,7 +458,7 @@ public namespace SoapClient {
             # we have to write the request key after the HTTPClient::post() call but before the log message above
             # (on_exit statements are executed in reverse order when the block is exited)
             on_exit info += ("request-body": msg.body, "request-soap-headers": header);
-            msglog(('reason': 'request', 'header': hdr, 'body': msg.body));
+            msglog(('reason': 'request', 'method': msg.method, 'path': msg.path, 'header': hdr, 'body': msg.body));
             # apply content encoding here
             data body = msg.body;
             if (seh.ce && body.size() > CompressionThreshold) {
@@ -466,7 +468,7 @@ public namespace SoapClient {
 
             hash rh;
             try {
-                rh = send(body, "POST", NOTHING, hdr, True, \info);
+                rh = send(body, msg.method, msg.path, hdr, True, \info);
                 info."response-body" = rh.body;
             }
             catch (hash ex) {

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -83,7 +83,7 @@ module SoapClient {
 %requires SoapClient
 SoapClient sc = new SoapClient(("wsdl" : "http://soap.server.org:8080/my-service?wsdl"));
 hash msg = getMessage();
-any result = sc.call("SubmitDocument", NOTHING, msg);
+any result = sc.call("SubmitDocument", msg);
     @endcode
 
     The SoapClient::constructor() takes named arguments in the form of a hash; valid arguments are:
@@ -281,14 +281,13 @@ public namespace SoapClient {
 
         #! returns a hash representing the serialized SOAP request for a given @ref WSDL::WSOperation "WSOperation"
         /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
-            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header data structure for the SOAP header, if required by the message
             @param op a reference to return the @ref WSDL::WSOperation "WSOperation" object found
-            @param b a reference to return the @ref WSDL::Binding "Binding" object found
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
             @param xml_opts an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
             @param soapaction an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
+            @param binding the SOAP binding name, if not provided, the first binding assigned to the operation will be used
 
             @return a hash with the following keys:
             - \c hdr: a hash of message headers
@@ -301,27 +300,24 @@ public namespace SoapClient {
 
             @note content encoding is not applied here but rather internally by the call() methods
         */
-        hash getMsg(string operation, *string binding, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
+        hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction, *string binding) {
             op = wsdl.getOperation(operation);
-            hash msg = op.serializeRequest(args, binding, header, getEncoding(), nsh, xml_opts, soapaction);
+            hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction, binding);
             if (msg.hdr."Content-Type" !~ /charset=/i && msg.body.typeCode != NT_BINARY)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
 
             return msg;
         }
-        deprecated hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
-            return getMsg(operation, NOTHING, args, header, \op, nsh, xml_opts, soapaction);
-        }
 
         #! makes a server call with the given operation, arguments, options, and optional info hash reference and returns the result
         /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
-            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param opts an optional hash of options for the call as follows:
             - \c soap_header: a hash giving SOAP header information, if required by the message
             - \c http_header: a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
             - \c xml_opts: an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
             - \c soapaction: an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
+            - \c binding: the SOAP binding name, if not provided the first binding assigned to the operation will be used
             @param info an optional reference to return a hash of technical information about the SOAP call (raw message info and headers); the following keys are present in this hash:
             - \c "headers": a hash of HTTP request headers
             - \c "request-uri": the request URI string (ex: \c "POST /services/Soap/c/29.0 HTTP/1.1")
@@ -346,22 +342,16 @@ public namespace SoapClient {
 
             @since %SoapClient 0.2.4.1
          */
-        any callOperation(string operation, *string binding, any args, *hash opts, *reference info) {
-            return makeCallIntern(\info, operation, binding, args, opts.soap_header, opts.http_header, opts.xml_opts, opts.soapaction);
-        }
-
-        deprecated any callOperation(string operation, any args, *hash opts, *reference info) {
-            return callOperation(operation, NOTHING, args, opts, \info);
+        any callOperation(string operation, any args, *hash opts, *reference info) {
+            return makeCallIntern(\info, operation, args, opts);
         }
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
-            @param binding SOAP binding name, if not provi
-            ed us he first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
-            @param xml_opts an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
+            @param binding the SOAP binding name, if not provided, the first binding assigned to the operation will be used
 
             @return the deserialized result of the SOAP call to the SOAP server
 
@@ -371,18 +361,12 @@ public namespace SoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(string operation, *string binding, any args, *hash header, *hash nsh) {
-            hash info;
-            return makeCallIntern(\info, operation, binding, args, header, nsh);
-        }
-
-        deprecated any call(string operation, any args, *hash header, *hash nsh) {
-            return call(operation, NOTHING, args, header, nsh);
+        any call(string operation, any args, *hash header, *hash nsh, *string binding) {
+            return makeCallIntern(NOTHING, operation, args, ("soap_header": header, "http_header": nsh, "binding": binding));
         }
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
-            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param info an optional reference to return a hash of technical information about the SOAP call (raw message info and headers); the following keys are present in this hash:
             - \c "headers": a hash of HTTP request headers
@@ -395,6 +379,7 @@ public namespace SoapClient {
             - \c "response-body": the raw XML response body (in case content encoding is used, this is the decoded value)
             - \c "request-body": the raw XML request body
             - \c "request-soap-headers": an optional hash of SOAP headers used in the request (if applicable)
+            @param binding the SOAP binding name, if not provided, the first binding assigned to the operation will be used
 
             @return the deserialized result of the SOAP call to the SOAP server
 
@@ -404,11 +389,8 @@ public namespace SoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(string operation, *string binding, any args, *reference info) {
-            return makeCallIntern(\info, operation, binding, args);
-        }
-        deprecated any call(string operation, any args, *reference info) {
-            return call(operation, NOTHING, args, \info);
+        any call(string operation, any args, *reference info, *string binding) {
+            return makeCallIntern(\info, operation, args, ("binding": binding));
         }
 
         #! makes a server call with the given operation and arguments and returns the deserialized result with an output argument giving technical information about the call
@@ -424,10 +406,13 @@ public namespace SoapClient {
             - \c "request-body": the raw XML request body
             - \c "request-soap-headers": an optional hash of SOAP headers used in the request (if applicable)
             @param operation the operation name for the SOAP call
-            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
-            @param header optional soap headers (if required by the operation)
-            @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
+            @param opts an optional hash of options for the call as follows:
+            - \c soap_header: a hash giving SOAP header information, if required by the message
+            - \c http_header: a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
+            - \c xml_opts: an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
+            - \c soapaction: an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
+            - \c binding: the SOAP binding name, if not provided the first binding assigned to the operation will be used
 
             @return the deserialized result of the SOAP call to the SOAP server
 
@@ -437,17 +422,20 @@ public namespace SoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(reference info, string operation, *string binding, any args, *hash header, *hash nsh) {
-            return makeCallIntern(\info, operation, binding, args, header, nsh);
-        }
-        deprecated any call(reference info, string operation, any args, *hash header, *hash nsh) {
-            return call(\info, operation, NOTHING, args, header, nsh);
+        any call(reference info, string operation, any args, *hash header, *hash nsh, *string binding) {
+            return makeCallIntern(\info, operation, args, ("soap_header": header, "http_header": nsh, "binding": binding));
         }
 
         #! makes the call to the SOAP server and ensures that SOAP fault responses returned with a 500-series status code are processed as a SOAP fault so that error information is returned in the resulting exception
-        private any makeCallIntern(*reference info, string operation, *string binding, any args, *hash header, *hash nsh, *int xml_opts, *string soapaction) {
+        private:internal any makeCallIntern(*reference info, string operation, any args, *hash opts) {
+            *hash header = opts.soap_header;
+            *hash nsh = opts.http_header;
+            *int xml_opts = opts.xml_opts;
+            *string soapaction = opts.soapaction;
+            *string binding = opts.binding;
+
             WSOperation op;
-            hash msg = getMsg(operation, binding, args, header, \op, nsh, xml_opts, soapaction);
+            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction, binding);
             hash hdr = headers + msg.hdr;
 
             date now = now_us();
@@ -492,7 +480,7 @@ public namespace SoapClient {
 
         #! uses SoapClient::call() to transparently serialize the argument and make a call to the given operation and return the deserialized results
         /** @param op the operation name, which is the method name passed to methodGate()
-            @param arg a list or arguments or a single argument (or NOTHING) for the operation
+            @param ... zero or more arguments for the operation
 
             @return the deserialized result of the SOAP call to the SOAP server
 
@@ -501,8 +489,8 @@ public namespace SoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any methodGate(string op, any arg) {
-            return call(op, NOTHING, arg);
+        any methodGate(string op) {
+            return call(op, argv.typeCode() == NT_LIST && argv.size() == 1 ? argv[0] : argv);
         }
 
         #! returns a hash that can be used to ensure serialization with the XSD type given as the \a type argument
@@ -528,8 +516,8 @@ sc.setSendEncoding("gzip");
             @throw SOAPCLIENT-ERROR invalid or unsupported data content encoding / compression option
 
             @see
-            - @ref SoapClient::setContentEncoding()
-            - @ref SoapClient::getSendEncoding()
+            - @ref setContentEncoding()
+            - @ref getSendEncoding()
         */
         setSendEncoding(string enc = "auto") {
             if (enc == "auto")
@@ -552,8 +540,8 @@ soap.setContentEncoding("gzip");
             @throw SOAPCLIENT-ERROR invalid or unsupported data content encoding / compression option
 
             @see
-            - @ref SoapClient::getSendEncoding()
-            - @ref SoapClient::setSendEncoding()
+            - @ref getSendEncoding()
+            - @ref setSendEncoding()
 
             @since %SoapClient 0.2.4
         */
@@ -595,7 +583,7 @@ hash h = soap.getDefaultHeaders();
 
             @note default headers can be set in the constructor and in addDefaultHeaders()
 
-            @see @ref SoapClient::addDefaultHeaders()
+            @see @ref getDefaultHeaders()
 
             @since %SoapClient 0.2.4
         */
@@ -612,8 +600,8 @@ hash h = soap.getDefaultHeaders();
             @return the current data content encoding (compression) object or @ref nothing if no encoding option is set; see @ref EncodingSupport for valid options
 
             @see
-            - @ref SoapClient::setContentEncoding()
-            - @ref SoapClient::setSendEncoding()
+            - @ref setContentEncoding()
+            - @ref setSendEncoding()
 
             @since %SoapClient 0.2.4
         */

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -152,6 +152,9 @@ public namespace SoapClient {
             WSDL::WebService wsdl;
             # service name
             string svc;
+            string port;
+            string binding;
+            *string url_path;
 
             *code logc;
             *code dbglogc;
@@ -205,7 +208,7 @@ public namespace SoapClient {
             - \c send_encoding: a @ref EncodingSupport "send data encoding option" or the value \c "auto" which means to use automatic encoding; if not present defaults to no content-encoding on sent message bodies
             - \c content_encoding: for possible values, see @ref EncodingSupport; this sets the send encoding (if the \c "send_encoding" option is not set) and the requested response encoding
             - [\c service]: in case multiple service entries are found in the WSDL, give the one to be used here
-            - [\c port]: in case multiple port entries are found in the WSDL, give the one to be used here
+            - [\c port]: in case multiple port entries are found in the WSDL, give the one to be used here. Binding is resolved from service+port.
             - [\c log]: a log closure or call reference taking a single string giving the log message
             - [\c dbglog]: a log closure or call reference taking a single string giving the debug log message
             - also all options from SoapClient::SoapClient::HTTPOptions, which are passed to the HTTPClient constructor
@@ -247,7 +250,14 @@ public namespace SoapClient {
 
             hash svch = wsdl.getService(svc);
 
-            url = h.url ?? svch.port.firstValue().address;
+            if (svch.port.size() > 1 && !h.port)
+                throw "SOAP-CLIENT-ERROR", sprintf("no 'port' key passed in the option hash argument to SoapClient::constructor() (WSDL defines the following ports: %y for service: %y)", keys svch.port, svc);
+            port = h.port ?? svch.port.firstKey();
+            binding = svch.port{port}.binding.name;
+
+            url = h.url ?? svch.port{port}.address;
+
+            url_path = parse_url(url).path;
 
             headers += h.headers;
             # setup default headers
@@ -280,14 +290,13 @@ public namespace SoapClient {
         }
 
         #! returns a hash representing the serialized SOAP request for a given @ref WSDL::WSOperation "WSOperation"
-        /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
+        /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class and port/binding, an exception will be thrown
             @param args the arguments to the SOAP operation
             @param header data structure for the SOAP header, if required by the message
             @param op a reference to return the @ref WSDL::WSOperation "WSOperation" object found
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
             @param xml_opts an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
             @param soapaction an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
-            @param binding the SOAP binding name, if not provided, the first binding assigned to the operation will be used
 
             @return a hash with the following keys:
             - \c hdr: a hash of message headers
@@ -300,8 +309,8 @@ public namespace SoapClient {
 
             @note content encoding is not applied here but rather internally by the call() methods
         */
-        hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction, *string binding) {
-            op = wsdl.getOperation(operation);
+        hash getMsg(string operation, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
+            op = wsdl.getBindingOperation(binding, operation);
             hash msg = op.serializeRequest(args, header, getEncoding(), nsh, xml_opts, soapaction, binding);
             if (msg.hdr."Content-Type" !~ /charset=/i && msg.body.typeCode != NT_BINARY)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
@@ -412,7 +421,6 @@ public namespace SoapClient {
             - \c http_header: a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
             - \c xml_opts: an integer XML generation option code; see @ref xml_generation_constants for possible values; combine multiple codes with binary or (\c |)
             - \c soapaction: an optional string that will override the SOAPAction for the request; en empty string here will prevent the SOAPAction from being sent
-            - \c binding: the SOAP binding name, if not provided the first binding assigned to the operation will be used
 
             @return the deserialized result of the SOAP call to the SOAP server
 
@@ -422,8 +430,8 @@ public namespace SoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
         */
-        any call(reference info, string operation, any args, *hash header, *hash nsh, *string binding) {
-            return makeCallIntern(\info, operation, args, ("soap_header": header, "http_header": nsh, "binding": binding));
+        any call(reference info, string operation, any args, *hash header, *hash nsh) {
+            return makeCallIntern(\info, operation, args, ("soap_header": header, "http_header": nsh));
         }
 
         #! makes the call to the SOAP server and ensures that SOAP fault responses returned with a 500-series status code are processed as a SOAP fault so that error information is returned in the resulting exception
@@ -432,10 +440,9 @@ public namespace SoapClient {
             *hash nsh = opts.http_header;
             *int xml_opts = opts.xml_opts;
             *string soapaction = opts.soapaction;
-            *string binding = opts.binding;
 
             WSOperation op;
-            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction, binding);
+            hash msg = getMsg(operation, args, header, \op, nsh, xml_opts, soapaction);
             hash hdr = headers + msg.hdr;
 
             date now = now_us();
@@ -447,9 +454,17 @@ public namespace SoapClient {
             # we have to write the request key after the HTTPClient::post() call but before the log message above
             # (on_exit statements are executed in reverse order when the block is exited)
             on_exit info += ("request-body": msg.body, "request-soap-headers": header);
+            if (url_path) {
+                if (msg.path) {
+                    if (msg.path !~ /^[\/\?]/ ) {
+                        msg.path = "/" + msg.path;
+                    }
+                }
+                msg.path = url_path + msg.path;
+            }
             msglog(('reason': 'request', 'method': msg.method, 'path': msg.path, 'header': hdr, 'body': msg.body));
             # apply content encoding here
-            data body = msg.body;
+            data body = msg.body ?? "";
             if (seh.ce && body.size() > CompressionThreshold) {
                 hdr."Content-Encoding" = seh.ce;
                 body = seh.func(body);
@@ -501,6 +516,16 @@ public namespace SoapClient {
         #! returns the WSDL::WebService object associated with this object
         WSDL::WebService getWebService() {
             return wsdl;
+        }
+
+        #! returns current service, port, binding, url in hash
+        hash getInfo() {
+            return (
+                "service": svc,
+                "port": port,
+                "binding": binding,
+                "url": url,
+            );
         }
 
         #! change the data content encoding (compression) option for the object; see @ref EncodingSupport for valid options

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -281,7 +281,7 @@ public namespace SoapClient {
 
         #! returns a hash representing the serialized SOAP request for a given @ref WSDL::WSOperation "WSOperation"
         /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
-            @param binding SOAP binding, if not provided use the first binding assigned to operation
+            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header data structure for the SOAP header, if required by the message
             @param op a reference to return the @ref WSDL::WSOperation "WSOperation" object found
@@ -301,7 +301,7 @@ public namespace SoapClient {
         */
         hash getMsg(string operation, *string binding, any args, *hash header, reference op, *hash nsh, *int xml_opts, *string soapaction) {
             op = wsdl.getOperation(operation);
-            hash msg = op.serializeRequest(args, op.getBinding(binding), header, getEncoding(), nsh, xml_opts, soapaction);
+            hash msg = op.serializeRequest(args, binding, header, getEncoding(), nsh, xml_opts, soapaction);
             if (msg.hdr."Content-Type" !~ /charset=/i)
                 msg.hdr."Content-Type" += ";charset=" + getEncoding();
 
@@ -313,7 +313,7 @@ public namespace SoapClient {
 
         #! makes a server call with the given operation, arguments, options, and optional info hash reference and returns the result
         /** @param operation the SOAP operation to use to serialize the request; if the operation is not known to the underlying @ref WSDL::WebService "WebService" class, an exception will be thrown
-            @param binding SOAP binding, if not provided use the first binding assigned to operation
+            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param opts an optional hash of options for the call as follows:
             - \c soap_header: a hash giving SOAP header information, if required by the message
@@ -354,7 +354,7 @@ public namespace SoapClient {
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
-            @param binding SOAP binding, if not provided use the first binding assigned to operation
+            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
@@ -379,7 +379,7 @@ public namespace SoapClient {
 
         #! makes a server call with the given operation and arguments and returns the deserialized result
         /** @param operation the operation name for the SOAP call
-            @param binding SOAP binding, if not provided use the first binding assigned to operation
+            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param info an optional reference to return a hash of technical information about the SOAP call (raw message info and headers); the following keys are present in this hash:
             - \c "headers": a hash of HTTP request headers
@@ -421,7 +421,7 @@ public namespace SoapClient {
             - \c "request-body": the raw XML request body
             - \c "request-soap-headers": an optional hash of SOAP headers used in the request (if applicable)
             @param operation the operation name for the SOAP call
-            @param binding SOAP binding, if not provided use the first binding assigned to operation
+            @param binding SOAP binding name, if not provided use the first binding assigned to operation
             @param args the arguments to the SOAP operation
             @param header optional soap headers (if required by the operation)
             @param nsh a hash giving HTTP header information to include in the message (does not override automatically-generated SOAP message headers)
@@ -484,7 +484,7 @@ public namespace SoapClient {
             msglog(('reason': 'response', 'header': rmsg.header, 'body': rmsg.body));
             hash xmldata = WSDLLib::parseSOAPMessage(rmsg);
             #printf("DEBUG ans: %s\n", rh);
-            return op.deserializeResponse(xmldata, op.getBinding(binding));
+            return op.deserializeResponse(xmldata, binding);
         }
 
         #! uses SoapClient::call() to transparently serialize the argument and make a call to the given operation and return the deserialized results

--- a/qlib/SoapHandler.qm
+++ b/qlib/SoapHandler.qm
@@ -50,7 +50,7 @@
 %strict-args
 
 module SoapHandler {
-    version = "0.2.5";
+    version = "0.2.6";
     desc = "SoapHandler module";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -68,6 +68,9 @@ module SoapHandler {
     This module provides the @ref SoapHandler::SoapHandler "SoapHandler" class which can be used to provide an RPC handler for the HttpServer class provided by the HttpServer module.
 
     @section soaphandler_relnotes SoapHandler Release History
+
+    @subsection soaphandler_0_2_6 SoapHandler 0.2.6
+    - reimplmented operation to support multi binding, operation can be assigned to more bindings
 
     @subsection soaphandler_0_2_5 SoapHandler 0.2.5
     - added support for matching requests with soap action values
@@ -101,7 +104,7 @@ public namespace SoapHandler {
     #! SoapHandler implementation; to be registered as a request handler in the HttpServer class
     public class SoapHandler inherits public AbstractHttpRequestHandler {
         #! version of the SoapHandler implementation
-        const Version = "0.2.5";
+        const Version = "0.2.6";
 
         #! @cond nodoc
         private {
@@ -153,6 +156,7 @@ public namespace SoapHandler {
 
         #! adds a method to the handler dynamically
         /** @param ws the WebService object for the method
+            @param binding SOAP binding
             @param op the WSOperation object for the web service operation the method corresponds to
             @param func a call reference, a closure, or a string function name to call with the deserialized arguments to the method; the return value will be serialized to SOAP according to the WSDL and sent back to the caller
             @param help optional help text for the method
@@ -162,13 +166,14 @@ public namespace SoapHandler {
             @param err_func a call reference, a closure, or a string function name to call with error information if an exception is thrown with SOAP data
             @param altpath an alternate path for the service / WSDL
          */
-        addMethod(WebService ws, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
+        addMethod(WebService ws, Binding binding, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
             if (!func)
                 throw "SOAP-SERVER-ADDMETHOD-PARAMETER-ERROR", sprintf("second argument is not a function name or callable value type (got: %y)", func);
 
             addMethodInternal(ws,
                                 ( "operation" : op,
                                   "name"      : op.name,
+                                  "binding"   : binding,
                                   "function"  : func,
                                   "err_func"  : err_func,
                                   "help"      : help,
@@ -179,6 +184,11 @@ public namespace SoapHandler {
                                 ));
             #printf("methods=%N\n", methods);
         }
+
+        addMethod(WebService ws, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
+            addMethod(ws, op.bindings.firstValue(), op, func, help, logopt, cmark, path, err_func, altpath);
+        }
+
 
         #! turns on or off debugging; when debugging is enabled more verbose error messages are reported
         setDebug(bool dbg = True) {
@@ -225,7 +235,7 @@ public namespace SoapHandler {
         final private addMethodInternal(WebService ws, hash method) {
             string rn = method.operation.getTopLevelRequestName();
 
-            *string sa = method.operation.soapAction;
+            *string sa = method.bindings.operations{method.name}.soapAction;
             if (sa)
                 method.soap_action = sa;
 

--- a/qlib/SoapHandler.qm
+++ b/qlib/SoapHandler.qm
@@ -23,7 +23,7 @@
 */
 
 # make sure we have the required qore version
-%requires qore >= 0.8.12
+%requires qore >= 0.8.13
 
 # requires XML functionality
 %requires xml
@@ -71,6 +71,7 @@ module SoapHandler {
 
     @subsection soaphandler_0_2_6 SoapHandler 0.2.6
     - reimplmented operation to support multi binding, operation can be assigned to more bindings
+    - HTTP binding support
 
     @subsection soaphandler_0_2_5 SoapHandler 0.2.5
     - added support for matching requests with soap action values
@@ -101,6 +102,7 @@ module SoapHandler {
 
 #! main SoapHandler namespace
 public namespace SoapHandler {
+
     #! SoapHandler implementation; to be registered as a request handler in the HttpServer class
     public class SoapHandler inherits public AbstractHttpRequestHandler {
         #! version of the SoapHandler implementation
@@ -122,10 +124,10 @@ public namespace SoapHandler {
             # lookup alt path -> WebService object
             hash wsph;
 
-            # soapaction map: action -> operation
+            # soapaction map: action -> binding -> operation
             hash sam;
 
-            # service -> soapaction
+            # service -> binding -> soapaction
             hash psam;
 
             int loglevel;
@@ -141,6 +143,11 @@ public namespace SoapHandler {
 
             # hash of methods by path
             hash th;
+
+            # path TreeMap for each HTTP method
+            hash mapMethodPathToOperation;
+
+            # soapaction -> method -> binding
         }
         #! @endcond
 
@@ -228,56 +235,78 @@ public namespace SoapHandler {
         #! @cond nodoc
         # don't reimplement this method; fix/enhance it in the module
         final private addMethodInternal(WebService ws, hash method) {
+            #printf("DEBUG: SoapHandler::addMethodInternal() method: %N\n", method);
             string rn = method.operation.getTopLevelRequestName();
 
             hash binding = method.operation.getBinding(method.binding);
-            *string sa = binding.soapAction;
-            if (sa)
-                method.soap_action = sa;
 
-            rwl.writeLock();
-            on_exit rwl.writeUnlock();
+            if (binding.soapTransport) {
+                # soap binding
+                *string sa = binding.soapAction;
+                if (sa)
+                    method.soap_action = sa;
 
-            if (sa) {
-                if (!sam{sa})
-                    sam{sa} = method;
-                else if (sam{sa}.operation != method.operation)
-                    throw "SOAPACTION-ERROR", sprintf("cannot register soapAction %y for operation %y because it is already registered for operation %y", sa, method.operation.name, sam{sa}.operation.name);
-            }
+                rwl.writeLock();
+                on_exit rwl.writeUnlock();
 
-            #printf("DEBUG: SoapHandler::addMethodInternal() method: %N\n", method);
-
-            # map top-level element to method
-            if (method.path) {
-                string path = method.path;
-
-                # add path / soapaction mapping for service removal
-                if (sa && !psam{path}{sa})
-                    psam{path}{sa} = True;
-
-                # add link to WebService object
-                if (!wsh{path})
-                    wsh{path} = ws;
-
-                if (method.altpath && !wsph{method.altpath}) {
-                    # add lookup for altpath
-                    plh{path}.(method.altpath) = True;
-                    wsph{method.altpath} = ws;
+                if (sa) {
+                    if (!sam{sa})
+                        sam{sa} = method;
+                    else if (sam{sa}.operation != method.operation)
+                        throw "SOAPACTION-ERROR", sprintf("cannot register soapAction %y for operation %y because it is already registered for operation %y", sa, method.operation.name, sam{sa}.operation.name);
                 }
 
-                # add a link for each operation as well
-                map owsh{$1.operation.name} = ws, ws.listOperations(), !owsh{$1.operation.name};
+                # map top-level element to method
+                if (method.path) {
+                    string path = method.path;
 
-                # add method link if it doesn't already exist
-                if (!methods{rn}) {
-                    methods{rn} = method;
-                    th{path}{rn} = True;
+                    # add path / soapaction mapping for service removal
+                    if (sa && !psam{path}{sa})
+                        psam{path}{sa} = True;
+
+                    # add link to WebService object
+                    if (!wsh{path})
+                        wsh{path} = ws;
+
+                    if (method.altpath && !wsph{method.altpath}) {
+                        # add lookup for altpath
+                        plh{path}.(method.altpath) = True;
+                        wsph{method.altpath} = ws;
+                    }
+
+                    # add a link for each operation as well
+                    map owsh{$1.operation.name} = ws, ws.listOperations(), !owsh{$1.operation.name};
+
+                    # add method link if it doesn't already exist
+                    if (!methods{rn}) {
+                        methods{rn} = method;
+                        th{path}{rn} = True;
+                    }
                 }
-            }
-            else {
-                # add method link if it doesn't already exist
-                if (!methods{rn})
-                    methods{rn} = method;
+                else {
+                    # add method link if it doesn't already exist
+                    if (!methods{rn})
+                        methods{rn} = method;
+                }
+
+            } else if (binding.httpMethod) {
+                # http binding
+
+                rwl.readLock();
+                on_exit rwl.readUnlock();
+                if (!mapMethodPathToOperation{binding.httpMethod}) {
+                    mapMethodPathToOperation{binding.httpMethod} = new TreeMap();
+                }
+                method.parseUrlOnly = binding.input.urlEncoded || binding.input.urlReplacement;
+                method.exactMatch = !binding.input.urlReplacement;
+                method.path = ltrim(method.path ?? binding.location, "/");
+                if (index(method.path, "?") >= 0) {
+                    throw "SOAPACTION-ERROR", sprintf("cannot register path %y for operation %y because it contains parameters", method.path, method.operation.name);
+                }
+                mapMethodPathToOperation{binding.httpMethod}.put(method.path, method);
+
+            } else {
+                throw "SOAPACTION-ERROR", sprintf("cannot register operation %y because it has no binding", method.operation.name);
             }
 
             #printf("DEBUG: SoapHandler::addMethodInternal() %N %N\n", method.name, method.path);
@@ -337,6 +366,7 @@ private nothing msglog(hash cx, hash msg) {
                     ("soapenv:Fault":
                      ("soapenv:Code": ("soapenv:Value": err),
                       "soapenv:Reason": ("soapenv:Text": desc)));
+                      # optional Node, Role, Detail, see https://www.w3.org/TR/soap12/, 5.4 Fault
             }
             else {
                 o = ENVELOPE_11_NS;
@@ -345,42 +375,21 @@ private nothing msglog(hash cx, hash msg) {
                       ("faultcode": err,
                        "faultstring": desc,
                        "desc": ""));
+                # optional faultActor,  https://www.w3.org/TR/2000/NOTE-SOAP-20000508/ 4.4 SOAP fault
             }
+            #TODO: http binding https://www.w3.org/TR/2007/REC-soap12-part2-20070427/#soapinhttp
             hash msg = (
                 "code": code,
                 "errlog": errLog,
                 "body": make_xml(o, fmt ? XGF_ADD_FORMATTING: 0),
-                "hdr": ("Content-Type" : soap12 ? MimeTypeSoapXml : MimeTypeXml),
+                "hdr": ("Content-Type" : WSDLLib::getSoapMimeType12(soap12)),
             );
             msglog(cx, ('reason': 'error', 'code': code, 'header': msg.hdr, 'body': msg.body));
             return msg;
         }
 
         # don't reimplement this method; fix/enhance it in the module
-        final private *hash callOperation(hash cx, any args, *string soapaction, bool reqsoap12) {
-            *string element = cx.element;
-
-            *hash method;
-            {
-                rwl.readLock();
-                on_exit rwl.readUnlock();
-
-                # first match with soapaction if possible
-                if (soapaction && sam{soapaction}) {
-                    method = sam{soapaction};
-                    #printf("DEBUG: request matched with SoapAction %y\n", soapaction);
-                }
-                else {
-                    method = methods{element};
-
-                    #printf("DEBUG: found element %N method %N\n", element, method);
-                    if (!method) {
-                        if (!element)
-                            throw "SOAP-SERVER-UNKNOWN-OPERATION", sprintf("cannot find operation element in SOAP call; call context=%N", cx);
-                        throw "SOAP-SERVER-UNKNOWN-OPERATION", sprintf("cannot map top-level element %n to a SOAP operation: %s", element, elements methods ? sprintf("currently recognized top-level elements: %n", keys methods) : "no SOAP services are currently registered");
-                    }
-                }
-            }
+        final private *hash callOperation(hash cx, any args, hash method, bool reqsoap12) {
 
             # NOTE: internal methods have no operation definition and can take no parameters
             hash h;
@@ -395,7 +404,11 @@ private nothing msglog(hash cx, hash msg) {
             cx.operation = method.operation;
 
             try {
-                args = method.operation.deserializeRequest(args);
+                if (method.parseUrlOnly) {
+                    args = method.operation.deserializePath(cx.url.path, method.binding);
+                } else {
+                    args = method.operation.deserializeRequest(args, method.binding);
+                }
             }
             catch (ex) {
                 if (method.err_func) {
@@ -460,7 +473,7 @@ private nothing msglog(hash cx, hash msg) {
             if (method.operation.output) {
                 try {
                     any header = remove rv."^header^";
-                    h += method.operation.serializeResponse(rv, header, NOTHING, NOTHING, reqsoap12);
+                    h += method.operation.serializeResponse(rv, header, NOTHING, NOTHING, reqsoap12, NOTHING, method.binding);
                     msglog(cx, ('reason': 'response', 'header': h.hdr, 'body': h.body));
                 }
                 catch (hash ex) {
@@ -474,6 +487,21 @@ private nothing msglog(hash cx, hash msg) {
             return h;
         }
 
+        private *hash matchMethod(TreeMap tm, string path, reference unmatched) {
+            bool hasParams = index(path, "?") >= 0;
+            *string um;
+            *hash method = tm.get(path, \um);
+            if (method) {
+                if (method.exactMatch) {
+                    if (!hasParams && um != "" || hasParams && index(um, "?") > 0) {
+                        return NOTHING;
+                    }
+                }
+                unmatched = um;
+            }
+            return method;
+        }
+
         # method called by HttpServer
         # don't reimplement this method; fix/enhance it in the module
         final hash handleRequest(hash cx, hash hdr, *data body) {
@@ -481,31 +509,74 @@ private nothing msglog(hash cx, hash msg) {
             #printf("soap handler context=%y hdr=%y body=%y keys wsh=%y\n", cx, hdr, body, wsh.keys()); #XXX
             cx.http_header = hdr;
             cx.http_body = body;
+            *hash method;
 
-            *string soapaction = (hdr."content-type" =~ x/;action=(.+)/)[0];
-            if (soapaction)
-                hdr."content-type" =~ s/;.+$/;#/;
-            else
-                soapaction = hdr.soapaction;
-
-            any args;
             bool reqsoap12 = False; # set to True if soap 1.2 envelope is used in request
 
-            if (hdr.method == "GET") {
-                *string path = cx.url.path;
+            *string path = cx.url.path;
+            # remove query args if present
+            # path =~ s/\?.*$//;
+            # remove leading / in path, if any
+            path =~ s/^\///;
 
+            if (hdr.method == "POST") {
+                # try SoapBinding
+                *string soapaction = (hdr."content-type" =~ x/;action=(.+)/)[0];
+                if (soapaction)
+                    hdr."content-type" =~ s/;.+$/;#/;    # TODO: is regex correct should not match till ;
+                else
+                    soapaction = hdr.soapaction;
+                if (soapaction) {
+                    rwl.readLock();
+                    on_exit rwl.readUnlock();
+
+                    method = sam{soapaction};
+                    #printf("DEBUG: request matched with SoapAction %y\n", soapaction);
+                }
+            }
+
+            if (!method) {
+                # SOAP action is not explicitely specified, e.g. HTTP binding, try get it from path
+                rwl.readLock();
+                on_exit rwl.readUnlock();
+                *string args;
+                if (exists mapMethodPathToOperation{hdr.method}) {
+                    TreeMap tm = mapMethodPathToOperation{hdr.method};
+                    method = matchMethod(tm, path, \args);
+                    if (!method) {
+                        if (cx.root_path && path.equalPartialPath(cx.root_path)) {
+                            method = tm.get(path.substr(cx.root_path.size()), \args);
+                        }
+                    }
+                }
+                if (method && method.parseUrlOnly) {
+                    try {
+                        msglog(cx, ('reason': 'request', 'method': hdr.method, 'path': path));  # we need log request
+                        #printf("DEBUG: context: %N\nargs: %N\n", cx, args);
+                        return ("code": 200) + callOperation(cx, args, method, reqsoap12);
+                    }
+                    catch (ex) {
+                        string str = debug
+                            ? get_exception_string(ex)
+                            : sprintf("exception in %s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
+                        return makeSoapFaultResponse(cx, 500, str, reqsoap12, ex.err, ex.desc);
+                    }
+                }
+            }
+
+            if (!method && hdr.method == "GET") {
+                # path has not been resolved to an operation, so try an heuristic to match a service
                 # remove query args if present
                 path =~ s/\?.*$//;
-                # remove leading / in path, if any
-                path =~ s/^\///;
 
                 #printf("DEBUG: PATH=%N (%n %n)\n", path, exists wsh{path}, keys wsh);
 
-                if (!path)
+                if (!path) {
                     return (
                         "code": 501,
                         "body": sprintf("invalid HTTP GET: no path given in URL; known services: %y", wsh.keys()),
                     );
+                }
 
                 rwl.readLock();
                 on_exit rwl.readUnlock();
@@ -528,7 +599,7 @@ private nothing msglog(hash cx, hash msg) {
                     return (
                         "code": 501,
                         "body": sprintf("invalid HTTP GET: no WebService object for path %y; known paths / services: %y; known operations: %y; known alt paths: %y", path, wsh.keys(), owsh.keys(), wsph.keys()),
-                        );
+                    );
                 }
 
                 # get URL for service
@@ -559,84 +630,97 @@ private nothing msglog(hash cx, hash msg) {
                     "code": 200,
                     "body": ws.getWSDL(base_url),
                     "hdr": ("Content-Type": "text/xml"),
-                    );
+                );
             }
 
-            if (hdr.method != "POST")
-                return ( "code" : 501,
-                         "body" : sprintf("don't know how to handle method %n", hdr.method) );
+            if (method || hdr.method == "POST") {
+                # still chance to get method from xml element in case of SoapBinding (i.e.POST), we need parse message now
+                any args;
+                try {
+                    *string ct = hdr."_qore_orig_content_type";
+                    *string element = (ct =~ x/action=".*\/(.*)"/)[0];
+                    # parse multipart messages
+                    if (ct =~ /multipart\//) {
+                        *string  x = (ct =~ x/multipart\/([^;]+)/)[0];
+                        hdr."_qore_multipart" = x;
+                        x = (ct =~ x/start=([^;]+)/)[0];
+                        if (exists x)
+                            hdr."_qore_multipart_start" = x;
+                        x = (ct =~ x/boundary=([^;]+)/)[0];
+                        if (exists x)
+                            hdr."_qore_multipart_boundary" = x;
+                        #printf("hdr=%N\n", hdr);
+                    }
+                    hash msg = WSDLLib::parseMultiPartSOAPMessage(hdr + ("body" : body));
+                    msglog(cx, ('reason': 'request', 'header': msg.header, 'method': hdr.method, 'body': msg.body));
+                    args = WSDLLib::parseSOAPMessage(msg);
+                    if (WSDLLib::isSOAPMessage(msg)) {
+                        # it is SOAP message (or XML content)
+                        WSDL::XsdBase::removeNS(\args);
+                        WSDL::XsdBase::removeNS(\args.Envelope);
 
-            try {
-                *string ct = hdr."_qore_orig_content_type";
-                # parse multipart messages
-                if (ct =~ /multipart\//) {
-                    *string  x = (ct =~ x/multipart\/([^;]+)/)[0];
-                    hdr."_qore_multipart" = x;
-                    x = (ct =~ x/start=([^;]+)/)[0];
-                    if (exists x)
-                        hdr."_qore_multipart_start" = x;
-                    x = (ct =~ x/boundary=([^;]+)/)[0];
-                    if (exists x)
-                        hdr."_qore_multipart_boundary" = x;
-                    #printf("hdr=%N\n", hdr);
-                }
-                hash msg = WSDLLib::parseMultiPartSOAPMessage(hdr + ("body" : body));
-                msglog(cx, ('reason': 'request', 'header': msg.header, 'body': msg.body));
-                args = WSDLLib::parseSOAPMessage(msg);
-                WSDL::XsdBase::removeNS(\args);
-                WSDL::XsdBase::removeNS(\args.Envelope);
+                        if (!method) {
+                            # get SOAP operation name from top XML element
+                            if (!exists element && exists args.Envelope.Body && args.Envelope.Body.typeCode() == NT_HASH ) {
+                                foreach string k in (keys args.Envelope.Body) {
+                                    if (k == "multiRef" || k == "^attributes^")
+                                        continue;
+                                    element = k =~ x/.*:(.*)/[0];
+                                    break;
+                                }
+                            }
+                            if (element) {
+                                rwl.readLock();
+                                on_exit rwl.readUnlock();
 
-                # get SOAP operation name
-                *string element;
-                if (!exists (element = (ct =~ x/action=".*\/(.*)"/)[0])) {
+                                method = methods{element};
+                            }
+                        }
 
-                    *hash sbody = args.Envelope.Body;
-                    if (!exists sbody)
-                        throw "SOAP-CALL-ERROR", "missing SOAP body in SOAP envelope in SOAP operation call";
-
-                    foreach string k in (sbody.keyIterator()) {
-                        if (k == "multiRef" || k == "^attributes^")
-                            continue;
-                        element = k =~ x/.*:(.*)/[0];
-                        break;
+                        # set soap version in request
+                        *hash attr = args.Envelope."^attributes^";
+                        foreach string k in (attr.keyIterator()) {
+                            if (k =~ /:soapenv$/) {
+                                if (attr{k} == SOAP_12_ENV)
+                                    reqsoap12 = True;
+                                else if (attr{k} != SOAP_11_ENV)
+                                    throw "SOAP-CALL-ERROR", sprintf("unsupported SOAP envelope received: %n", attr{k});
+                                break;
+                            }
+                        }
+                        if (!exists element) {
+                            throw "SOAP-CALL-ERROR", "no operation call found in message";
+                        }
                     }
                 }
-
-                # set soap version in request
-                *hash attr = args.Envelope."^attributes^";
-                foreach string k in (attr.keyIterator()) {
-                    if (k =~ /:soapenv$/) {
-                        if (attr{k} == SOAP_12_ENV)
-                            reqsoap12 = True;
-                        else if (attr{k} != SOAP_11_ENV)
-                            throw "SOAP-CALL-ERROR", sprintf("unsupported SOAP envelope received: %n", attr{k});
-                        break;
-                    }
+                catch (ex) {
+                    log(cx, "exception parsing SOAP msg: %y\n%y", body, ex);
+                    string str = sprintf("exception in %s:%d: %s: %s (1: %N)", ex.file, ex.line, ex.err, ex.desc, ex.callstack)
+                    #string str = debug
+                        ? get_exception_string(ex)
+                        : sprintf("%s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
+                    return makeSoapFaultResponse(cx, 500, str, reqsoap12, ex.err, ex.desc);
                 }
 
-                if (!exists element)
-                    throw "SOAP-CALL-ERROR", "no operation call found in message";
+                if (method) {
+                    try {
+                        #printf("DEBUG: context: %N\nargs: %N\n", cx, args);
+                        return ("code": 200) + callOperation(cx, args, method, reqsoap12);
+                    }
+                    catch (ex) {
+                        string str = debug
+                            ? get_exception_string(ex)
+                            : sprintf("exception in %s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
+                        return makeSoapFaultResponse(cx, 500, str, reqsoap12, ex.err, ex.desc);
+                    }
+                }
+            }
 
-                cx.element = element;
-            }
-            catch (ex) {
-                log(cx, "exception parsing SOAP msg: %y", body);
-                #string str = sprintf("exception in %s:%d: %s: %s (1: %N)", ex.file, ex.line, ex.err, ex.desc, ex.callstack);
-                string str = debug
-                    ? get_exception_string(ex)
-                    : sprintf("%s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
-                return makeSoapFaultResponse(cx, 500, str, reqsoap12, ex.err, ex.desc);
-            }
-            try {
-                #printf("DEBUG: context: %N\nargs: %N\n", cx, args);
-                return ("code": 200) + callOperation(cx, args, soapaction, reqsoap12);
-            }
-            catch (ex) {
-                string str = debug
-                    ? get_exception_string(ex)
-                    : sprintf("exception in %s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
-                return makeSoapFaultResponse(cx, 500, str, reqsoap12, ex.err, ex.desc);
-            }
+            return (
+                "code" : 501,
+                "body" : sprintf("don't know how to handle request with method %n", hdr.method),
+            );
+
         }
 
         private *WebService tryMatch(string path) {

--- a/qlib/SoapHandler.qm
+++ b/qlib/SoapHandler.qm
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! @file SoapHandler.qm SOAP handler module providing the SoapHandler class to be registered as a handler with the Qore HttpServer module
 
-/*  SoapHandler.qm Copyright (C) 2012 - 2016 David Nichols
+/*  SoapHandler.qm Copyright (C) 2012 - 2017 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -157,7 +157,6 @@ public namespace SoapHandler {
         #! adds a method to the handler dynamically
         /** @param ws the WebService object for the method
             @param op the WSOperation object for the web service operation the method corresponds to
-            @param binding SOAP binding name, leave empty to use the first assigned binding
             @param func a call reference, a closure, or a string function name to call with the deserialized arguments to the method; the return value will be serialized to SOAP according to the WSDL and sent back to the caller
             @param help optional help text for the method
             @param logopt log options which can be used by a custom logger (see the \a getLogMessage parameter in the constructor)
@@ -165,8 +164,9 @@ public namespace SoapHandler {
             @param path an optional path for the method (assumed to be the name of the service)
             @param err_func a call reference, a closure, or a string function name to call with error information if an exception is thrown with SOAP data
             @param altpath an alternate path for the service / WSDL
+            @param binding SOAP binding name, leave empty to use the first assigned binding
          */
-        addMethod(WebService ws, WSOperation op, *string binding, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
+        addMethod(WebService ws, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath, *string binding) {
             if (!func)
                 throw "SOAP-SERVER-ADDMETHOD-PARAMETER-ERROR", sprintf("second argument is not a function name or callable value type (got: %y)", func);
 
@@ -184,11 +184,6 @@ public namespace SoapHandler {
                                 ));
             #printf("methods=%N\n", methods);
         }
-
-        addMethod(WebService ws, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
-            addMethod(ws, op, NOTHING, func, help, logopt, cmark, path, err_func, altpath);
-        }
-
 
         #! turns on or off debugging; when debugging is enabled more verbose error messages are reported
         setDebug(bool dbg = True) {
@@ -250,7 +245,7 @@ public namespace SoapHandler {
                     throw "SOAPACTION-ERROR", sprintf("cannot register soapAction %y for operation %y because it is already registered for operation %y", sa, method.operation.name, sam{sa}.operation.name);
             }
 
-            #printf("DEBUG: SoapHandler::addMethodIntern() method: %N\n", method);
+            #printf("DEBUG: SoapHandler::addMethodInternal() method: %N\n", method);
 
             # map top-level element to method
             if (method.path) {
@@ -317,7 +312,7 @@ public namespace SoapHandler {
             @par cx context passed from @ref HttpServer::HttpServer "HttpServer"
             @par msg information about message to be logged. There are keys 'reason' with value 'request', 'response' or 'error',
                  'header' (HTTP header, in casew ) and 'body' containing XML data in readable form, i.e. uncompressed and in case of
-                 multipart message only the related part is passed. Method is executed before message is sent or after 
+                 multipart message only the related part is passed. Method is executed before message is sent or after
                  has been received. Do not allow exception raising in method not to interrupt handler function.
 
             @par Example:

--- a/qlib/SoapHandler.qm
+++ b/qlib/SoapHandler.qm
@@ -156,8 +156,8 @@ public namespace SoapHandler {
 
         #! adds a method to the handler dynamically
         /** @param ws the WebService object for the method
-            @param binding SOAP binding
             @param op the WSOperation object for the web service operation the method corresponds to
+            @param binding SOAP binding name, leave empty to use the first assigned binding
             @param func a call reference, a closure, or a string function name to call with the deserialized arguments to the method; the return value will be serialized to SOAP according to the WSDL and sent back to the caller
             @param help optional help text for the method
             @param logopt log options which can be used by a custom logger (see the \a getLogMessage parameter in the constructor)
@@ -166,7 +166,7 @@ public namespace SoapHandler {
             @param err_func a call reference, a closure, or a string function name to call with error information if an exception is thrown with SOAP data
             @param altpath an alternate path for the service / WSDL
          */
-        addMethod(WebService ws, Binding binding, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
+        addMethod(WebService ws, WSOperation op, *string binding, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
             if (!func)
                 throw "SOAP-SERVER-ADDMETHOD-PARAMETER-ERROR", sprintf("second argument is not a function name or callable value type (got: %y)", func);
 
@@ -186,7 +186,7 @@ public namespace SoapHandler {
         }
 
         addMethod(WebService ws, WSOperation op, any func, *string help, *int logopt, any cmark, *string path, any err_func, *string altpath) {
-            addMethod(ws, op.bindings.firstValue(), op, func, help, logopt, cmark, path, err_func, altpath);
+            addMethod(ws, op, NOTHING, func, help, logopt, cmark, path, err_func, altpath);
         }
 
 
@@ -235,7 +235,8 @@ public namespace SoapHandler {
         final private addMethodInternal(WebService ws, hash method) {
             string rn = method.operation.getTopLevelRequestName();
 
-            *string sa = method.bindings.operations{method.name}.soapAction;
+            hash binding = method.operation.getBinding(method.binding);
+            *string sa = binding.soapAction;
             if (sa)
                 method.soap_action = sa;
 

--- a/qlib/SoapHandler.qm
+++ b/qlib/SoapHandler.qm
@@ -403,7 +403,7 @@ private nothing msglog(hash cx, hash msg) {
                     nex.desc = sprintf("error deserializing incoming SOAP request: %s", ex.desc);
                     call_function(method.err_func, cx, nex);
                 }
-		        string str = debug
+                string str = debug
                     ? get_exception_string(ex)
                     : sprintf("%s: %s: %s", get_ex_pos(ex), ex.err, ex.desc);
                 return makeSoapFaultResponse(cx, 500, str, reqsoap12, ex.err, ex.desc);
@@ -478,7 +478,7 @@ private nothing msglog(hash cx, hash msg) {
         # don't reimplement this method; fix/enhance it in the module
         final hash handleRequest(hash cx, hash hdr, *data body) {
             #log(LL_DEBUG_1, "soap handler context=%y hdr=%y body=%y wsh=%y", cx, hdr, body, wsh.keys());
-            #printf("soap handler context=%y hdr=%y body=%y keys wsh=%y\n", cx, hdr, body, wsh.keys());
+            printf("soap handler context=%y hdr=%y body=%y keys wsh=%y\n", cx, hdr, body, wsh.keys()); #XXX
             cx.http_header = hdr;
             cx.http_body = body;
 

--- a/qlib/SoapHandler.qm
+++ b/qlib/SoapHandler.qm
@@ -478,7 +478,7 @@ private nothing msglog(hash cx, hash msg) {
         # don't reimplement this method; fix/enhance it in the module
         final hash handleRequest(hash cx, hash hdr, *data body) {
             #log(LL_DEBUG_1, "soap handler context=%y hdr=%y body=%y wsh=%y", cx, hdr, body, wsh.keys());
-            printf("soap handler context=%y hdr=%y body=%y keys wsh=%y\n", cx, hdr, body, wsh.keys()); #XXX
+            #printf("soap handler context=%y hdr=%y body=%y keys wsh=%y\n", cx, hdr, body, wsh.keys()); #XXX
             cx.http_header = hdr;
             cx.http_body = body;
 

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1914,7 +1914,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         bindings{bname} = opparams;
     }
 
-    private hash serializeSoapMessage(any h, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
+    private:internal hash serializeSoapMessage(any h, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
         string io = request ? "input" : "output";
         # setup namespaces for SOAP envelope
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
@@ -2008,7 +2008,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
 
-    private *data serializeHttpMessage(any h, hash binding, bool request, reference ct, reference enc) {
+    private:internal *data serializeHttpMessage(any h, hash binding, bool request, reference ct, reference enc) {
         string io = request ? "input" : "output";
         if (binding{io}.content.formUrlEncoded) {
             ct = MimeTypeFormUrlEncoded;
@@ -2249,7 +2249,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return (mrh, body);
     }
 
-    private any deserializeSoapMessage(hash o, hash binding, bool request) {
+    private:internal any deserializeSoapMessage(hash o, hash binding, bool request) {
         #printf("DEBUG: deserializeSoapMessage(%N, %y)\n", o, request);
         string io = request ? "input" : "output";
         WSDL::XsdBase::removeNS2(\o);
@@ -2355,7 +2355,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return rv;
     }
 
-    private *hash deserializeHttpMessage(hash v, hash binding, bool request) {
+    private:internal *hash deserializeHttpMessage(hash v, hash binding, bool request) {
         string io = request ? "input" : "output";
         *string ct = v."content-type";
         if (!exists ct) {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1,5 +1,5 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
-#! @file WSDL.qm WSDL: Web Services Description Language: http://www.w3.org/TR/wsdl
+#! @file WSDL.qm WSDL: Web Services Description Language: http://www.w3.org/TR/wsdl, SOAP 1.1: https://www.w3.org/TR/2000/NOTE-SOAP-20000508/, SOAP 1.2: https://www.w3.org/TR/soap12-part1/
 
 /*  WSDL.qm Copyright (C) 2012 - 2016 Qore Technologies, s.r.o.
 
@@ -204,6 +204,10 @@ public class WSDL::WSDLLib {
     #! Mime types recognized as SOAP messages
     const SoapMimeTypes = (MimeTypeSoapXml, MimeTypeXml, MimeTypeXmlApp);
 
+    static string getSoapMimeType12(bool soap12) {
+        return soap12 ? MimeTypeSoapXml : MimeTypeXml;
+    }
+
     #! retrieves a local file and returns the file's contents as a string
     /** called by WSDLLib::getFileFromURL() in case the scheme is "file"
     */
@@ -390,13 +394,22 @@ public class WSDL::WSDLLib {
         }
     }
 
-    #! takes a hash representation returned by parseMultiPartSOAPMessage and parses it to a Qore data structure, checks the content-type, and handles hrefs in the message
+    #! returns True is the message has a SOAP mime type
+    static bool isSOAPMessage(hash msg) {
+        return WSDLLib::isContentType(msg."content-type", SoapMimeTypes);
+    }
+
+    /**!
+    takes a hash representation returned by parseMultiPartSOAPMessage and parses it to a Qore data structure, checks the content-type, and handles hrefs in the message.
+    Operation is not yet known if SoapAction header is not presented
+    */
     static *hash parseSOAPMessage(hash msg) {
+
         if (!msg.body) {
             hash h."content-type" = msg."content-type" ?? "text/plain";
             h.body = NOTHING;
             return h;
-        } else if (WSDLLib::isContentType(msg."content-type", SoapMimeTypes)) {
+        } else if (WSDLLib::isSOAPMessage(msg)) {
             hash xmldata;
             if (msg.body) {
                 xmldata = parse_xml(msg.body);
@@ -627,7 +640,7 @@ public class WSDL::XsdAbstractType inherits WSDL::XsdNamedData {
         return ons;
     }
 
-    abstract any serialize(any val, *softbool omitType, *softbool keepBinary);
+    abstract any serialize(any val, *softbool omitType);
     abstract any deserialize(string en, *TypeMap tmap, *hash mrh, any val);
 }
 
@@ -639,7 +652,7 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
     constructor(string t, Namespaces nsc, string ns = "xsd") : XsdAbstractType(t, ns, nsc) {
     }
 
-    any serialize(any val, *softbool omitType, *softbool keepBinary) {
+    any serialize(any val, *softbool omitType) {
         *hash comments;
         if (val.typeCode() == NT_HASH) {
             foreach string k in (val.keyIterator()) {
@@ -758,19 +771,16 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
                 break;
 
             case "base64Binary":
-                if (keepBinary) {
-                    val = binary(val);
-                } else {
-                    val = make_base64_string(val);
-                }
+                val = make_base64_string(val);
                 break;
 
             case "hexBinary":
-                if (keepBinary) {
-                    val = binary(val);
-                } else {
-                    val = make_hex_string(val);
-                }
+                val = make_hex_string(val);
+                break;
+
+            case "binary":
+                # used for HTTP binding only
+                val = binary(val);
                 break;
         }
 
@@ -929,6 +939,14 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
                     return val.empty() ? binary() : parse_hex_string(val);
                 }
 
+            case "binary":
+                # used for HTTP binding only
+                if (val.typeCode() == NT_BINARY) {
+                    return val;
+                } else {
+                    return val.empty() ? binary() : binary(val);
+                }
+
             default: {
                 if (name == "anyType")  {
                     *XsdAbstractType t = tmap.tryGet(type);
@@ -948,7 +966,7 @@ public class WSDL::XsdArrayType inherits WSDL::XsdAbstractType {
             throw "XSD-ARRAYTYPE-ERROR", sprintf("don't know how to handle arrays of type %y", t);
     }
 
-    any serialize(any val, *softbool omitType, *softbool keepBinary) {
+    any serialize(any val, *softbool omitType) {
         switch (name) {
             case "binary": {
                 int t = val.typeCode();
@@ -1242,7 +1260,7 @@ public class WSDL::XsdSimpleType inherits WSDL::XsdAbstractType {
         #printf("DEBUG: st: %y\n", self); exit();
     }
 
-    any serialize(any val, *softbool omitType, *softbool keepBinary) {
+    any serialize(any val, *softbool omitType) {
         *hash rh;
         if (val.typeCode() == NT_HASH) {
             foreach string k in (val.keyIterator()) {
@@ -1561,7 +1579,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         return rv;
     }
 
-    *hash serialize(any h, *softbool omitType, *softbool keepBinary) {
+    *hash serialize(any h, *softbool omitType) {
         if (exists array)
             return array.serialize(h, omitType);
 
@@ -2007,7 +2025,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             return mime_get_form_urlencoded_string(self{io}.serializeAllPartData(h));
         } else if (binding{io}.content) {
 
-            hash v = self{io}.serializeData(binding{io}.content.part, h, True);
+            hash v = self{io}.serializeData(binding{io}.content.part, h);
             if (v."content-type") {
                 if (!binding{io}.content.acceptAllContentTypes) {
                     WSDLLib::checkContentType(v."content-type", binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
@@ -2028,7 +2046,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         } else if (binding{io}.mimeXml) {
             ct = MimeTypeXml;
             # in case of mimeXml is body content, i.e. XML tag based on element/type name, not part
-            return make_xml(self{io}.serializeRpc(binding{io}.mimeXml.part, NOTHING, NOTHING, binding{io}.mimeXml.part, False, \h));
+            string ons;
+            hash hh;
+            hh{binding{io}.mimeXml.part} = self{io}.serializeRpcValue(binding{io}.mimeXml.part, False, \h, \ons);
+            return make_xml(hh);
         }
     }
 
@@ -2067,7 +2088,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh an optional namespace hash for the output message
         @param xml_opts optional XML generation options
-        @param req_soapaction if present will override any SOAPAction value for the request
+        @param req_soapaction if present will override any SOAPAction value for the request, ignored for HTTP binding
         @param bname SOAP binding name or empty to get the first assigned binding
 
         @return a hash with keys:
@@ -2084,13 +2105,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             req_soapaction = bindings{name}.soapAction;
 
         string ct;
-        if (nsc.hasSoap12()) {
-            ct = MimeTypeSoapXml;
-            if (req_soapaction)
-                ct += sprintf(";action: %s", req_soapaction);
-        } else
-            ct = MimeTypeXml;
-
         enc = enc ?? get_default_encoding();
 
         hash rv = (
@@ -2100,30 +2114,54 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         if (binding.httpMethod) {
             rv.body = serializeHttpMessage(h, binding, True, \ct, \enc);
+            if (binding.output.content) {
+                if (binding.output.content.acceptAllContentTypes) {
+                    rv.accept = "*/*";
+                } else {
+                    *list l;
+                    l = binding.output.content.acceptedContentTypeSubtypes;
+                    foreach string t in (binding.output.content.acceptedContentTypes)
+                        push l, t+"*";
+                    rv.accept = l.join(",");
+                }
+            } else if (binding.output.mimeXml) {
+                rv.accept = MimeTypeXml;
+            }
+            if (exists rv.body && exists ct) {
+                rv."content-type" = ct;
+                if (exists enc) {
+                    ct += sprintf(";charset=%s", enc);
+                }
+                rv.hdr."Content-Type" = ct;
+            }
         } else {
             MultiPartRelatedMessage mpm;
             rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
             if (mpm) {
-                mpm.splicePart(rv.body, sprintf("<%s>", (binding.input.body.parts ? binding.input.body.parts : keys input.args).join(" ")), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
+                mpm.splicePart(rv.body, sprintf("<%s>", (binding.input.body.parts ? binding.input.body.parts : keys input.args).join(" ")), ct);
 
                 hash rv = mpm.getMsgAndHeaders();
-                if (req_soapaction) {
-                    if (nsc.hasSoap12())
-                        ct += sprintf(";action: %s", req_soapaction);
+            }
+            rv.accept = WSDLLib::SoapMimeTypes.join(",");
+
+            string ct = WSDLLib::getSoapMimeType12(nsc.hasSoap12());
+            rv."content-type" = ct;
+
+            if (req_soapaction) {
+                rv.hdr += ("SOAPAction": req_soapaction);
+                if (nsc.hasSoap12()) {
+                    ct += sprintf(";action: %s", req_soapaction);
                 }
             }
-        }
-
-        if (exists enc) {
-            ct += sprintf(";charset=%s", enc);
-        }
-
-        if (exists rv.body) {
+            if (exists enc) {
+                ct += sprintf(";charset=%s", enc);
+            }
             rv.hdr."Content-Type" = ct;
         }
 
-        if (req_soapaction)
-            rv.hdr += ("SOAPAction": req_soapaction);
+        if (rv.accept) {
+            rv.hdr."Accept" = rv.accept;
+        }
 
         return rv;
     }
@@ -2171,7 +2209,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
             rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, False, soap12, \mpm), xml_opts, enc);
 
-            ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
+            ct = WSDLLib::getSoapMimeType12(soap12);
             if (exists mpm) {
                 mpm.splicePart(rv.body, sprintf("<%s>", (binding.output.body.parts ? binding.output.body.parts : keys output.args).join(" ")), ct);
                 return mpm.getMsgAndHeaders();
@@ -2365,14 +2403,17 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (!exists ct && !binding{io}.mimeXml) {
             throw SOAP_DESERIALIZATION_ERROR, sprintf("missing content-type in input hash: %y", v);
         }
-        if (binding{io}.urlEncoded) {
+        if (binding{io}.urlEncoded || binding{io}.urlReplacement) {
+            # is should be processed via deserializeUrl()
             throw SOAP_DESERIALIZATION_ERROR, sprintf("urlencoded message deserialization is not supported in binding: %y", binding.name);
         }
         if (binding{io}.content.formUrlEncoded) {
             WSDLLib::checkContentType(ct, list(MimeTypeFormUrlEncoded));
-            v.body = binary_to_string(v.body);
+            if (v.body.typeCode() == NT_BINARY) {
+                v.body = binary_to_string(v.body);
+            }
             hash h = mime_parse_form_urlencoded_string(v.body); # TODO: data have no encoding
-            return self{io}.deserializeRpc(NOTHING, h, NOTHING);
+            return self{io}.deserializeAllPartData(h);
         } else if (binding{io}.content) {
 
             if (!binding{io}.content.acceptAllContentTypes) {
@@ -2380,13 +2421,13 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             }
             hash v2;
             v2{binding{io}.content.part} = v.body;
-            hash h = self{io}.deserializeRpc(NOTHING, v2, binding{io}.content.part);
+            hash h = self{io}.deserializeData(binding{io}.content.part, v2);
             string k = h.firstKey();
             h{k}."^value^" = remove h{k};
             h{k}."^attributes^"."^content-type^" = ct;
             return h;
         } else if (binding{io}.mimeXml) {
-            *hash h = self{io}.deserializeRpc(NOTHING, v, binding{io}.mimeXml.part);
+            *hash h = self{io}.deserializeData(binding{io}.mimeXml.part, v);
             return h;
         }
     }
@@ -2419,6 +2460,47 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         } else {
             return deserializeSoapMessage(o, binding, False);
         }
+    }
+
+    /** Operation is resolved from method and path so let's look if data are passed in URL.
+    When URL replacement is defined for operation then exception is raised.
+    @return NOTHING if data are not encoded in URL for operation
+    */
+    any deserializePath(string path, *string bname) {
+        hash binding = getBinding(bname);
+        if (binding.input.urlReplacement) {
+            # all parameters are somehow encoded in path
+            throw SOAP_DESERIALIZATION_ERROR, sprintf("url replacement message deserialization is not supported in binding: %y", binding.name);
+        }
+        if (binding.input.urlEncoded) {
+            hash h;
+            if (index(path, "?") >= 0) {
+                # any params ?
+                int i = index(path, binding.location);
+                if (i >= 0) {
+                    # strip potential prefix in URL params
+                    path = substr(path, i+binding.location.size());
+                }
+                # all parameters are in URL
+                i = index(path, "?");
+                if (i >= 0) {
+                    path = substr(path, i+1);
+                }
+                i = 0;
+                while (path[i] == "&") {
+                    i++;
+                }
+                if (i) {
+                    path = substr(path, i);
+                }
+                if (path != "") {
+                    h = mime_parse_form_urlencoded_string(path);
+                    return self.input.deserializeAllPartData(h);
+                }
+            }
+            return hash();
+        }
+        throw SOAP_DESERIALIZATION_ERROR, sprintf("BUG: cannot deserialize url: %y", binding.input);
     }
 
     private hash processNSValue(hash h) {
@@ -2510,6 +2592,38 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         }
     }
 
+    /**
+        Just serialize value and return namespace
+        @param ons is reference to string
+    */
+    any serializeRpcValue(string key, bool encoded, reference h, reference ons) {
+        any v = getValueFromHash(key, \h, True);
+        if (!exists v) {
+            if (key || args.size() == 1) {
+                v = getValueFromHash(args{key}.element, \h, True);
+            }
+            if (v.typeCode() == NT_NULL) {
+                v = NOTHING;
+            } else {
+                if (!exists v) return;
+            }
+        }
+
+        any hv;
+        #printf("DEBUG: arg %y with %y\n", key, args{key});
+        #printf("DEBUG: arg %y with %y\n", key, v."^val^" ?? v);
+        if (args{key}.element) {
+            hv = args{key}.element.serialize(v, !encoded, key, name);
+            ons = nsc.getOutputNamespacePrefix(args{key}.element.ns);
+        }
+        else {
+            hv = args{key}.type.serialize(v, !encoded);
+            ons = args{key}.type.getOutputNamespacePrefix();
+        }
+        #printf("DEBUG: arg %s got %y from %y (%y)\n", k, hv, v, exists args{key}.element ? args{key}.element : args{key}.type);
+        return hv;
+    }
+
     #! serializes data into hash with SOAP soup as namespaces etc.
     /**
      * @param if present then serializes only particular element or part, if NOTHING then serializes all message elements
@@ -2520,32 +2634,9 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         hash rh;
         #printf("DEBUG: message %s: keys: %y, h: %y\n", name , keys, h);
         foreach string k in (key ? key : keys args) {
-            any v = getValueFromHash(k, \h, True);
-            if (!exists v) {
-                if (key || args.size() == 1) {
-                    v = getValueFromHash(args{k}.element, \h, True);
-                }
-                if (v.typeCode() == NT_NULL) {
-                    v = NOTHING;
-                } else {
-                    if (!exists v) continue;
-                }
-            }
-
-            any hv;
-            #printf("DEBUG: arg %y with %y\n", k, args{k});
-            #printf("DEBUG: arg %y with %y\n", k, v."^val^" ?? v);
             string ons;
-            if (args{k}.element) {
-                hv = args{k}.element.serialize(v, !encoded, k, name);
-                ons = nsc.getOutputNamespacePrefix(args{k}.element.ns);
-            }
-            else {
-                hv = args{k}.type.serialize(v, !encoded);
-                ons = args{k}.type.getOutputNamespacePrefix();
-            }
-            #printf("DEBUG: arg %s got %y from %y (%y)\n", k, hv, v, exists args{k}.element ? args{k}.element : args{k}.type);
-
+            any hv = serializeRpcValue(k, encoded, \h, \ons);
+            if (!exists hv) continue;
             #printf("DEBUG: WSMessage::serialize() k: %y args: %y, parts: %y\n", k, keys args, msginfo.parts);
             if (msginfo.parts{k}) {
                 any ct = msginfo.parts{k};
@@ -2684,14 +2775,14 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
-    #! serialized all values as string or binary
+    #! serialize all values as string or binary
     /**
         @return hash of all parts in key-value pair
     */
-    hash serializeAllPartData(*hash val, *softbool keepBinary) {
+    hash serializeAllPartData(*hash val) {
         hash rv;
         foreach string k in (args.keyIterator()) {
-            hash v = serializeData(k, val, keepBinary);
+            hash v = serializeData(k, val);
             rv{k} = v.value;
         }
         return rv;
@@ -2701,18 +2792,41 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
     /**
         @param val value to be resolved
         @param key member name, it is requires reference to a simple type, not compaund element
-        @param keepbinary if True then value is returned as is in case of binary value in @param h
 
         @return as hash with 'value' and optional 'content-type' key passed from v.content-type if exists
      */
-    hash serializeData(string key, *hash val, *softbool keepBinary) {
+    hash serializeData(string key, *hash val) {
         if (args{key}.element) {
             throw SOAP_SERIALIZATION_ERROR, sprintf("cannot get element value %y in message %y. Type part is needed", key, name);
         }
         any v = getValueFromHash(key, \val, False);
-        hash rv.value = args{key}.type.serialize(v, False, keepBinary){"^value^"};
+        hash rv.value = args{key}.type.serialize(v, False){"^value^"};
         if (v.typeCode() == NT_HASH) {
             rv."content-type" = v."^attributes^"."^content-type^";
+        }
+        return rv;
+    }
+
+    #! deserialize value in string or binary form
+    /**
+        @return hash in key-value pair
+    */
+    hash deserializeData(string key, hash val) {
+        hash rv;
+        rv{args{key}.part ?? key} = args{key}.element
+            ? args{key}.element.deserialize(tmap, NOTHING, val{key}, val.hasKey(key))
+            : args{key}.type.deserialize(name, tmap, NOTHING, val{key});
+        return rv;
+    }
+
+    #! deserialize all values in string or binary form
+    /**
+        @return hash of all parts in key-value pair
+    */
+    hash deserializeAllPartData(hash val) {
+        *hash rv;
+        foreach string k in (args.keyIterator()) {
+            rv += deserializeData(k, val);
         }
         return rv;
     }
@@ -3074,7 +3188,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                                 op{io}.content.formUrlEncoded = True;
                                 continue;
                             }
-
                             if (!cnt.type || cnt.type == "*/*") {
                                 op{io}.content.acceptAllContentTypes = True;
                             } else {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1775,7 +1775,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         *string soapAction;  # TODO: remove   SoapHandler, SoapClient
         *string request_name;
 
-        # link to binding
+        # params per associated binding
         hash bindings;
     }
 
@@ -1815,7 +1815,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     setDocStyle(reference idocmap) {
-        # docstyle = True;  # property of in binding
+        # docstyle = True;  # property per binding
 
         foreach string key in (input.args.keyIterator()) {
             # FIXME: could be a type here instead of an element
@@ -1840,18 +1840,33 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
     /** @param name the name of the binding, if not provided then uses the first assigned binding
 
-        @return a @ref WSDL::Binding object
+        @return a binding param hash
 
         @throw WSDL-BINDING-ERROR unknown binding
      */
-    WSDL::Binding getBinding(*string bname) {
-        *Binding b = exists bname ? bindings{bname} : bindings.firstValue();
-        if (!b)
+    hash getBinding(*string bname) {
+        if (bindings && !exists bname)
+            return bindings.firstValue();
+        if (!exists bindings{bname})
             throw "WSDL-BINDING-ERROR", sprintf("binding %y is not a known binding for operation %y; known bindings: %y", bname, name, bindings.keys());
-        return b;
+        return bindings{bname};
     }
 
-    private hash serializeSoapMessage(any h, Binding binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
+    /** @param bname binding name, must be unique in operation
+        @param opparams binding getOperationParams
+
+        @throw WSDL-BINDING-ERROR when binding already registered
+     */
+
+    addBinding(string bname, hash opparams) {
+        if (bindings{bname}) {
+            throw "WSDL-BINDING-ERROR", sprintf("binding %y is already registered in operation %y", bname, name);
+        }
+        opparams.name = bname;
+        bindings{bname} = opparams;
+    }
+
+    private hash serializeSoapMessage(any h, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
         string io = request ? "input" : "output";
         # setup namespaces for SOAP envelope
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
@@ -1860,10 +1875,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (header) {
             #printf("DEBUG %s header: %y\n", io, header);
 
-            if (binding.operations{name}{io}.header.typeCode() == NT_LIST) {
+            if (binding{io}.header.typeCode() == NT_LIST) {
                 throw "WSDL-BINDING-ERROR", sprintf("multi headers not yet implemented");  # TODO
             }
-            *hash hdr = binding.operations{name}{io}.header;
+            *hash hdr = binding{io}.header;
             hash h;
             if (hdr) {
                 hash hh.(hdr.part) = header;
@@ -1875,18 +1890,18 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         }
 
         # do we have mime/multipart io format?
-        if (exists binding.operations{name}{io}.multipart)
+        if (exists binding{io}.multipart)
             mpm = new MultiPartRelatedMessage();
 
-        #printf("DEBUG: docstyle: %y\n", binding.operations{name}.docstyle);
+        #printf("DEBUG: docstyle: %y\n", binding.docstyle);
         if (self{io}) {
             *hash body;
-            if (binding.operations{name}.docstyle)
-                body = self{io}.serializeDocument(NOTHING, binding.operations{name}{io}, mpm, h);
+            if (binding.docstyle)
+                body = self{io}.serializeDocument(NOTHING, binding{io}, mpm, h);
             else {
                 string mname = input_name ? input_name : name + (request ? "":"Response");
-                if (binding.operations{name}{io})
-                    body = self{io}.serialize(binding.operations{name}{io}, mpm, mname, h);
+                if (binding{io})
+                    body = self{io}.serialize(binding{io}, mpm, mname, h);
             }
             if (body) {
                 rh{soapenvEnvelope}."soapenv:Body" = body;
@@ -1899,7 +1914,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
     #! serializes a request to an XML string for the operation
     /** @param h the request to serialize
-        @param binding SOAP binding
+        @param bname SOAP binding name or empty to get the first assigned binding
         @param header optional soap header info to serialize if required (ex: authorization info)
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh an optional namespace hash for the output message
@@ -1910,7 +1925,8 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c body: XML string in the SOAP request format
         - \c hdr: hash of HTTP headers
         */
-    hash serializeRequest(any h, Binding binding, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
+    hash serializeRequest(any h, *string bname, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
+        hash binding = getBinding(bname);
 
         if (!exists req_soapaction)
             req_soapaction = bindings{name}.soapAction;
@@ -1919,7 +1935,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         string body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
 
         if (mpm) {
-            mpm.splicePart(body, sprintf("<%s>", binding.operations{name}.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
+            mpm.splicePart(body, sprintf("<%s>", binding.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
 
             hash rv = mpm.getMsgAndHeaders();
             if (req_soapaction) {
@@ -1955,13 +1971,13 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
-        return serializeRequest(h, getBinding(), header, enc, nsh, xml_opts, req_soapaction);
+        return serializeRequest(h, NOTHING, header, enc, nsh, xml_opts, req_soapaction);
 
     }
 
     #! serializes a SOAP response to an XML string for the operation
     /** @param h the response to serialize
-        @param binding SOAP binding
+        @param bname SOAP binding name, leave empty to get the first assigned binding
         @param header SOAP header hash
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh namespace hash
@@ -1972,7 +1988,8 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c body: XML string in the SOAP request format
         - \c hdr: hash of HTTP headers
     */
-    hash serializeResponse(any h, Binding binding, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
+    hash serializeResponse(any h, *string bname, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
+        hash binding = getBinding(bname);
         if (exists soap12) {
             if (soap12) {
                 if (!nsc.hasSoap12())
@@ -1989,14 +2006,14 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         MultiPartRelatedMessage mpm;
         # do we have mime/multipart output format?
-        if (exists binding.operations{name}.output.multipart)
+        if (exists binding.output.multipart)
             mpm = new MultiPartRelatedMessage();
 
         string body = make_xml(serializeSoapMessage(h, binding, header, nsh, False, soap12, \mpm), xml_opts, enc);
 
         string ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
         if (exists mpm) {
-            mpm.splicePart(body, sprintf("<%s>", binding.operations{name}.output.body.parts), ct);
+            mpm.splicePart(body, sprintf("<%s>", binding.output.body.parts), ct);
             return mpm.getMsgAndHeaders();
         }
 
@@ -2009,7 +2026,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
-        return serializeResponse(h, getBinding(), header, enc, nsh, soap12, xml_opts);
+        return serializeResponse(h, NOTHING, header, enc, nsh, soap12, xml_opts);
     }
 
     private list processMultiRef(hash body) {
@@ -2068,14 +2085,15 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
     #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed XML request (parsed with parseXMLAsData()) for the operation
-        @param binding SOAP binding
+        @param bname SOAP binding name, leave empty to use the first assigned binding
         @return the Qore data structure corresponding to the request data
     */
-    any deserializeRequest(hash o, Binding binding) {
+    any deserializeRequest(hash o, *string bname) {
         WSDL::XsdBase::removeNS(\o);
         WSDL::XsdBase::removeNS(\o.Envelope);
 
         *hash body = o.Envelope.Body;
+        hash binding = getBinding(bname);
 
         if (!input) {
             if (exists body)
@@ -2090,7 +2108,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         #any ns = msg.".ns";
         msg -= ("ns", ".ns");
 
-        if (binding.operations{name}.docstyle)
+        if (binding.docstyle)
             return input.deserializeDocument(mrh, msg);
 
         string mname = input_name ? input_name : name;
@@ -2103,16 +2121,12 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return input.deserialize(mrh, msg);
     }
 
-    any deserializeRequest(hash o) {
-        return deserializeRequest(o, getBinding());
-    }
-
     #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed XML response (parsed with parse_xml()) for the operation
-        @param binding SOAP binding
+        @param bname SOAP binding name, leave empty to use the first assigned binding
         @return the Qore data structure corresponding to the response data
     */
-    any deserializeResponse(hash o, Binding binding) {
+    any deserializeResponse(hash o, *string bname) {
         WSDL::XsdBase::removeNS2(\o);
         WSDL::XsdBase::removeNS2(\o.Envelope);
 
@@ -2161,7 +2175,9 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             }
         }
 
-        if (binding.operations{name}.docstyle)
+        hash binding = getBinding(bname);
+
+        if (binding.docstyle)
             return output.deserializeDocument(mrh, msg);
 
         string mname = input_name ? input_name : name + "Response";
@@ -2172,10 +2188,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         msg -= (".ns", "ns");
 
         return output.deserialize(mrh, msg);
-    }
-
-    any deserializeResponse(hash o) {
-        return deserializeResponse(o, getBinding());
     }
 
     private hash processNSValue(hash h) {
@@ -2451,12 +2463,9 @@ class WSDL::XsdLateResolverHelper {
 public class WSDL::Binding inherits WSDL::XsdNamedData {
     private {
         string port;
-    }
-    public {
         bool docstyle = False;
         *string httpMethod;
         *string soapTransport;
-        hash operations = {};
     }
 
     constructor(hash data, Namespaces nsc, reference portTypes, reference idocmap, *hash messages) : XsdNamedData(\data) {
@@ -2497,9 +2506,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
             if (!exists portTypes{port}.operations{opname})
                 throw WSDL_ERROR, sprintf("binding %y references unknown porttype %y operation %y", name, port, opname);
 
-            if (exists operations{opname}) {
-                throw WSDL_ERROR, sprintf("binding %y already contains operation %y", name, opname);
-            }
             hash op;
             op.name = opname;
             WSDL::XsdBase::removeNS(\ophash);
@@ -2649,8 +2655,13 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                 }
             }
 
-            operations{opname} = op;
-            portTypes{port}.operations{opname}.bindings{name} = self;   # register itself in operation
+
+            portTypes{port}.operations{opname}.addBinding(name,
+                (
+                "httpMethod": httpMethod,
+                "soapTransport": soapTransport,
+                ) + op
+            );
         }
 
         #binding = data;
@@ -2660,7 +2671,7 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
     string getPort() {
         return port;
     }
-
+/*
     bool isSoapBinding() {
         return exists soapTransport;
     }
@@ -2668,6 +2679,7 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
     bool isHttpBinding() {
         return exists httpMethod;
     }
+    */
 }
 
 # private namespace prefix redefinition class

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -389,25 +389,50 @@ public class WSDL::WSDLLib {
     }
 
     #! takes a hash representation returned by parseMultiPartSOAPMessage and parses it to a Qore data structure, checks the content-type, and handles hrefs in the message
-    static hash parseSOAPMessage(hash msg) {
-        # check content-type
-        WSDLLib::checkContentType(msg."content-type", SoapMimeTypes);
-        hash xmldata = parse_xml(msg.body);
-        if (msg.parts) {
-            # parse entire data structure to find "href"s or href attributes
-            WSDLLib::substHref(\xmldata, msg.parts);
+    static *hash parseSOAPMessage(hash msg) {
+        if (WSDLLib::isContentType(msg."content-type", SoapMimeTypes)) {
+            hash xmldata;
+            if (msg.body) {
+                xmldata = parse_xml(msg.body);
+            }
+            if (msg.parts) {
+                # parse entire data structure to find "href"s or href attributes
+                WSDLLib::substHref(\xmldata, msg.parts);
+            }
+            if (!exists xmldata) {
+                # fake data, e.g. when URLEncoded
+                xmldata."content-type" = msg."content-type";
+                xmldata.body = NOTHING;
+            }
+            return xmldata;
+        } else {
+            string ct = msg."content-type";
+            hash h."content-type" = (ct =~ x/^([^;]+)/)[0];
+            if (ct =~ /charset=/) {
+                string c = (ct =~ x/charset=([^;]+)/)[0];
+                h.body = force_encoding(msg.body, c);
+            } else {
+                h.body = binary(msg.body);  # needed or is it already ?
+            }
+            return h;
         }
-        return xmldata;
     }
 
-    /*private in module*/ static checkContentType(string ct, list MimeTypes) {
+    /*private in module*/ static bool isContentType(string ct, list MimeTypes) {
         ct = ltrim(ct);
         foreach string sct in (MimeTypes) {
             # Content-Type := type "/" subtype *[";" parameter] ... so we can test if string is starting at index 0
             if (bindex(ct, sct) == 0)
-                return;
+                return True;
         }
-        throw "SOAP-MESSAGE-ERROR", sprintf("don't know how to handle content-type %y (expecting one of: %y)", ct, MimeTypes);
+        return False;
+    }
+
+
+    /*private in module*/ static checkContentType(string ct, list MimeTypes) {
+        if (!WSDLLib::isContentType(ct, MimeTypes)) {
+            throw "SOAP-MESSAGE-ERROR", sprintf("don't know how to handle content-type %y (expecting one of: %y)", ct, MimeTypes);
+        }
     }
 
     private static processHref(reference xmldata, string hr, hash parts) {
@@ -890,10 +915,18 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
                 return float(val);
 
             case "base64Binary":
-                return val.empty() ? binary() : parse_base64_string(val);
+                if (val.typeCode() == NT_BINARY) {
+                    return val;
+                } else {
+                    return val.empty() ? binary() : parse_base64_string(val);
+                }
 
             case "hexBinary":
-                return val.empty() ? binary() : parse_hex_string(val);
+                if (val.typeCode() == NT_BINARY) {
+                    return val;
+                } else {
+                    return val.empty() ? binary() : parse_hex_string(val);
+                }
 
             default: {
                 if (name == "anyType")  {
@@ -2014,7 +2047,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                             throw SOAP_SERIALIZATION_ERROR, sprintf("url replacement requested for operation %s with no message (%y)", name, h);
                         }
                         hash v = input.getNameValue(binding.input.urlReplacement{k}, h);
-                        path += encode_url(v.firstValue(), True);
+                        path += encode_url(string(v.firstValue()), True);
                     }
                 }
             } else if (binding.input.urlEncoded) {
@@ -2083,7 +2116,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (exists enc) {
             ct += sprintf(";charset=%s", enc);
         }
-
         rv.hdr."Content-Type" = ct;
 
         if (req_soapaction)
@@ -2211,129 +2243,161 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return (mrh, body);
     }
 
-    hash parseSOAPMessage(hash msg, *string bname, bool request) {
-        string io = request ? "input": "output";
-        hash binding = getBinding(bname);
-        if (binding.httpMethod) {
-            string ct = (msg."content-type" =~ x/^([^;]+)/)[0];
-            if (!binding{io}.acceptAllContentTypes)
-                WSDLLib::checkContentType(ct, binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
-            if (msg."content-type" =~ /charset=/) {
-                string c = (msg."content-type" =~ x/charset=([^;]+)/)[0];
-                msg.body = force_encoding(msg.body, c);
-            } else {
-                msg.body = binary(msg.body);  # needed or is it already ?
-            }
-        } else {
-            return WSDLLib::parseSOAPMessage(msg);
-        }
-    }
+    private any deserializeSoapMessage(hash o, hash binding, bool request) {
+        #printf("DEBUG: deserializeSoapMessage(%N, %y)\n", o, request);
+        string io = request ? "input" : "output";
+        WSDL::XsdBase::removeNS2(\o);
+        WSDL::XsdBase::removeNS2(\o.Envelope);
+        hash rv;
+        if (binding{io}.header) {
+            *hash header = o.Envelope.Header;
+            WSDL::XsdBase::removeNS2(\header);
 
-    #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
-    /** @param o the parsed XML request (parsed with parseXMLAsData()) for the operation
-        @param bname SOAP binding name, leave empty to use the first assigned binding
-        @return the Qore data structure corresponding to the request data
-    */
-    any deserializeRequest(hash o, *string bname) {
-        WSDL::XsdBase::removeNS(\o);
-        WSDL::XsdBase::removeNS(\o.Envelope);
+            #printf("DEBUG: Deserialize SOAP headers: %N\n", header);
+            hash hrv;
+            foreach hash hdr in (binding{io}.header) {
+                if (header.hasKey(hdr.msgpart)) {
+                    # seems it may appear part name conflict between messages when namespace is stripped
+                    hash v;
+                    if (binding.docstyle) {
+                        hrv{hdr.msg.name} += hdr.msg.deserializeDocument(NOTHING, header, hdr.msgpart, True);
+                    } else {
+                        hrv{hdr.msg.name} += hdr.msg.deserialize(NOTHING, header, hdr.msgpart, True);
+                    }
+                }
+            }
+            #printf("DEBUG: Deserialized SOAP headers: %N\n", hrv);
+            if (exists hrv) {
+                rv."^header^" = hrv;
+            }
+        }
 
         *hash body = o.Envelope.Body;
-        hash binding = getBinding(bname);
 
-        if (!input) {
+        if (!self{io}) {
             if (exists body)
-                throw SOAP_DESERIALIZATION_ERROR, sprintf("request body value given for operation %y with no input message: %y", name, body);
-            return;
+                throw SOAP_DESERIALIZATION_ERROR, sprintf("%s value given for operation %y with no %s message: %y", request ? "request" : "response", name, io, body);
+            return rv;
         }
         else if (!exists body)
-            throw SOAP_DESERIALIZATION_ERROR, sprintf("no request body value given for operation %y", name);
+            throw SOAP_DESERIALIZATION_ERROR, sprintf("no %s body value given for operation %y", request ? "request" : "response", name);
 
         (*hash mrh, hash msg) = processMultiRef(body);
+
+        if (!request) {
+            # check for Soap Fault, if so raise an exception immediately with the fault info
+            WSDL::XsdBase::removeNS2(\body);
+
+            if (body.Fault) {
+                WSDL::XsdBase::removeNS(\body.Fault);
+                delete body.Fault.".ns";
+                if (nsc.hasSoap12()) {
+                    WSDL::XsdBase::removeNS(\body.Fault.Code);
+                    WSDL::XsdBase::removeNS(\body.Fault.Reason);
+                    string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.Code.Value);
+                    any sc = body.Fault.Code.Subcode;
+                    while (exists sc) {
+                        WSDL::XsdBase::removeNS(\sc);
+                        desc += sprintf(", subcode: %y", sc.Value);
+                        sc = sc.Subcode;
+                    }
+                    foreach any rn in (body.Fault.Reason.Text) {
+                        desc += sprintf(", text: %y", rn);
+                    }
+
+                    throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
+                }
+                else {
+                    string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.faultcode);
+                    if (exists body.Fault.faultstring)
+                        desc += sprintf(", faultstring: %y", body.Fault.faultstring);
+                    if (exists body.Fault.desc)
+                        desc += sprintf(", desc: %y", body.Fault.desc);
+
+                    throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
+                }
+            }
+        }
 
         #any ns = msg.".ns";
         msg -= ("ns", ".ns");
-
-        if (binding.docstyle)
-            return input.deserializeDocument(mrh, msg);
-
-        string mname = input_name ? input_name : name;
-        if (!msg{mname})
-            throw SOAP_DESERIALIZATION_ERROR, sprintf("missing input message name %y as top-level element; got elements: %y", mname, keys msg);
-        msg = remove msg{mname};
-        XsdBase::removeNS2(\msg);
-        remove msg.".ns";
-
-        return input.deserialize(mrh, msg);
-    }
-
-    #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
-    /** @param o the parsed XML response (parsed with parse_xml()) for the operation
-        @param bname SOAP binding name, leave empty to use the first assigned binding
-        @return the Qore data structure corresponding to the response data
-    */
-    any deserializeResponse(hash o, *string bname) {
-        WSDL::XsdBase::removeNS2(\o);
-        WSDL::XsdBase::removeNS2(\o.Envelope);
-
-        *hash body = o.Envelope.Body;
-
-        if (!output) {
-            if (exists body)
-                throw SOAP_DESERIALIZATION_ERROR, sprintf("response value given for operation %y with no output message: %y", name, body);
-            return;
-        }
-        else if (!exists body)
-            throw SOAP_DESERIALIZATION_ERROR, sprintf("no response body value given for operation %y", name);
-
-        (*hash mrh, hash msg) = processMultiRef(body);
-
-        # check for Soap Fault, if so raise an exception immediately with the fault info
-        WSDL::XsdBase::removeNS2(\body);
-
-        if (body.Fault) {
-            WSDL::XsdBase::removeNS(\body.Fault);
-            delete body.Fault.".ns";
-            if (nsc.hasSoap12()) {
-                WSDL::XsdBase::removeNS(\body.Fault.Code);
-                WSDL::XsdBase::removeNS(\body.Fault.Reason);
-                string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.Code.Value);
-                any sc = body.Fault.Code.Subcode;
-                while (exists sc) {
-                    WSDL::XsdBase::removeNS(\sc);
-                    desc += sprintf(", subcode: %y", sc.Value);
-                    sc = sc.Subcode;
-                }
-                foreach any rn in (body.Fault.Reason.Text) {
-                    desc += sprintf(", text: %y", rn);
-                }
-
-                throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
-            }
-            else {
-                string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.faultcode);
-                if (exists body.Fault.faultstring)
-                    desc += sprintf(", faultstring: %y", body.Fault.faultstring);
-                if (exists body.Fault.desc)
-                    desc += sprintf(", desc: %y", body.Fault.desc);
-
-                throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
+        if (binding.docstyle) {
+            if (exists rv) {
+                return rv + self{io}.deserializeDocument(mrh, msg, NOTHING, True);
+            } else {
+                return self{io}.deserializeDocument(mrh, msg);
             }
         }
 
-        hash binding = getBinding(bname);
-
-        if (binding.docstyle)
-            return output.deserializeDocument(mrh, msg);
-
-        string mname = input_name ? input_name : name + "Response";
+        string mname = input_name ? input_name : name + (request ? "" : "Response");
         if (!msg{mname})
-            throw SOAP_DESERIALIZATION_ERROR, sprintf("missing output message name %y as top-level element; got elements: %y", mname, keys msg);
+            throw SOAP_DESERIALIZATION_ERROR, sprintf("missing %s message name %y as top-level element; got elements: %y", io, mname, keys msg);
         msg = remove msg{mname};
         XsdBase::removeNS2(\msg);
         msg -= (".ns", "ns");
 
-        return output.deserialize(mrh, msg);
+        if (exists rv) {
+            return rv + self{io}.deserialize(mrh, msg, NOTHING, True);
+        } else {
+            return self{io}.deserialize(mrh, msg);
+        }
+    }
+
+    private *hash deserializeHttpMessage(hash v, hash binding, bool request) {
+        string io = request ? "input" : "output";
+        *string ct = v."content-type";
+        if (!exists ct) {
+            throw SOAP_DESERIALIZATION_ERROR, sprintf("missing content-type in input hash: %y", v);
+        }
+        if (binding{io}.urlEncoded) {
+            throw SOAP_DESERIALIZATION_ERROR, sprintf("urlencoded message deserialization is not supported in binding: %y", binding.name);
+        }
+        if (binding{io}.content.formUrlEncoded) {
+            WSDLLib::checkContentType(ct, list(MimeTypeFormUrlEncoded));
+            v.body = binary_to_string(v.body);
+            hash h = mime_parse_form_urlencoded_string(v.body); # TODO: data have no encoding
+            return self{io}.deserialize(NOTHING, h, NOTHING, True);
+        } else if (binding{io}.content) {
+
+            if (!binding{io}.content.acceptAllContentTypes) {
+                WSDLLib::checkContentType(ct, binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
+            }
+            hash v2;
+            v2{binding{io}.content.part} = v.body;
+            hash h = self{io}.deserialize(NOTHING, v2, binding{io}.content.part, True);
+            string k = h.firstKey();
+            h{k}."^value^" = remove h{k};
+            h{k}."^attributes^"."^content-type^" = ct;
+            return h;
+        }
+    }
+
+    #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
+    /** @param o the parsed SOAP or HTTP request with @ref WSDLLib::parseSOAPMessage() for the operation
+        @param bname SOAP binding name, leave empty to use the first assigned binding
+        @return the Qore data structure corresponding to the request data
+    */
+    any deserializeRequest(hash o, *string bname) {
+        hash binding = getBinding(bname);
+        if (binding.httpMethod) {
+            return deserializeHttpMessage(o, binding, True);
+        } else {
+            return deserializeSoapMessage(o, binding, True);
+        }
+    }
+
+    #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
+    /** @param o the parsed SOAP or HTTP request with @ref WSDLLib::parseSOAPMessage() for the operation
+        @param bname SOAP binding name, leave empty to use the first assigned binding
+        @return the Qore data structure corresponding to the response data
+    */
+    any deserializeResponse(hash o, *string bname) {
+        hash binding = getBinding(bname);
+        if (binding.httpMethod) {
+            return deserializeHttpMessage(o, binding, False);
+        } else {
+            return deserializeSoapMessage(o, binding, False);
+        }
     }
 
     private hash processNSValue(hash h) {
@@ -2508,67 +2572,68 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
-    any deserialize(*hash mrh, hash val) {
-        #printf("DBG WSMessage::deserialize() args: %y pmap: %y val: %y\n", args.keys(), pmap, val);
+    any deserialize(*hash mrh, hash val, *string key, bool keepHash = False) {
+        #printf("DBG WSMessage::deserialize() args: %y pmap: %y val: %y\n", args.keys(), pmap, val); #XXX
         hash ro;
 
-        foreach string key in (args.keyIterator()) {
-            bool present = val.hasKey(key);
-            any v = remove val{key};
+        foreach string k in (exists key ? key : args.keyIterator()) {
+
+            bool present = val.hasKey(k);
+            any v = remove val{k};
             if (v.typeCode() == NT_HASH)
                 XsdBase::removeNS2(\v);
 
-            string rk = key;
-            if (pmap{key} && !args.(pmap{key}))
-                rk = pmap{key};
+            string rk = k;
+            if (pmap{k} && !args.(pmap{k}))
+                rk = pmap{k};
 
-            ro{rk} = args{key}.element
-                ? args{key}.element.deserialize(tmap, mrh, getValue(mrh, v), present)
-                : args{key}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
+            ro{rk} = args{k}.element
+                ? args{k}.element.deserialize(tmap, mrh, getValue(mrh, v), present)
+                : args{k}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
         }
 
-        if (val)
+        if (val && !exists key)
             throw SOAP_DESERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", val.keys(), name);
 
         # if there is only one argument, return it directly
-        return ro.size() == 1 ? ro.firstValue() : ro;
+        return (ro.size() == 1 && !keepHash) ? ro.firstValue() : ro;
     }
 
-    any deserializeDocument(*hash mrh, any val) {
-        any rh;
+    any deserializeDocument(*hash mrh, any val, *string key, bool keepHash = False) {
+        hash rh;
 
         *hash attr = remove val."^attributes^";
 
         #printf("DBG WSMessage::deserializeDocument() args: %y val: %y\n", args.keys(), val);
+
         if (args.size() == 1) {
-            string key = args.firstKey();
-            bool present;
-            any v;
-            if (val.typeCode() == NT_HASH && val.hasKey(key)) {
-                present = True;
-                v = remove val{key};
-            }
-            else {
-                present = exists val;
-                v = remove val;
-            }
-            XsdBase::removeNS2(\v);
-            rh = args.firstValue().element.deserialize(tmap, mrh, v, present);
-        }
-        else {
-            foreach string key in (args.keyIterator()) {
-                bool present = val.hasKey(key);
-                any v = remove val{key};
-                XsdBase::removeNS2(\v);
-                rh{key} = args{key}.element.deserialize(tmap, mrh, v, present);
+            string k = args.firstKey();
+            if (val.typeCode() != NT_HASH || !val.hasKey(k)) {
+                any v = val;
+                val = hash();
+                val{k} = v;
             }
         }
 
-        if (val)
+        foreach string k in (exists key ? key : args.keyIterator()) {
+            bool present = val.hasKey(k);
+            any v = remove val{k};
+            XsdBase::removeNS2(\v);
+
+            string rk = k;
+            if (pmap{k} && !args.(pmap{k}))
+                rk = pmap{k};
+
+            rh{rk} = args{k}.element ?
+                args{k}.element.deserialize(tmap, mrh, v, present) :
+                args{k}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
+        }
+
+        if (val && !exists key)
             throw SOAP_DESERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", val.keys(), name);
 
         #printf("DBG WSMessage::deserializeDocument() args: %y val: %y\nRH: %y\n", args.keys(), val, rh);
-        return rh;
+        return (rh.size() == 1 && !keepHash) ? rh.firstValue() : rh;
     }
 
     hash getNameValue(*string key, any h, *softbool keepBinary) {
@@ -2596,7 +2661,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         }
         return rv;
     }
-
 }
 
 # private helper class for lazy name resolution

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -304,7 +304,7 @@ public class WSDL::WSDLLib {
         return WSDLLib::getFileFromURL(wsdl, "file", http_client, http_headers, NOTHING, NOTHING, \new_def_path);
     }
 
-    #! takes a hash representation of a SOAP message and  handles multipart messages, checks the content-type, and handles hrefs in the message
+    #! takes a hash representation of a SOAP message and handles multipart messages, checks the content-type, and handles hrefs in the message
     static hash parseMultiPartSOAPMessage(hash msg) {
         if (exists msg."_qore_multipart") {
             if (msg."_qore_multipart" != "related")
@@ -400,12 +400,13 @@ public class WSDL::WSDLLib {
         return xmldata;
     }
 
-    private static checkContentType(string ct, list MimeTypes) {
+    /*private in module*/ static checkContentType(string ct, list MimeTypes) {
+        ct = ltrim(ct);
         foreach string sct in (MimeTypes) {
-            if (bindex(ct, sct) != -1)
+            # Content-Type := type "/" subtype *[";" parameter] ... so we can test if string is starting at index 0
+            if (bindex(ct, sct) == 0)
                 return;
         }
-
         throw "SOAP-MESSAGE-ERROR", sprintf("don't know how to handle content-type %y (expecting one of: %y)", ct, MimeTypes);
     }
 
@@ -2032,24 +2033,31 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             "method": binding.httpMethod ?? "POST",
         );
 
-        if (binding.input.content) {
-            ct = binding.input.content.type;
-            if (ct == MimeTypeFormUrlEncoded) {
+        if (binding.httpMethod) {
+            if (binding.input.content.formUrlEncoded) {
+                ct = MimeTypeFormUrlEncoded;
                 # TODO: throws exception when character is > 127, discussed e.g. https://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
                 rv.body = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
                 # application/x-www-form-urlencoded Content-Type does not have any parameters
                 delete enc;
-            } else {
-                if (input.args.size() > 1) {
-                    throw SOAP_SERIALIZATION_ERROR, sprintf("message %y related to input operation %y has more arguments so it's not possible assign to body", input.name, name);
+            } else if (binding.input.content) {
+                hash v = input.resolveValue(binding.input.content.part, h, True);
+                if (v."content-type") {
+                    if (!binding.input.content.acceptAllContentTypes) {
+                        WSDLLib::checkContentType(v."content-type", binding.input.content.acceptedContentTypeSubtypes + binding.input.content.acceptedContentTypes);
+                    }
+                    ct = v."content-type";
+                } else {
+                    if (binding.input.content.acceptAllContentTypes || binding.input.content.acceptedContentTypes || binding.input.content.acceptedContentTypeSubtypes.size() != 1) {
+                        throw SOAP_SERIALIZATION_ERROR, sprintf("ambiguous content type in message %y related to input operation %y", input.name, name);
+                    }
+                    ct = binding.input.content.acceptedContentTypeSubtypes[0];
                 }
-                hash v = input.getNameValue(binding.input.content.part, h, True);
-                data d = v.firstValue();
-                if (d.typeCode() == NT_BINARY) {
-                    rv.body = d;
+                if (v.value.typeCode() == NT_BINARY) {
+                    rv.body = v.value;
                     delete enc;
                 } else {
-                    rv.body = convert_encoding(d, enc);
+                    rv.body = convert_encoding(v.value, enc);
                 }
             }
         } else {
@@ -2188,6 +2196,23 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         remove body.".ns";
 
         return (mrh, body);
+    }
+
+    hash parseSOAPMessage(hash msg, *string bname) {
+        hash binding = getBinding(bname);
+        if (binding.httpMethod) {
+            string ct = (msg."content-type" =~ x/^([^;]+)/)[0];
+            if (!binding.output.content.acceptAllContentTypes)
+                WSDLLib::checkContentType(ct, binding.output.content.acceptedContentTypeSubtypes + binding.output.content.acceptedContentTypes);
+            if (msg."content-type" =~ /charset=/) {
+                string c = (msg."content-type" =~ x/charset=([^;]+)/)[0];
+                msg.body = force_encoding(msg.body, c);
+            } else {
+                msg.body = binary(msg.body);  # needed or is it already ?
+            }
+        } else {
+            return WSDLLib::parseSOAPMessage(msg);
+        }
     }
 
     #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
@@ -2535,15 +2560,25 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
     hash getNameValue(*string key, any h, *softbool keepBinary) {
         hash rv;
         foreach string k in (key ? key : args.keyIterator()) {
-            if (args{k}.element) {
-                throw SOAP_SERIALIZATION_ERROR, sprintf("cannot get element value %y in message %y. Type part is needed", k, name);
-            }
-            any v;
-            if (h.hasKey(k))
-                v = h{k};
-            else if (pmap{k} && !exists h{k})
-                v = h.(pmap{k});
-            rv{k} = args{k}.type.serialize(v, False, keepBinary){"^value^"};
+            hash v = resolveValue(k, h, keepBinary);
+            rv{k} = v.value;
+        }
+        return rv;
+    }
+
+    hash resolveValue(string key, any h, *softbool keepBinary) {
+        if (args{key}.element) {
+            throw SOAP_SERIALIZATION_ERROR, sprintf("cannot get element value %y in message %y. Type part is needed", key, name);
+        }
+        hash rv;
+        any v;
+        if (h.hasKey(key))
+            v = h{key};
+        else if (pmap{key} && !exists h{key})
+            v = h.(pmap{key});
+        rv.value = args{key}.type.serialize(v, False, keepBinary){"^value^"};
+        if (v.typeCode() == NT_HASH) {
+            rv."content-type" = v."^attributes^"."^content-type^";
         }
         return rv;
     }
@@ -2800,14 +2835,65 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                     }
 
                     if (exists ophash{io}.content) {
-                        op{io}.contents = ();
+                        op{io}.content.acceptedContentTypes = ();  # type / *
+                        op{io}.content.acceptedContentTypeSubtypes = ();  # type / subtype
+                        *string p;
                         foreach any cnt in (ophash{io}.content) {
                             WSDL::XsdBase::removeNS(\cnt);
                             cnt = remove cnt."^attributes^";
-                            if (!cnt.type) {
-                                cnt.type = "*/*";
+                            bool isFormUrlEncoded = cnt.type == MimeTypeFormUrlEncoded;
+                            if ((isFormUrlEncoded && op{io}.content.type) ||
+                                (!isFormUrlEncoded && op{io}.content.formUrlEncoded)) {
+                                throw WSDL_ERROR, sprintf("%y content type must be single in message %y", MimeTypeFormUrlEncoded, ophash{io}.content);
                             }
-                            push op{io}.contents, cnt;
+                            if (isFormUrlEncoded) {
+                                op{io}.content.formUrlEncoded = True;
+                                continue;
+                            }
+
+                            if (!cnt.type || cnt.type == "*/*") {
+                                op{io}.content.acceptAllContentTypes = True;
+                            } else {
+                                hash act;
+                                list st = cnt.type.split("/");
+                                if (st.size() != 2) {
+                                    throw WSDL_ERROR, sprintf("Content type %y does not match 'type/subtype' pattern", cnt.type);
+                                }
+                                if (bindex(st[0], "*") != -1) {
+                                    throw WSDL_ERROR, sprintf("Content type %y contains unexpected asterisk in type part", cnt.type);
+                                }
+                                act.type = st[0];
+                                if (st[1] == "*") {
+                                    push op{io}.content.acceptedContentTypes, st[0]+"/";
+                                } else {
+                                    if (bindex(st[1], "*") != -1) {
+                                        throw WSDL_ERROR, sprintf("Content type %y contains unexpected asterisk in subtype part", cnt.type);
+                                    }
+                                    push op{io}.content.acceptedContentTypeSubtypes, st[0]+"/"+st[1];
+                                }
+                            }
+
+                            if (!exists cnt.part) {
+                                cnt.part = "";
+                            }
+                            if (exists p && p != cnt.part) {
+                                throw WSDL_ERROR, sprintf("ambiguous part %y in message %y in binding %y for %s operation %y", cnt.part, portTypes{port}.operations{opname}{io}.name, name, io, opname);
+                            }
+                            p = cnt.part;
+                        }
+
+                        if (exists p) {
+                            if (p == "") {
+                                if (portTypes{port}.operations{opname}{io}.args.size() != 1) {
+                                    throw WSDL_ERROR, sprintf("multiple parts %y in message %y in binding %y for %s operation %y", keys portTypes{port}.operations{opname}{io}.args, portTypes{port}.operations{opname}{io}.name, name, io, opname);
+                                }
+                                p = portTypes{port}.operations{opname}{io}.args.firstKey();
+                            } else {
+                                if (!exists portTypes{port}.operations{opname}{io}.args{p}) {
+                                    throw WSDL_ERROR, sprintf("missing part %y in message %y in binding %y for %s operation %y", p, portTypes{port}.operations{opname}{io}.name, name, io, opname);
+                                }
+                            }
+                            op{io}.content.part = p;
                         }
                         delete ophash{io}.content;
                     }
@@ -2820,28 +2906,10 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                 }
             }
 
-            if (op.input.contents) {
-                if (op.input.contents.size() > 1) {
-                    throw WSDL_ERROR, sprintf("multiple content types in binding %y for input operation %y", name, opname);
-                }
-                op.input.content = op.input.contents[0];
-                remove op.input.contents;
-                if (op.input.content.type != MimeTypeFormUrlEncoded) {
-                    if (exists op.input.content.part) {
-                        if (!exists portTypes{port}.operations{opname}.input.args{op.input.content.part}) {
-                            throw WSDL_ERROR, sprintf("missing part %y in message %y in binding %y for input operation %y", op.input.content.part, portTypes{port}.operations{opname}.input.name, name, opname);
-                        }
-                    } else {
-                        if (portTypes{port}.operations{opname}.input.args.size() != 1) {
-                            throw WSDL_ERROR, sprintf("multiple parts %y in message %y in binding %y for input operation %y", keys portTypes{port}.operations{opname}.input.args, portTypes{port}.operations{opname}.input.name, name, opname);
-                        }
-                        op.input.content.part = portTypes{port}.operations{opname}.input.args.firstKey();
-                    }
-                }
+            if (op.output.content.formUrlEncoded) {
+                throw WSDL_ERROR, sprintf("%y type is not supported as output type in binding %y for output operation %y", MimeTypeFormUrlEncoded, name, opname);
             }
-            if (op.output.contents) {
-                throw WSDL_ERROR, sprintf("content types in binding %y for output operation %y is not yet supported", name, opname);
-            }
+
             portTypes{port}.operations{opname}.addBinding(name,
                 (
                 "httpMethod": httpMethod,

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -76,7 +76,7 @@ module WSDL {
     @subsection wsdl_0_3_6 WSDL v0.3.6
     - reimplmented operation to support multi binding, operation can be assigned to more bindings
     - support for HTTP binding and content-types, "^content-type^" attribute can identify content type to be used
-    - extended SOAP binding serialization and deserialization with "^header^" key
+    - extended SOAP binding serialization and deserialization with support to both body and header
 
     @subsection wsdl_0_3_5_1 WSDL v0.3.5.1
     - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
@@ -1943,7 +1943,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             #printf("DEBUG: %s, header: %y\n", io, header);
             hash outh;
             foreach hash hdr in (binding{io}.header) {
-                #printf("DEBUG: hdr: %y, hdr.msg.name/part: %y/%y\n", hdr, hdr.msg.name, hdr.part);
+                #printf("DEBUG: hdr: %y, hdr.msg.name/part: %y/%y, val:%y\n", hdr, hdr.msg.name, hdr.part, val);
                 if (binding.docstyle) {
                     *hash h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hdr.encoded, \header);
                     if (!h && val) {
@@ -1958,6 +1958,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                     *hash h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, hdr.encoded, \header);
                     if (!h && val) {
                         # data provided in val ?
+                        #printf("DEBUG: testing val\n");
                         h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, hdr.encoded, \val);
                     }
                     if (h) {
@@ -2334,17 +2335,21 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             }
         }
 
-        if (exists rv) {
+        if (exists hrv) {
+            foreach my string k in (keys hrv) {
+                if (exists rv{k}) {
+                    # name conflict
+                    rv{self{io}.name} = rv;
+                    break;
+                }
+            }
+            rv += hrv;
+        } else if (exists rv ) {
             # for backwards compatibility with a flat hash when there was only argument
             # but we must be care of when the argument is a type (not element)
             if (rv.size() == 1 && rv.typeCode() == NT_HASH) {
                 rv = rv.firstValue();
             }
-        }
-        if (exists hrv) {
-            if (rv.typeCode() != NT_HASH)
-                rv = ("^value^": rv);
-            rv."^header^" = hrv;
         }
 
         return rv;
@@ -2385,7 +2390,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed SOAP or HTTP request with @ref WSDLLib::parseSOAPMessage() for the operation
         @param bname SOAP binding name, leave empty to use the first assigned binding
-        @return the Qore data structure corresponding to the request data. When SOAP header is deserialized according binding/input WSDL then data are passed under "^header^" key.
+        @return the Qore data structure corresponding to the request data. When SOAP header is deserialized according binding/input WSDL then all data are passed under sub hash values prefixed by message name
         In case of HTTP binding the content type is matched against WSDL binding when wildcards are supported and current content type value is applied to "^attributes^"."^content-type^".
     */
     any deserializeRequest(hash o, *string bname) {
@@ -2400,7 +2405,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed SOAP or HTTP request with @ref WSDLLib::parseSOAPMessage() for the operation
         @param bname SOAP binding name, leave empty to use the first assigned binding
-        @return the Qore data structure corresponding to the response data. When SOAP header is deserialized according binding/output WSDL then data are passed under "^header^" key.
+        @return the Qore data structure corresponding to the response data. When SOAP header is deserialized according binding/output WSDL then all data are passed under sub hash values prefixed by message name
         In case of HTTP binding the content type is matched against WSDL binding when wildcards are supported and current content type value is applied to "^attributes^"."^content-type^".
     */
     any deserializeResponse(hash o, *string bname) {
@@ -2550,15 +2555,17 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             rh{en} = hv;
         }
 
-        if (encoded && rh)
-            rh."^attributes^" += (
-                "soapenv:encodingStyle": SOAP_ENCODING,
-                "xmlns:soapenc": SOAP_ENCODING,
-            );
+        if (rh) {
+            if (encoded)
+                rh."^attributes^" += (
+                    "soapenv:encodingStyle": SOAP_ENCODING,
+                    "xmlns:soapenc": SOAP_ENCODING,
+                );
 
-        hash rvh.("ns1:" + n_name) = rh;
+            hash rvh.("ns1:" + n_name) = rh;
 
-        return rvh;
+            return rvh;
+        }
     }
 
     *hash serializeDocument(*softlist key, any msginfo, any mpm, bool encoded, reference h) {
@@ -2755,7 +2762,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
 
     #! when only one arg then try get values based on element keys
     /* private in module*/any getValueFromHash(*WSDL::XsdElement element, reference v, bool removeFound) {
-#printf("getValueFromHash(%N, %y)\n\n", element, v);
         if (!element) return;
         if (element.type instanceof WSDL::XsdComplexType) {
             hash rv;

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -75,6 +75,8 @@ module WSDL {
 
     @subsection wsdl_0_3_6 WSDL v0.3.6
     - reimplmented operation to support multi binding, operation can be assigned to more bindings
+    - support for HTTP binding and content-types, "^content-type^" attribute can identify content type to be used
+    - extended SOAP binding serialization and deserialization with "^header^" key
 
     @subsection wsdl_0_3_5_1 WSDL v0.3.5.1
     - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
@@ -2032,7 +2034,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         }
     }
 
-    #! serializes path part of URL.
+    #! serializes path part of URL when urlEncoded WSDL is defined
     *string serializePath(any h, hash binding) {
         string path;
         if (binding.location) {
@@ -2061,19 +2063,20 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return path;
     }
 
-    #! serializes a request to an XML string for the operation
+    #! serializes a request to an XML string or HTTP payload for the operation.
     /** @param h the request to serialize
         @param bname SOAP binding name or empty to get the first assigned binding
-        @param header optional soap header info to serialize if required (ex: authorization info)
+        @param header optional soap header info to serialize if required (ex: authorization info). In the first step headers are matched to binding/input/header WSDL definition, remaining headers are passed as-is
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh an optional namespace hash for the output message
         @param xml_opts optional XML generation options
         @param req_soapaction if present will override any SOAPAction value for the request
 
         @return a hash with keys:
-        - \c body: XML string in the SOAP request format or body part of HTTP message (string or binary)
+        - \c body: XML string in the SOAP request format or body part of HTTP message (string or binary). Target content type is evaluated from WSDL or in case of ambiguity
+        using "^attributes^"."^content-type^". Provided content type must match allowed types in WSDL. Also "application/x-www-form-urlencoded" or any general type are supported.
         - \c hdr: hash of HTTP headers
-        - \c path: the path part of URL
+        - \c path: the path part of URL. Used when urlEncoded is defined
         - \c method: the HTTP request method
         */
     hash serializeRequest(any h, *string bname, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
@@ -2131,14 +2134,15 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     #! serializes a SOAP response to an XML string for the operation
     /** @param h the response to serialize
         @param bname SOAP binding name, leave empty to get the first assigned binding
-        @param header SOAP header hash
+        @param header SOAP header hash. In the first step headers are matched to binding/input/header WSDL definition, remaining headers are passed as-is
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh namespace hash
         @param soap12 set to True if the response should use SOAP 1.2 encoding
         @param xml_opts optional XML generation options
 
         @return a hash with keys:
-        - \c body: XML string in the SOAP request format
+        - \c body: XML string in the SOAP request format or body part of HTTP message (string or binary). Target content type is evaluated from WSDL or in case of ambiguity
+        using "^attributes^"."^content-type^". Provided content type must match allowed types in WSDL.
         - \c hdr: hash of HTTP headers
     */
     hash serializeResponse(any h, *string bname, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
@@ -2375,7 +2379,8 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed SOAP or HTTP request with @ref WSDLLib::parseSOAPMessage() for the operation
         @param bname SOAP binding name, leave empty to use the first assigned binding
-        @return the Qore data structure corresponding to the request data
+        @return the Qore data structure corresponding to the request data. When SOAP header is deserialized according binding/input WSDL then data are passed under "^header^" key.
+        In case of HTTP binding the content type is matched against WSDL binding when wildcards are supported and current content type value is applied to "^attributes^"."^content-type^".
     */
     any deserializeRequest(hash o, *string bname) {
         hash binding = getBinding(bname);
@@ -2389,7 +2394,8 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed SOAP or HTTP request with @ref WSDLLib::parseSOAPMessage() for the operation
         @param bname SOAP binding name, leave empty to use the first assigned binding
-        @return the Qore data structure corresponding to the response data
+        @return the Qore data structure corresponding to the response data. When SOAP header is deserialized according binding/output WSDL then data are passed under "^header^" key.
+        In case of HTTP binding the content type is matched against WSDL binding when wildcards are supported and current content type value is applied to "^attributes^"."^content-type^".
     */
     any deserializeResponse(hash o, *string bname) {
         hash binding = getBinding(bname);

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1905,21 +1905,26 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                 if (hh) {
                     hash hh2.(hdr.msgpart) = hh;
                     #printf("DEBUG: serialize(%y,%y)\n", hdr.msgpart, hh2);
-                    # outh += hdr.msg.serializeDocument(hdr.msgpart, NOTHING, NOTHING, hh2); # does not work at least for non-elements
-                    hash h = hdr.msg.serialize(hdr.msgpart, NOTHING, NOTHING, hdr.msgpart, hh2); # TODO: it does no add types
-                    #printf("DEBUG: result: %y\n", h);
-                    # tricky part, flatten hash, TODO: make it more transparently
-                    string fk = h.firstKey();
-                    h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
-                    #printf("DEBUG: flatten result: %y\n", h);
-                    if (exists outh{fk}) {
-                        # it could in theory happoen when two message parts are equal
-                        if (outh{fk}.typeCode() != NT_LIST) {
-                            outh{fk} = () + outh{fk};
-                        }
-                        outh{fk} += h{fk};
-                    } else {
+                    if (binding.docstyle) {
+                        hash h = hdr.msg.serializeDocument(hdr.msgpart, NOTHING, NOTHING, hh2); # does not work at least for non-elements
+                        remove h."^attributes^".("soapenv:encodingStyle", "xmlns:soapenc");
                         outh += h;
+                    } else {
+                        hash h = hdr.msg.serialize(hdr.msgpart, NOTHING, NOTHING, hdr.msgpart, hh2); # TODO: it does no add types
+                        #printf("DEBUG: result: %y\n", h);
+                        # tricky part, flatten hash, TODO: make it more transparently
+                        string fk = h.firstKey();
+                        h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
+                        #printf("DEBUG: flatten result: %y\n", h);
+                        if (exists outh{fk}) {
+                            # it could in theory happoen when two message parts are equal
+                            if (outh{fk}.typeCode() != NT_LIST) {
+                                outh{fk} = () + outh{fk};
+                            }
+                            outh{fk} += h{fk};
+                        } else {
+                            outh += h;
+                        }
                     }
                 }
             }
@@ -1973,7 +1978,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                     }
                 }
             } else if (binding.input.urlEncoded) {
-                string s = input.serializeAsUrlEncodedString(h);
+                string s = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
                 if (s) {
                     path += binding.location =~ /\?/ ? "&" : "?";
                     path += s;
@@ -2018,7 +2023,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (binding.input.content) {
             ct = binding.input.content.type;
             if (ct == MimeTypeFormUrlEncoded) {
-                body = input.serializeAsUrlEncodedString(h);
+                body = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
             } else {
                 if (input.args.size() > 1) {
                     throw SOAP_SERIALIZATION_ERROR, sprintf("messege %y related to input operation %y has more arguments so it's not possible assign to body", input.name, name);
@@ -2067,7 +2072,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
     hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
         return serializeRequest(h, NOTHING, header, enc, nsh, xml_opts, req_soapaction);
-
     }
 
     #! serializes a SOAP response to an XML string for the operation
@@ -2415,39 +2419,42 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rvh;
     }
 
-    hash serializeDocument(*string k, any msginfo, any mpm, any h) {
+    hash serializeDocument(*string key, any msginfo, any mpm, any h) {
         hash rh;
+
+        if (!key && args.size() == 1) {
+            string key = args.firstKey();
+            if (h.typeCode() != NT_HASH || !h.hasKey(key)) {
+                hash nh;
+                nh{key} = h;
+                h = nh;
+            }
+        }
+        foreach string k in (key ? key : args.keyIterator()) {
+            any val = remove h{k};
+            if (val.typeCode() == NT_HASH)
+                XsdBase::removeNS2(\val);
+            string ons;
+            any th;
+            if (args{k}.element) {
+                th = args{k}.element.serialize(val, !encoded, k, name);
+                ons = nsc.getOutputNamespacePrefix(args{k}.element.ns);
+                rh.(ons + ":" + args{k}.element.name) = th;
+            } else {
+                th = args{k}.type.serialize(val, !encoded);
+                #ons = args{k}.type.getOutputNamespacePrefix();
+                rh.("ns1:" + args{k}.name) = th;
+            }
+        }
+
+        if (h.typeCode() == NT_HASH && h)
+            throw SOAP_SERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", h.keys(), name);
 
         if (encoded)
             rh."^attributes^" += (
                 "soapenv:encodingStyle": SOAP_ENCODING,
                 "xmlns:soapenc": SOAP_ENCODING,
             );
-
-        if (!k && args.size() == 1) {
-            string key = args.firstKey();
-            any v = (h.typeCode() == NT_HASH && h.hasKey(key)) ? remove h{key} : remove h;
-            XsdBase::removeNS2(\v);
-            string ons;
-            any th = args{key}.element.serialize(v, !encoded, key, name);
-            ons = nsc.getOutputNamespacePrefix(args{key}.element.ns);
-            rh.(ons + ":" + args{key}.element.name) = th;
-        }
-        else {
-            foreach string key in (k ? k : args.keyIterator()) {
-                any val = remove h{key};
-                if (val.typeCode() == NT_HASH)
-                    XsdBase::removeNS2(\val);
-
-                string ons;
-                any th = args{key}.element.serialize(val, !encoded, key, name);
-                ons = nsc.getOutputNamespacePrefix(args{key}.element.ns);
-                rh.(ons + ":" + args{key}.element.name) = th;
-            }
-        }
-
-        if (h.typeCode() == NT_HASH && h)
-            throw SOAP_SERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", h.keys(), name);
 
         #printf("DEBUG: message %s: force_ns: %y args: %y h: %y\n", name, force_ns, keys args, h);
 
@@ -2533,14 +2540,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rv;
     }
 
-    string serializeAsUrlEncodedString(any h) {
-        hash nv = getNameValue(NOTHING, h);
-        list l;
-        foreach string k in (keys nv) {
-            push l, encode_url(k, True) + "=" + encode_url(nv{k}, True);
-        }
-        return l.join("&");
-    }
 }
 
 # private helper class for lazy name resolution
@@ -2733,12 +2732,17 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                             if (!exists msg)
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
 
-                            ma.msg = msg;
+                            bool enc  = ma.use == "encoded";
+                            if (enc != msg.encoded) {
+                                ma.msg = msg.copy();
+                                ma.msg.encoded = enc;
+                            } else {
+                                ma.msg = msg;
+                            }
                             hash pmap2;
                             map pmap2{$1.value}=$1.key, msg.pmap.pairIterator();
                             ma.msgpart = pmap2{ma.part} ?? ma.part;
                             #printf("DEBUG: match part to message: part: %y, msg.pmap: %y->%y, ma.msgpart: %y\n", ma.part, msg.pmap, pmap2, ma.msgpart);
-                            ma.encoded = ma.use == "encoded";   # TODO: move to WSOperation ???
                             if (op{io}.header) {
                                 if (op{io}.header.typeCode() != NT_LIST) {
                                     op{io}.header = () + op{io}.header;

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1873,20 +1873,62 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         string soapenvEnvelope = rh.firstKey();
         rh{soapenvEnvelope}."^attributes^" += nsc.getOutputNamespaceHash(nsh);
         if (header) {
-            #printf("DEBUG %s header: %y\n", io, header);
-
-            if (binding{io}.header.typeCode() == NT_LIST) {
-                throw "WSDL-BINDING-ERROR", sprintf("multi headers not yet implemented");  # TODO
+            #printf("DEBUG: %s, header: %y\n", io, header);
+            hash outh;
+            *hash header2 = header;  # non processed values will be added to soap header
+            foreach hash hdr in (binding{io}.header) {
+                /*printf("DEBUG: hdr.message/part/msgpart: %y/%y/%y, exists: %y,%y,%y,%y, %y\n", hdr.message, hdr.part, hdr.msgpart,
+                       exists header{hdr.message}, exists header{hdr.message}{hdr.part},
+                       exists header{hdr.message}{hdr.msgpart}, exists header{hdr.part}, exists header{hdr.msgpart}
+                );*/
+                # there is not unique part name space as it may contain parts from more message so let's do a little heuristic
+                any hh;
+                if (exists header{hdr.message} && exists header{hdr.message}{hdr.part}) {
+                    hh = header{hdr.message}{hdr.part};
+                    remove header2{hdr.message}{hdr.part};
+                    if (!header2{hdr.message}) {
+                        remove header2{hdr.message};
+                    }
+                } else if (exists header{hdr.message} && exists header{hdr.message}{hdr.msgpart}) {
+                    hh = header{hdr.message}{hdr.msgpart};
+                    remove header2{hdr.message}{hdr.msgpart};
+                    if (!header2{hdr.message}) {
+                        remove header2{hdr.message};
+                    }
+                } else if (exists header{hdr.part}) {
+                    hh = header{hdr.part};
+                    remove header2{hdr.part};
+                } else if (exists header{hdr.msgpart}) {
+                    hh = header{hdr.msgpart};
+                    remove header2{hdr.msgpart};
+                }
+                if (hh) {
+                    hash hh2.(hdr.msgpart) = hh;
+                    #printf("DEBUG: serialize(%y,%y)\n", hdr.msgpart, hh2);
+                    # outh += hdr.msg.serializeDocument(hdr.msgpart, NOTHING, NOTHING, hh2); # does not work at least for non-elements
+                    hash h = hdr.msg.serialize(hdr.msgpart, NOTHING, NOTHING, hdr.msgpart, hh2); # TODO: it does no add types
+                    #printf("DEBUG: result: %y\n", h);
+                    # tricky part, flatten hash, TODO: make it more transparently
+                    string fk = h.firstKey();
+                    h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
+                    #printf("DEBUG: flatten result: %y\n", h);
+                    if (exists outh{fk}) {
+                        # it could in theory happoen when two message parts are equal
+                        if (outh{fk}.typeCode() != NT_LIST) {
+                            outh{fk} = () + outh{fk};
+                        }
+                        outh{fk} += h{fk};
+                    } else {
+                        outh += h;
+                    }
+                }
             }
-            *hash hdr = binding{io}.header;
-            hash h;
-            if (hdr) {
-                hash hh.(hdr.part) = header;
-                h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hh);
-            } else {
-                h = header;
+            if (header2) {
+                # append unprocessed values
+                outh += header2;
             }
-            rh{soapenvEnvelope}."soapenv:Header" = h;
+            #printf("DEBUG: outh: %y\n", outh);
+            rh{soapenvEnvelope}."soapenv:Header" = outh;
         }
 
         # do we have mime/multipart io format?
@@ -1901,7 +1943,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             else {
                 string mname = input_name ? input_name : name + (request ? "":"Response");
                 if (binding{io})
-                    body = self{io}.serialize(binding{io}, mpm, mname, h);
+                    body = self{io}.serialize(NOTHING, binding{io}, mpm, mname, h);
             }
             if (body) {
                 rh{soapenvEnvelope}."soapenv:Body" = body;
@@ -2259,11 +2301,11 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         }
     }
 
-    hash serialize(any msginfo, any mpm, string n_name, any h) {
+    hash serialize(*string key, any msginfo, any mpm, string n_name, any h) {
         hash rh;
         #printf("DEBUG: message %s: h: %y\n", name ,h);
 
-        foreach string k in (args.keyIterator()) {
+        foreach string k in (key ? key : args.keyIterator()) {
             any v;
             if (h.hasKey(k))
                 v = remove h{k};
@@ -2345,6 +2387,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
                     XsdBase::removeNS2(\val);
 
                 string ons;
+printf("args{key}: %N\n", args{key});
                 any th = args{key}.element.serialize(val, !encoded, key, name);
                 ons = nsc.getOutputNamespacePrefix(args{key}.element.ns);
                 rh.(ons + ":" + args{key}.element.name) = th;
@@ -2546,6 +2589,10 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
                         delete ophash{io}.body;
                     }
+
+                    if (ophash{io}.("body", "content", "part") && !exists portTypes{port}.operations{opname}{io})
+                        throw WSDL_ERROR, sprintf("cannot assign %s message definition in binding %y for operation %y with no %s: %y", io, name, opname, io, ophash);
+
                     if (exists ophash{io}.multipartRelated) {
                         if (exists op{io}.body)
                             throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies both body and multipart elements", io, name, opname);
@@ -2594,12 +2641,10 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                         delete ophash{io}.multipartRelated;
                     }
 
-                    if (ophash{io} && !exists portTypes{port}.operations{opname}{io})
-                        throw WSDL_ERROR, sprintf("cannot assign %s message definition in binding %y for operation %y with no %io: %y", io, name, opname, io, ophash);
 
                     if (exists ophash{io}.header) {
                         foreach hash hdr in (ophash{io}.header) {
-                            *hash ma = ophash{io}.header."^attributes^";
+                            *hash ma = hdr."^attributes^";
 
                             if (!ma.message)
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'message' attribute (attr: %y)", io, name, opname, ma);
@@ -2612,6 +2657,11 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                             if (!exists msg)
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
 
+                            ma.msg = msg;
+                            hash pmap2;
+                            map pmap2{$1.value}=$1.key, msg.pmap.pairIterator();
+                            ma.msgpart = pmap2{ma.part} ?? ma.part;
+                            #printf("DEBUG: match part to message: part: %y, msg.pmap: %y->%y, ma.msgpart: %y\n", ma.part, msg.pmap, pmap2, ma.msgpart);
                             ma.encoded = ma.use == "encoded";   # TODO: move to WSOperation ???
                             if (op{io}.header) {
                                 if (op{io}.header.typeCode() != NT_LIST) {
@@ -2654,7 +2704,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                     }
                 }
             }
-
 
             portTypes{port}.operations{opname}.addBinding(name,
                 (

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -600,7 +600,7 @@ public class WSDL::XsdAbstractType inherits WSDL::XsdNamedData {
         return ons;
     }
 
-    abstract any serialize(any val, *softbool omit_type);
+    abstract any serialize(any val, *softbool omitType, *softbool keepBinary);
     abstract any deserialize(string en, *TypeMap tmap, *hash mrh, any val);
 }
 
@@ -612,19 +612,7 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
     constructor(string t, Namespaces nsc, string ns = "xsd") : XsdAbstractType(t, ns, nsc) {
     }
 
-    any serialize(any val, *softbool omit_type) {
-        *string type;
-        # set type according to Qore type if xsd type is anyType
-        if (name == "anyType") {
-            # we have to specify the type in this case
-            omit_type = False;
-            type = any_type_map{val.type()};
-            if (!type)
-                throw SOAP_SERIALIZATION_ERROR, sprintf("cannot serialize xsd type anyType from Qore type %y", val.type());
-        }
-        else {
-            type = name;
-        }
+    any serialize(any val, *softbool omitType, *softbool keepBinary) {
         *hash comments;
         if (val.typeCode() == NT_HASH) {
             foreach string k in (val.keyIterator()) {
@@ -633,6 +621,18 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
                 }
             }
             val = val."^value^";
+        }
+        *string type;
+        # set type according to Qore type if xsd type is anyType
+        if (name == "anyType") {
+            # we have to specify the type in this case
+            omitType = False;
+            type = any_type_map{val.type()};
+            if (!type)
+                throw SOAP_SERIALIZATION_ERROR, sprintf("cannot serialize xsd type anyType from Qore type %y", val.type());
+        }
+        else {
+            type = name;
         }
         switch (type) {
             case "byte": {
@@ -731,16 +731,24 @@ public class WSDL::XsdBaseType inherits WSDL::XsdAbstractType {
                 break;
 
             case "base64Binary":
-                val = make_base64_string(val);
+                if (keepBinary) {
+                    val = binary(val);
+                } else {
+                    val = make_base64_string(val);
+                }
                 break;
 
             case "hexBinary":
-                val = make_hex_string(val);
+                if (keepBinary) {
+                    val = binary(val);
+                } else {
+                    val = make_hex_string(val);
+                }
                 break;
         }
 
         #printf("DEBUG: FORCE: type: %y, nstype: %y, val: %y\n", type, nstype, val);
-        if (omit_type)
+        if (omitType)
             if (comments) {
                 return comments + (
                     "^value^": val
@@ -905,7 +913,7 @@ public class WSDL::XsdArrayType inherits WSDL::XsdAbstractType {
             throw "XSD-ARRAYTYPE-ERROR", sprintf("don't know how to handle arrays of type %y", t);
     }
 
-    any serialize(any val, *softbool omit_type) {
+    any serialize(any val, *softbool omitType, *softbool keepBinary) {
         switch (name) {
             case "binary": {
                 int t = val.typeCode();
@@ -1064,21 +1072,21 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
     }
     */
 
-    any serialize(any h, *softbool omit_type, string key, string typename) {
+    any serialize(any h, *softbool omitType, string key, string typename) {
         if (type.typeCode() == NT_HASH)
             printf("ERROR: %y\n", self);
 
         if (h."^type^" && h."^type^" instanceof XsdAbstractType && h.hasKey("^val^")) {
             XsdAbstractType ntype = cast<XsdAbstractType>(h."^type^");
             ntype.checkExtends(type, name);
-            return serializeAsIntern(ntype, h."^val^", omit_type, key, name);
+            return serializeAsIntern(ntype, h."^val^", omitType, key, name);
         }
 
-        return serializeAsIntern(type, h, omit_type, key, typename);
+        return serializeAsIntern(type, h, omitType, key, typename);
     }
 
-    private any serializeAsIntern(XsdAbstractType type, any h, *softbool omit_type, string key, string typename) {
-        #printf("DEBUG: XsdElement::serializeAsIntern() name: %y (with type: %y) h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, ((!omit_type || type != self.type) && type.hasRealName()), h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);
+    private any serializeAsIntern(XsdAbstractType type, any h, *softbool omitType, string key, string typename) {
+        #printf("DEBUG: XsdElement::serializeAsIntern() name: %y (with type: %y) h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, ((!omitType || type != self.type) && type.hasRealName()), h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);
 
         int tc = h.typeCode();
         if (tc == NT_LIST && h.size() == 1)
@@ -1090,7 +1098,7 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
 
             if (nillable || type.isNillable()) {
                 hash rh = ("xsi:nil": "true");
-                if ((!omit_type || type != self.type) && type.hasRealName())
+                if ((!omitType || type != self.type) && type.hasRealName())
                     rh += ("xsi:type": type.getNameWithNS());
                 return ("^attributes^": rh);
             }
@@ -1105,7 +1113,7 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
         }
 
         *hash pf;
-        if ((!omit_type || type != self.type) && type.hasRealName())
+        if ((!omitType || type != self.type) && type.hasRealName())
             pf = ("^attributes^": ("xsi:type": !usedocns ? type.getName() : type.getNameWithNS()));
 
         if (tc == NT_LIST) {
@@ -1119,15 +1127,15 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
 
             list l = ();
             foreach any e in (h) {
-                l += (pf + type.serialize(e, omit_type));
+                l += (pf + type.serialize(e, omitType));
             }
             return l;
         }
         if (minOccurs > 1)
             throw SOAP_SERIALIZATION_ERROR, sprintf("only one element passed to element %y of type %y, but minOccurs = %d", name, type.getName(), minOccurs);
 
-        #printf("DEBUG: element %y type %s: %y omit_type: %y h: %y\n", name, type.className(), type.name, omit_type, h);
-        return (pf + type.serialize(h, omit_type));
+        #printf("DEBUG: element %y type %s: %y omitType: %y h: %y\n", name, type.className(), type.name, omitType, h);
+        return (pf + type.serialize(h, omitType));
     }
 
     any deserialize(*TypeMap tmap, *hash mrh, any val, bool present) {
@@ -1201,7 +1209,7 @@ public class WSDL::XsdSimpleType inherits WSDL::XsdAbstractType {
         #printf("DEBUG: st: %y\n", self); exit();
     }
 
-    any serialize(any val, *softbool omit_type) {
+    any serialize(any val, *softbool omitType, *softbool keepBinary) {
         *hash rh;
         if (val.typeCode() == NT_HASH) {
             foreach string k in (val.keyIterator()) {
@@ -1215,7 +1223,7 @@ public class WSDL::XsdSimpleType inherits WSDL::XsdAbstractType {
         if (enum && !enum{val})
             throw "SOAP-SERIALIZATION-ERROR", sprintf("value %y passed to simpleType %y is not in the enumeration list (%y)", val, name, enum.keys());
 
-        return rh + type.serialize(val, omit_type);
+        return rh + type.serialize(val, omitType);
     }
 
     any deserialize(string en, *TypeMap tmap, *hash mrh, any val) {
@@ -1499,11 +1507,11 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         return h;
     }
 
-    private *hash serializeElement(string key, XsdElement element, any h, *softbool omit_type) {
+    private *hash serializeElement(string key, XsdElement element, any h, *softbool omitType) {
         any v = h{key};
         string e_ons;
         #printf("DEBUG: XsdComplexType::serializeElement() key: %y v: %y h: %y ns: %y\n", key, v, h, nsc.getTargetNamespaceUri());
-        any e = element.serialize(v, omit_type, key, name);
+        any e = element.serialize(v, omitType, key, name);
 
         if (!exists e && !element.isRequired())
             return;
@@ -1520,9 +1528,9 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         return rv;
     }
 
-    *hash serialize(any h, *softbool omit_type) {
+    *hash serialize(any h, *softbool omitType, *softbool keepBinary) {
         if (exists array)
-            return array.serialize(h, omit_type);
+            return array.serialize(h, omitType);
 
         # process attributes first
         *hash ah;
@@ -1554,7 +1562,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         if (cx_type == XET_SIMPLE) {
             if (exists h."^value^")
                 h = h."^value^";
-            rh."^value^" = simpleType.serialize(h, omit_type);
+            rh."^value^" = simpleType.serialize(h, omitType);
         }
         else if (cx_type != XET_NONE) {
             if (exists h && h.typeCode() != NT_HASH)
@@ -1563,7 +1571,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
             if (cx_type == XET_SEQUENCE || cx_type == XET_ALL) {
                 foreach string p in (elementmap.keyIterator()) {
                     #printf("DEBUG element: %y (%y)\nvalue: %y\n", p, elementmap{p}, h{p});
-                    rh += serializeElement(p, elementmap{p}, h, omit_type);
+                    rh += serializeElement(p, elementmap{p}, h, omitType);
                     delete h{p};
                 }
 
@@ -1585,12 +1593,12 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
                     }
                     else {
                         if (vh) {
-                            rh += serializeChoice(ch.elementmap, vh, omit_type, False);
+                            rh += serializeChoice(ch.elementmap, vh, omitType, False);
                             # remove the serialized key from the input hash for the check below
                             map remove h{$1}, keys vh;
                         }
                         if (vhch) {
-                            rh += serializeChoice(ch.elementmap, vhch, omit_type, True);
+                            rh += serializeChoice(ch.elementmap, vhch, omitType, True);
                             map remove hch{$1}, keys vhch;
                         }
                     }
@@ -1605,7 +1613,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
                 }
             }
             else { # "choice" - union
-                rh = serializeChoice(elementmap, h, omit_type, False);
+                rh = serializeChoice(elementmap, h, omitType, False);
             }
         }
         else { # "none"
@@ -1613,7 +1621,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         }
 
         #printf("DEBUG name: %y desc: %y\n", name, descriptive_name);
-        if (name && !omit_type && !descriptive_name)
+        if (name && !omitType && !descriptive_name)
             rh."^attributes^" += ("xsi:type": "ns1:" + name) + ah;
         else if (ah)
             rh."^attributes^" += ah;
@@ -1621,7 +1629,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
         return rh;
     }
 
-    private hash serializeChoice(hash emap, hash h, *softbool omit_type, bool all_members) {
+    private hash serializeChoice(hash emap, hash h, *softbool omitType, bool all_members) {
         # normally there is only one choice but we also need output example message where all options are enumerated
         if (!all_members && elements h > 1)
             throw SOAP_SERIALIZATION_ERROR, sprintf("cannot serialize choice / union in complexType %y with more than 1 member (%y)", getName(), h.keys());
@@ -1631,7 +1639,7 @@ public class WSDL::XsdComplexType inherits WSDL::XsdAbstractType {
                 throw SOAP_SERIALIZATION_ERROR, sprintf("%y is an invalid member of choice / union in complexType %y; expecting one of: %y", key, getName(), emap.keys());
 
             # add namespace if necessary
-            rh += serializeElement(key, emap{key}, h, omit_type);
+            rh += serializeElement(key, emap{key}, h, omitType);
         }
         # add namespace if necessary
         return rh;
@@ -1998,7 +2006,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         @param req_soapaction if present will override any SOAPAction value for the request
 
         @return a hash with keys:
-        - \c body: XML string in the SOAP request format
+        - \c body: XML string in the SOAP request format or body part of HTTP message (string or binary)
         - \c hdr: hash of HTTP headers
         - \c path: the path part of URL
         - \c method: the HTTP request method
@@ -2019,37 +2027,42 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         enc = enc ?? get_default_encoding();
 
-        string body;
+        hash rv = (
+            "path": serializePath(h, binding),
+            "method": binding.httpMethod ?? "POST",
+        );
+
         if (binding.input.content) {
             ct = binding.input.content.type;
             if (ct == MimeTypeFormUrlEncoded) {
-                body = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
+                # TODO: throws exception when character is > 127, discussed e.g. https://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
+                rv.body = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
+                # application/x-www-form-urlencoded Content-Type does not have any parameters
+                delete enc;
             } else {
                 if (input.args.size() > 1) {
-                    throw SOAP_SERIALIZATION_ERROR, sprintf("messege %y related to input operation %y has more arguments so it's not possible assign to body", input.name, name);
+                    throw SOAP_SERIALIZATION_ERROR, sprintf("message %y related to input operation %y has more arguments so it's not possible assign to body", input.name, name);
                 }
-                if (ct !~ /^text\//) {
-                    delete ct;
+                hash v = input.getNameValue(binding.input.content.part, h, True);
+                data d = v.firstValue();
+                if (d.typeCode() == NT_BINARY) {
+                    rv.body = d;
+                    delete enc;
+                } else {
+                    rv.body = convert_encoding(d, enc);
                 }
-                # TODO: we need return raw value in case of binary
-                hash v = input.getNameValue(binding.input.content.part, h);
-                body = v.firstValue();
             }
         } else {
             MultiPartRelatedMessage mpm;
-            body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
+            rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
             if (mpm) {
-                mpm.splicePart(body, sprintf("<%s>", binding.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
+                mpm.splicePart(rv.body, sprintf("<%s>", binding.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
 
                 hash rv = mpm.getMsgAndHeaders();
                 if (req_soapaction) {
                     if (nsc.hasSoap12())
-                        rv.hdr."Content-Type" += sprintf(";action: %s", req_soapaction);
-                    rv.hdr += ("SOAPAction": req_soapaction);
+                        ct += sprintf(";action: %s", req_soapaction);
                 }
-
-                rv.hdr."Content-Type" += sprintf(";charset=%s", enc);
-                return rv;
             }
         }
 
@@ -2057,12 +2070,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             ct += sprintf(";charset=%s", enc);
         }
 
-        hash rv = (
-            "hdr": ("Content-Type": ct),
-            "body": body,
-            "path": serializePath(h, binding),
-            "method": binding.httpMethod ?? "POST",
-        );
+        rv.hdr."Content-Type" = ct;
 
         if (req_soapaction)
             rv.hdr += ("SOAPAction": req_soapaction);
@@ -2524,7 +2532,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
-    hash getNameValue(*string key, any h) {
+    hash getNameValue(*string key, any h, *softbool keepBinary) {
         hash rv;
         foreach string k in (key ? key : args.keyIterator()) {
             if (args{k}.element) {
@@ -2535,7 +2543,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
                 v = h{k};
             else if (pmap{k} && !exists h{k})
                 v = h.(pmap{k});
-            rv{k} = args{k}.type.serialize(v, True);
+            rv{k} = args{k}.type.serialize(v, False, keepBinary){"^value^"};
         }
         return rv;
     }

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1121,7 +1121,7 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
     }
 
     private any serializeAsIntern(XsdAbstractType type, any h, *softbool omitType, string key, string typename) {
-        #printf("DEBUG: XsdElement::serializeAsIntern() name: %y (with type: %y) h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, ((!omitType || type != self.type) && type.hasRealName()), h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);
+        printf("DEBUG: XsdElement::serializeAsIntern() name: %y (with type: %y) h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, ((!omitType || type != self.type) && type.hasRealName()), h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);  #XXX
 
         int tc = h.typeCode();
         if (tc == NT_LIST && h.size() == 1)
@@ -1891,6 +1891,8 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         @throw WSDL-BINDING-ERROR unknown binding
      */
     hash getBinding(*string bname) {
+printf("getbinding: %y\n", bname);
+printf("bindings: %y\n", bindings);
         if (bindings && !exists bname)
             return bindings.firstValue();
         if (!exists bindings{bname})
@@ -1911,12 +1913,14 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             throw "WSDL-BINDING-ERROR", sprintf("binding %y is already registered in operation %y", bname, name);
         }
         opparams.name = bname;
+printf("addBinding: %y, %y\n", bname, opparams);
         bindings{bname} = opparams;
     }
 
     private:internal hash serializeSoapMessage(any h, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
         string io = request ? "input" : "output";
         # setup namespaces for SOAP envelope
+        printf("DEBUG: serializeSoapMessage: io:%s, h: %y, header: %y, binding: %y\n", io, h, header, binding);  #XXX
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
         string soapenvEnvelope = rh.firstKey();
         rh{soapenvEnvelope}."^attributes^" += nsc.getOutputNamespaceHash(nsh);
@@ -1925,60 +1929,32 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             hash outh;
             *hash header2 = header;  # non processed values will be added to soap header
             foreach hash hdr in (binding{io}.header) {
-                /*printf("DEBUG: hdr.msg.name/part/msgpart: %y/%y/%y, exists: %y,%y,%y,%y,%y\n", hdr.msg.name, hdr.part, hdr.msgpart,
-                       exists header{hdr.msg.name}, exists header{hdr.msg.name}{hdr.part},
-                       exists header{hdr.msg.name}{hdr.msgpart}, exists header{hdr.part}, exists header{hdr.msgpart}
-                );*/
-                # there is not unique part name space as it may contain parts from more message so let's do a little heuristic
-                any hh;
-                if (exists header{hdr.msg.name} && exists header{hdr.msg.name}{hdr.part}) {
-                    hh = header{hdr.msg.name}{hdr.part};
-                    remove header2{hdr.msg.name}{hdr.part};
-                    if (!header2{hdr.msg.name}) {
-                        remove header2{hdr.msg.name};
-                    }
-                } else if (exists header{hdr.msg.name} && exists header{hdr.msg.name}{hdr.msgpart}) {
-                    hh = header{hdr.msg.name}{hdr.msgpart};
-                    remove header2{hdr.msg.name}{hdr.msgpart};
-                    if (!header2{hdr.msg.name}) {
-                        remove header2{hdr.msg.name};
-                    }
-                } else if (exists header{hdr.part}) {
-                    hh = header{hdr.part};
-                    remove header2{hdr.part};
-                } else if (exists header{hdr.msgpart}) {
-                    hh = header{hdr.msgpart};
-                    remove header2{hdr.msgpart};
-                }
-                if (hh) {
-                    hash hh2.(hdr.msgpart) = hh;
-                    #printf("DEBUG: serialize(%y,%y)\n", hdr.msgpart, hh2);
-                    if (binding.docstyle) {
-                        hash h = hdr.msg.serializeDocument(hdr.msgpart, NOTHING, NOTHING, hh2); # does not work at least for non-elements
-                        remove h."^attributes^".("soapenv:encodingStyle", "xmlns:soapenc");
-                        outh += h;
-                    } else {
-                        hash h = hdr.msg.serialize(hdr.msgpart, NOTHING, NOTHING, hdr.msgpart, hh2); # TODO: it does no add types
-                        #printf("DEBUG: result: %y\n", h);
-                        # tricky part, flatten hash, TODO: make it more transparently
-                        string fk = h.firstKey();
-                        h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
-                        #printf("DEBUG: flatten result: %y\n", h);
-                        if (exists outh{fk}) {
-                            # it could in theory happoen when two message parts are equal
-                            if (outh{fk}.typeCode() != NT_LIST) {
-                                outh{fk} = () + outh{fk};
-                            }
-                            outh{fk} += h{fk};
-                        } else {
-                            outh += h;
+                printf("DEBUG: hdr: %y, hdr.msg.name/part: %y/%y\n", hdr, hdr.msg.name, hdr.part);
+                if (binding.docstyle) {
+                    hash h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, \header);
+                    remove h."^attributes^".("soapenv:encodingStyle", "xmlns:soapenc");
+                    outh += h;
+                } else {
+                    hash h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, \header);
+                    #printf("DEBUG: result: %y\n", h);
+                    # tricky part, flatten hash, TODO: make it more transparently
+                    string fk = h.firstKey();
+                    h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
+                    #printf("DEBUG: flatten result: %y\n", h);
+                    if (exists outh{fk}) {
+                        # it could in theory happen when two message parts are equal
+                        if (outh{fk}.typeCode() != NT_LIST) {
+                            outh{fk} = () + outh{fk};
                         }
+                        outh{fk} += h{fk};
+                    } else {
+                        outh += h;
                     }
                 }
             }
-            if (header2) {
-                # append unprocessed values
-                outh += header2;
+            if (header) {
+                # append unprocessed values TODO: it's obsolete as it violates WSDL definition
+                outh += header;
             }
             #printf("DEBUG: outh: %y\n", outh);
             rh{soapenvEnvelope}."soapenv:Header" = outh;
@@ -1992,12 +1968,15 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (self{io}) {
             *hash body;
             if (binding.docstyle)
-                body = self{io}.serializeDocument(NOTHING, binding{io}, mpm, h);
+                body = self{io}.serializeDocument(binding{io}.body.parts, binding{io}, mpm, \h);
             else {
                 string mname = input_name ? input_name : name + (request ? "":"Response");
                 if (binding{io})
-                    body = self{io}.serialize(NOTHING, binding{io}, mpm, mname, h);
+                    body = self{io}.serializeRpc(binding{io}.body.parts, binding{io}, mpm, mname, \h);
             }
+            if (h.typeCode() == NT_HASH && h)
+                throw SOAP_SERIALIZATION_ERROR, sprintf("some data remains unserialized: %y", h.keys());
+
             if (body) {
                 rh{soapenvEnvelope}."soapenv:Body" = body;
             }
@@ -2015,9 +1994,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             # application/x-www-form-urlencoded Content-Type does not have any parameters
             delete enc;
             # TODO: throws exception when character is > 127, discussed e.g. https://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
-            return mime_get_form_urlencoded_string(self{io}.getNameValue(NOTHING, h));
+            return mime_get_form_urlencoded_string(self{io}.serializeAllPartData(h));
         } else if (binding{io}.content) {
-            hash v = self{io}.resolveValue(binding{io}.content.part, h, True);
+
+            hash v = self{io}.serializeData(binding{io}.content.part, h, True);
             if (v."content-type") {
                 if (!binding{io}.content.acceptAllContentTypes) {
                     WSDLLib::checkContentType(v."content-type", binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
@@ -2037,7 +2017,9 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             }
         } else if (binding{io}.mimeXml) {
             ct = MimeTypeXml;
-            return make_xml(self{io}.serialize(binding{io}.mimeXml.msgpart, NOTHING, NOTHING, binding{io}.mimeXml.msgpart, h));
+            # in case of mimeXml is body content, i.e. XML tag based on element/type name, not part
+printf("mimexml: part: %y, h:%N\n", binding{io}.mimeXml.part, h);
+            return make_xml(self{io}.serializeRpc(binding{io}.mimeXml.part, NOTHING, NOTHING, binding{io}.mimeXml.part, \h));
         }
     }
 
@@ -2055,12 +2037,12 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                         if (!input) {
                             throw SOAP_SERIALIZATION_ERROR, sprintf("url replacement requested for operation %s with no message (%y)", name, h);
                         }
-                        hash v = input.getNameValue(binding.input.urlReplacement{k}, h);
-                        path += encode_url(string(v.firstValue()), True);
+                        hash v = input.serializeData(binding.input.urlReplacement{k}, h);
+                        path += encode_url(string(v.value), True);
                     }
                 }
             } else if (binding.input.urlEncoded) {
-                string s = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
+                string s = mime_get_form_urlencoded_string(input.serializeAllPartData(h));
                 if (s) {
                     path += binding.location =~ /\?/ ? "&" : "?";
                     path += s;
@@ -2087,7 +2069,9 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c method: the HTTP request method
         */
     hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction, *string bname) {
+printf("serializeRequest %y\n", bname);
         hash binding = getBinding(bname);
+printf("serializeRequest %y\n", binding);
 
         if (!exists req_soapaction)
             req_soapaction = bindings{name}.soapAction;
@@ -2111,9 +2095,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             rv.body = serializeHttpMessage(h, binding, True, \ct, \enc);
         } else {
             MultiPartRelatedMessage mpm;
+printf("serializeRequest SSM\n");
             rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
             if (mpm) {
-                mpm.splicePart(rv.body, sprintf("<%s>", binding.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
+                mpm.splicePart(rv.body, sprintf("<%s>", (binding.input.body.parts ? binding.input.body.parts : keys input.args).join(" ")), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
 
                 hash rv = mpm.getMsgAndHeaders();
                 if (req_soapaction) {
@@ -2182,7 +2167,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
             ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
             if (exists mpm) {
-                mpm.splicePart(rv.body, sprintf("<%s>", binding.output.body.parts), ct);
+                mpm.splicePart(rv.body, sprintf("<%s>", (binding.output.body.parts ? binding.output.body.parts : keys output.args).join(" ")), ct);
                 return mpm.getMsgAndHeaders();
             }
         }
@@ -2264,13 +2249,13 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
             #printf("DEBUG: Deserialize SOAP headers: %N\n", header);
             foreach hash hdr in (binding{io}.header) {
-                if (header.hasKey(hdr.msgpart)) {
+                if (header.hasKey(hdr.part)) {
                     # seems it may appear part name conflict between messages when namespace is stripped
                     hash v;
                     if (binding.docstyle) {
-                        hrv{hdr.msg.name} += hdr.msg.deserializeDocument(NOTHING, header, hdr.msgpart);
+                        hrv{hdr.msg.name} += hdr.msg.deserializeDocument(NOTHING, header, hdr.part);
                     } else {
-                        hrv{hdr.msg.name} += hdr.msg.deserialize(NOTHING, header, hdr.msgpart);
+                        hrv{hdr.msg.name} += hdr.msg.deserializeRpc(NOTHING, header, hdr.part);
                     }
                 }
             }
@@ -2338,7 +2323,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                 XsdBase::removeNS2(\msg);
                 msg -= (".ns", "ns");
 
-                rv = self{io}.deserialize(mrh, msg);
+                rv = self{io}.deserializeRpc(mrh, msg);
             }
         }
 
@@ -2371,21 +2356,21 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             WSDLLib::checkContentType(ct, list(MimeTypeFormUrlEncoded));
             v.body = binary_to_string(v.body);
             hash h = mime_parse_form_urlencoded_string(v.body); # TODO: data have no encoding
-            return self{io}.deserialize(NOTHING, h, NOTHING);
+            return self{io}.deserializeRpc(NOTHING, h, NOTHING);
         } else if (binding{io}.content) {
 
             if (!binding{io}.content.acceptAllContentTypes) {
                 WSDLLib::checkContentType(ct, binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
             }
             hash v2;
-            v2{binding{io}.content.msgpart} = v.body;
-            hash h = self{io}.deserialize(NOTHING, v2, binding{io}.content.msgpart);
+            v2{binding{io}.content.part} = v.body;
+            hash h = self{io}.deserializeRpc(NOTHING, v2, binding{io}.content.part);
             string k = h.firstKey();
             h{k}."^value^" = remove h{k};
             h{k}."^attributes^"."^content-type^" = ct;
             return h;
         } else if (binding{io}.mimeXml) {
-            *hash h = self{io}.deserialize(NOTHING, v, binding{io}.mimeXml.msgpart);
+            *hash h = self{io}.deserializeRpc(NOTHING, v, binding{io}.mimeXml.part);
             return h;
         }
     }
@@ -2449,10 +2434,18 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 }
 
 #! web service message class
+/**
+Message definition consists of part definition. Part name is important for simple types to name it at both SOAP and Qore side (hash key).
+For elements is not used at the SOAP side, it implies condition the element name must be unique in message. In the other words
+it's forbidden definition of two parts with the same element. It's unclear if is legal in Wsdl and how to handle it. Class raises
+exception if detects it. The part name is also used for references from binding (header, content).
+*/
 public class WSDL::WSMessage inherits WSDL::XsdNamedData {
     public {
+        #! args keys are part names for types reps. element names for element. Definition must provide unique values.
         hash args;
-        # part map; maps element names to part names
+        #! part map; maps element names to part names
+        #! maps part names to args key, all parts are in hash
         hash pmap;
         bool encoded = False;
 
@@ -2461,50 +2454,60 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
 
         # keep a reference to the type map
         TypeMap tmap;
+
     }
 
     constructor(hash m, ElementMap emap, TypeMap n_tmap, Namespaces n_nsc) : XsdNamedData(\m) {
         nsc = n_nsc;
         tmap = n_tmap;
+printf("message constructor\n"); flush();
+printf("m:%N\n", self);flush();
 
         #printf("DEBUG: WSMessage::constructor() m: %y emap: %y\n", m, emap);
 
         name = m."^attributes^".name;
         foreach any p in (m.part) {
             any arg = p."^attributes^";
+            if (pmap{arg.name})
+                throw WSDL_ERROR, sprintf("duplicate part name %y in message %y", arg.name, name);
             if (arg.element) {
                 (*string ns, *string ename) = arg.element =~ x/(\w+):(\w+)/;
                 if (!ename)
                     ename = arg.element;
+                if (args{ename})
+                    throw WSDL_ERROR, sprintf("ambiguous element name %y in message %y", ename, name);
 
-                if (arg.name && arg.name != ename)
-                    pmap{ename} = arg.name;
+                if (arg.name) {
+                    # is unique name required or not ?
+                    args{ename}.part = arg.name;
+                    pmap{arg.name} = ename;
+                }
 
                 args{ename}.element = emap.get(nsc.getNamespaceUri(ns), ename);
             }
             else {
+                if (args{arg.name})
+                    throw WSDL_ERROR, sprintf("part name colission with element %y in message %y, ", arg.name, name);
                 args{arg.name} = arg;
-                args{arg.name}.type = nsc.doType(p."^attributes^".type);
+                args{arg.name}.type = nsc.doType(arg.type);
+                if (arg.name) {
+                    pmap{arg.name} = arg.name;
+                }
             }
         }
     }
 
-    #! serializes data into hash with SOAP soup as namespaces etc
+    #! serializes data into hash with SOAP soup as namespaces etc.
     /**
      * @param if present then serializes only particular element or part, if NOTHING then serializes all message elements
      * @param n_name name of output key
-     * @param h data to be serialized
+     * @param h data to be serialized, keys are wsdl element names (optionally part name is also possible) and part names for simple types
      */
-    hash serialize(*string key, any msginfo, any mpm, string n_name, any h) {
+    hash serializeRpc(*softlist key, any msginfo, any mpm, string n_name, reference h) {
         hash rh;
-        #printf("DEBUG: message %s: key: %y, h: %y\n", name , key, h);
-
-        foreach string k in (key ? key : args.keyIterator()) {
-            any v;
-            if (h.hasKey(k))
-                v = remove h{k};
-            else if (pmap{k})
-                v = remove h.(pmap{k});
+        #printf("DEBUG: message %s: keys: %y, h: %y\n", name , keys, h);
+        foreach string k in (key ? key : keys args) {
+            any v = getValueFromHash(k, \h, True);
 
             any hv;
             #printf("DEBUG: arg %y with %y\n", k, args{k});
@@ -2533,9 +2536,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             rh{en} = hv;
         }
 
-        if (h.typeCode() == NT_HASH && h)
-            throw SOAP_SERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", h.keys(), name);
-
         if (encoded)
             rh."^attributes^" += (
                 "soapenv:encodingStyle": SOAP_ENCODING,
@@ -2547,19 +2547,21 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rvh;
     }
 
-    hash serializeDocument(*string key, any msginfo, any mpm, any h) {
+    hash serializeDocument(*softlist key, any msginfo, any mpm, reference h) {
         hash rh;
 
         if (!key && args.size() == 1) {
-            string key = args.firstKey();
-            if (h.typeCode() != NT_HASH || !h.hasKey(key)) {
+            # deprecated, just for backward compatability
+            string k = args.firstKey();
+            if (h.typeCode() != NT_HASH || !h.hasKey(k)) {
                 hash nh;
-                nh{key} = h;
+                nh{k} = h;
                 h = nh;
             }
         }
-        foreach string k in (key ? key : args.keyIterator()) {
-            any val = remove h{k};
+printf("args: %N\n", args); #XXX
+        foreach string k in (key ? key : keys args) {
+            any val = getValueFromHash(k, \h, True);
             if (val.typeCode() == NT_HASH)
                 XsdBase::removeNS2(\val);
             string ons;
@@ -2575,9 +2577,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             }
         }
 
-        if (h.typeCode() == NT_HASH && h)
-            throw SOAP_SERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", h.keys(), name);
-
         if (encoded)
             rh."^attributes^" += (
                 "soapenv:encodingStyle": SOAP_ENCODING,
@@ -2589,9 +2588,14 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
-    #! deserialize message with keys equal to element names and returns hash with root keys according part name
-    *hash deserialize(*hash mrh, hash val, *string key) {
-        #printf("DBG WSMessage::deserialize() args: %y pmap: %y key: %y val: %y\n", args.keys(), pmap, key, val);
+    #! deserialize RPC message
+    /**
+    @param val, keys are element names or part names for simple types
+    @param key if exists then deserialize only particular element/type
+    @return serialized data, keys are wsdl element names (optionally part name is also possible) and part names for simple types
+    */
+    *hash deserializeRpc(*hash mrh, hash val, *string key) {
+        #printf("DBG WSMessage::deserializeRpc() args: %y pmap: %y key: %y val: %y\n", args.keys(), pmap, key, val);
         hash ro;
 
         foreach string k in (exists key ? key : args.keyIterator()) {
@@ -2601,7 +2605,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             if (v.typeCode() == NT_HASH)
                 XsdBase::removeNS2(\v);
 
-            ro{getPartFromElement(k)} = args{k}.element
+            ro{args{k}.part ?? k} = args{k}.element
                 ? args{k}.element.deserialize(tmap, mrh, getValue(mrh, v), present)
                 : args{k}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
         }
@@ -2634,7 +2638,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             any v = remove val{k};
             XsdBase::removeNS2(\v);
 
-            rh{getPartFromElement(k)} = args{k}.element ?
+            rh{args{k}.part ?? k} = args{k}.element ?
                 args{k}.element.deserialize(tmap, mrh, v, present) :
                 args{k}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
         }
@@ -2646,50 +2650,95 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
-    hash getNameValue(*string key, any h, *softbool keepBinary) {
+    #! serialized all values as string or binary
+    /**
+        @return hash of all parts in key-value pair
+    */
+    hash serializeAllPartData(*hash val, *softbool keepBinary) {
         hash rv;
-        foreach string k in (key ? key : args.keyIterator()) {
-            hash v = resolveValue(k, h, keepBinary);
+        foreach string k in (args.keyIterator()) {
+            hash v = serializeData(k, val, keepBinary);
             rv{k} = v.value;
         }
         return rv;
     }
 
-    hash resolveValue(string key, any h, *softbool keepBinary) {
+    #! serialized value of particular type value as string or binary
+    /**
+        @param val value to be resolved
+        @param key member name, it is requires reference to a simple type, not compaund element
+        @param keepbinary if True then value is returned as is in case of binary value in @param h
+
+        @return as hash with 'value' and optional 'content-type' key passed from v.content-type if exists
+     */
+    hash serializeData(string key, *hash val, *softbool keepBinary) {
         if (args{key}.element) {
             throw SOAP_SERIALIZATION_ERROR, sprintf("cannot get element value %y in message %y. Type part is needed", key, name);
         }
-        hash rv;
-        any v;
-        if (h.hasKey(key))
-            v = h{key};
-        else if (pmap{key})
-            v = h.(pmap{key});
-        rv.value = args{key}.type.serialize(v, False, keepBinary){"^value^"};
+        any v = getValueFromHash(key, \val, False);
+        hash rv.value = args{key}.type.serialize(v, False, keepBinary){"^value^"};
         if (v.typeCode() == NT_HASH) {
             rv."content-type" = v."^attributes^"."^content-type^";
         }
         return rv;
     }
 
-    #! return element name corresponding to partname, if not exists then try return element name otherwise raise exception 
-    /*private in module*/string getElementFromPart(string partname) {
-        hash pmap2;
-        map pmap2{$1.value}=$1.key, pmap.pairIterator();
-        if (pmap2{partname}) {
-            return pmap2{partname};
-        } else if (exists args{partname}) {
-            return partname;
-        } else
-            throw WSDL_ERROR, sprintf("cannot resolve partname %y in message %y", partname, name);
+    #! find part in value, remove that value from
+    /**
+        @param ename element/type name
+        @param reference to hash, supposed structure is [msgname.](partname|elemname) = value to support more message data in one hash
+        @param removeFound if True found values are remove from hash
+
+        @return resolved value, if not found then returns NOTHING
+    */
+    /* private in module*/any getValueFromHash(string ename, reference v, bool removeFound) {
+        any rv;
+        string k;
+        # there is not unique part name space as it may contain more messages in one hash so let's do a little heuristic
+        if (exists v{name}) {
+            if (args{ename}.part && exists v{name}{args{ename}.part}) {
+                k = args{ename}.part;
+            } else if (exists v{name}{ename}) {
+                k = ename;
+            }
+            if (k) {
+                rv = v{name}{k};
+                if (removeFound) {
+                    remove v{name}{k};
+                    if (!v{name}) {
+                        remove v{name};
+                    }
+                }
+            }
+        }
+        if (!k) {
+            if (args{ename}.part && exists v{args{ename}.part}) {
+                k = args{ename}.part;
+            } else if (exists v{ename}) {
+                k = ename;
+            }
+            if (k) {
+                rv = v{k};
+                if (removeFound) {
+                    remove v{k};
+                    if (!v{name}) {
+                        remove v{name};
+                    }
+                }
+            }
+        }
+        return rv;
     }
-    #! return part name corresponding to element name, if not exists then return element name
-    /*private in module*/string getPartFromElement(string ename) {
-        string rk = ename;
-        if (pmap{ename} && !args.(pmap{ename}))
-            rk = pmap{ename};
-        return rk;
+
+    #! check if pname is defined as message part
+    /** @return translated part name to element/type name */
+    /*private in module*/string checkPart(string pname) {
+        if (!pmap{pname}) {
+            throw sprintf("%y is unknown part in message %y, defined parts: %y", pname, name, keys pmap);
+        }
+        return pmap{pname};
     }
+
 }
 
 # private helper class for lazy name resolution
@@ -2771,7 +2820,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
         foreach hash ophash in (data.operation) {
             string opname = ophash."^attributes^".name;
-
             if (!exists portTypes{port}.operations{opname})
                 throw WSDL_ERROR, sprintf("binding %y references unknown porttype %y operation %y", name, port, opname);
 
@@ -2815,9 +2863,11 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                             throw WSDL_ERROR, sprintf("binding %y for operation %y does not reference %s message in porttype %y",  name, opname, io, port);
                     }
                     if (exists ophash{io}.body) {
-                        # any pa = ophash{io}.body."^attributes^";
-                        op{io}.body = ophash{io}.body."^attributes^";
-                        op{io}.body.encoded = ophash{io}.body."^attributes^".use == "encoded";  # TODO: move to WSOperation
+                        *hash pa = ophash{io}.body."^attributes^";
+                        op{io}.body.encoded = pa.use == "encoded";
+                        #op{io}.body.namespace = pa.namespace;
+                        #op{io}.encodingStyle = pa.encodingStyle;
+                        op{io}.body.parts = pa.parts;
 
                         delete ophash{io}.body;
                     }
@@ -2838,18 +2888,29 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                             #any a = part."^attributes^";
                             part -= "^attributes^";
                             if (exists part.body) {
+                                if (exists op{io}.body)
+                                    throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies multiple body parts in multipart elements", io, name, opname);
                                 any pa = part.body."^attributes^";
                                 if (pa.use != "literal")
                                     throw WSDL_ERROR, sprintf("unsupported body part without use=\"literal\": %y", part.body);
 
-                                op{io}.body = pa;
+                                op{io}.body.parts = pa.parts;
+
                             } else if (exists part.content) {
+                                *string pcname;
                                 foreach any c in (part.content) {
                                     WSDL::XsdBase::removeNS(\c);
                                     any pa = c."^attributes^";
                                     any name = pa.part;
                                     if (!exists name)
                                         throw WSDL_ERROR, sprintf("unsupported content part without part attribute: %y", c);
+                                    if (pcname) {
+                                        if (pcname != name)
+                                            throw WSDL_ERROR, sprintf("multiple content part names inside part section: %y!=%y", name, pcname);
+                                    } else {
+                                        pcname = name;
+                                        name = portTypes{port}.operations{opname}{io}.checkPart(name);
+                                    }
                                     any type = pa.type;
                                     if (!exists type)
                                         throw WSDL_ERROR, sprintf("unsupported content part without type attribute: %y", c);
@@ -2871,6 +2932,13 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                     }
 
 
+                    if (op{io}.body.parts) {
+                        op{io}.body.parts = op{io}.body.parts.split(" ");  # NMTOKENS
+                        foreach string p in (\op{io}.body.parts) {
+                            p = portTypes{port}.operations{opname}{io}.checkPart(p);
+                        }
+                    }
+
                     if (exists ophash{io}.header) {
                         foreach hash hdr in (ophash{io}.header) {
                             *hash ma = hdr."^attributes^";
@@ -2884,16 +2952,18 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
 
                             ma.part = checkMessagePart(msg, ma.part, sprintf("header %s operation %y", io, opname));
-                            ma.msgpart = msg.getElementFromPart(ma.part);
-
+                            ma.msg.name = h.val;
                             bool enc = ma.use == "encoded";
                             if (enc != msg.encoded) {
-                                ma.msg = msg.copy();
+                                #ma.msg = msg;
+#printf("COPY message\n");
+                                ma.msg = msg.copy();  # XXX
                                 ma.msg.encoded = enc;
                             } else {
+#printf("ASSIGN REFERENCE message: %y\n", messages);flush();  #ma.msg = \messages.(h.val); #msg;  # XXX
                                 ma.msg = msg;
                             }
-                            #printf("DEBUG: match part to message: part: %y, msg.pmap: %y->%y, ma.msgpart: %y\n", ma.part, msg.pmap, pmap2, ma.msgpart);
+                            #printf("DEBUG: match part to message: %y, part: %y\n", msg.name, ma.part);
                             if (op{io}.header) {
                                 if (op{io}.header.typeCode() != NT_LIST) {
                                     op{io}.header = () + op{io}.header;
@@ -2988,7 +3058,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                                 }
                             } else {
                                 op{io}.content.part = cnt.part;
-                                op{io}.content.msgpart = portTypes{port}.operations{opname}{io}.getElementFromPart(cnt.part);
                                 p = cnt.part;
                             }
                         }
@@ -2998,7 +3067,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
                     if (ophash{io}.hasKey("mimeXml")) {
                         op{io}.mimeXml.part = checkMessagePart(portTypes{port}.operations{opname}{io}, ophash{io}.mimeXml."^attributes^".part, sprintf("%s operation %y", io, opname));
-                        op{io}.mimeXml.msgpart = portTypes{port}.operations{opname}{io}.getElementFromPart(op{io}.mimeXml.part);
                         delete ophash{io}.mimeXml;
                     }
 
@@ -3027,16 +3095,14 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
     #! check if part exists in massage, if part is empty and message contains single part then return it otherwise raise exceptio
     private:internal string checkMessagePart(WSMessage msg, *string partname, string errs) {
-        if (!msg.args)
-            throw WSDL_ERROR, sprintf("message %y has no part, binding %y, %s", msg.name, name, errs);
-        if (!exists partname) {
-            if (msg.args.size() == 1) {
-                partname = msg.getPartFromElement(msg.args.firstKey());
-            } else {
-                throw WSDL_ERROR, sprintf("message %y is multiparted so the part must be defined, binding %y, %s", msg.name, name, errs);
-            }
+        if (exists partname) {
+            return msg.checkPart(partname);
         }
-        return partname;
+        if (msg.pmap.size() == 1) {  # some args may be defined without part name so use pmap to test
+            return msg.args.firstKey();
+        } else {
+            throw WSDL_ERROR, sprintf("to resolve default part neme in message %y requires just one defined part, binding %y, %s", msg.name, name, errs);
+        }
     }
 
     string getPort() {
@@ -3468,6 +3534,8 @@ public class WSDL::WebService inherits WSDL::XsdBase {
         *code try_import;
         #! default path for retrieving XSD references
         *string def_path;
+
+        int parseTypeRecurse;  #XXX
     }
 
     private {
@@ -3501,21 +3569,29 @@ public class WSDL::WebService inherits WSDL::XsdBase {
         nsc = new Namespaces(h.definitions."^attributes^");
         #getNSPrefixes(h.definitions."^attributes^");
         #printf("%y\n", h.definitions.types);
+printf("nsc\n"); flush();
+#printf("m:%N\n", nsc);flush();
 
         if (exists h.definitions.types)
             parseTypes(h.definitions.types, opts.http_client instanceof HTTPClient ? opts.http_client : NOTHING, opts.http_headers);
+printf("parsedtypes\n"); flush();
+printf("m:%N\n", tmap);flush();
 
         if (exists h.definitions.message)
             parseMessages(h.definitions.message);
 
         if (exists h.definitions.portType)
             parsePortType(h.definitions.portType);
+printf("DEBUG:parse binding\n");
 
         if (exists h.definitions.binding)
             parseBinding(h.definitions.binding);
+printf("DEBUG:parse service\n");
 
         if (exists h.definitions.service)
             parseService(h.definitions.service);
+printf("DEBUG:done\n"); #exit();
+
     }
 
     #! returns the given operation or throws an exception if it cannot be found; operations are searched in portTypes in the order they are declared
@@ -3658,6 +3734,9 @@ public class WSDL::WebService inherits WSDL::XsdBase {
 
     # parse XSD schema types
     private parseTypes(*hash data, any http_client, any http_headers) {
+    parseTypeRecurse++;
+        printf("DEBUG: parseTypes %y\n", parseTypeRecurse); #XXX
+        #printf("DEBUG: parseTypes data: %y, http_client: %y, http_headers: %y\n", data, http_client, http_headers); #XXX
         WSDL::XsdBase::removeNS(\data);
 
         XsdLateResolverHelper unresolved();
@@ -3670,7 +3749,7 @@ public class WSDL::WebService inherits WSDL::XsdBase {
 
             bool usedocns = sa.elementFormDefault == "qualified";
 
-            #printf("DEBUG: schema tn: %y\n", schema."^attributes^"."targetNamespace");
+            printf("DEBUG: schema tn: %y\n", schema."^attributes^"."targetNamespace");
             WSDL::XsdBase::removeNS(\schema);
             #printf("DEBUG: WebService::parseTypes() schema: %y\n", schema);
 
@@ -3696,7 +3775,7 @@ public class WSDL::WebService inherits WSDL::XsdBase {
                     # get schema member name
                     any sk = xh.firstKey();
 
-                    #printf("*** DEBUG %y: sk: %y a: %y\n", a.schemaLocation, sk, xh{sk}."^attributes^");
+                    printf("*** DEBUG %y: sk: %y a: %y\n", a.schemaLocation, sk, xh{sk}."^attributes^");
 
                     # use temporary Namespaces object for import
                     Namespaces n_nsc = nsc;
@@ -3718,15 +3797,13 @@ public class WSDL::WebService inherits WSDL::XsdBase {
             foreach hash st in (schema.simpleType) {
                 XsdSimpleType t(st, nsc, unresolved, usedocns);
                 tmap.add(t);
-                #printf("DEBUG: st: %y\n", t.name);
+                printf("DEBUG: st: %y\n", t.name);
             }
-
             foreach hash ct in (schema.complexType) {
-                XsdComplexType t(ct, nsc, unresolved, usedocns);
+                XsdComplexType t(ct, nsc, unresolved, usedocns);     # DEBUG: tady se to toci!
                 tmap.add(t);
-                #printf("DEBUG: ct: %y\n", t.name);
+                printf("DEBUG: ct: %y\n", t.name);
             }
-
             # make element map
             foreach any el in (schema.element) {
                 any attr = el."^attributes^";
@@ -3740,26 +3817,39 @@ public class WSDL::WebService inherits WSDL::XsdBase {
                         if (!et)
                             eattr.type = t;
 
-                        #printf("DEBUG: adding element %y type %y\n", attr.name, t);
+                        printf("DEBUG: adding element %y type %y\n", attr.name, t);
                         element = new WSDL::XsdElement(("^attributes^": eattr), nsc, et, unresolved, usedocns);
                     }
                     else {
-                        #printf("DEBUG: adding element %y type %y\n", attr.name, t);
+                        printf("DEBUG: adding element %y type %y\n", attr.name, t);
                         element = new WSDL::XsdElement(("^attributes^":("name":attr.name)), nsc, t, unresolved, usedocns);
                     }
                 }
                 else {
-                    #printf("DEBUG: adding element %y\n", attr.name);
+                    printf("DEBUG: adding element %y\n", attr.name);
                     element = new WSDL::XsdElement(el, nsc, NOTHING, unresolved, usedocns);
                 }
 
                 emap.add(element);
             }
         }
-
+printf("tmap\n");flush();
+printf("%y\n", tmap); flush();
+printf("emap\n");flush();
+printf("%y\n", emap); flush();
         # resolve types
+printf("unresolved\n\n");flush();
+printf("%N\n", unresolved); flush();
         map resolveType($1), unresolved.getList();
+printf("unresolved.getlist2\n");flush();
+printf("%y\n", unresolved.getList()); flush();
+printf("emap\n");flush();
+printf("%y\n", emap); flush();
+printf("unresolved2\n");flush();
+printf("%y\n", unresolved); flush();
         unresolved.clearResolved();
+printf("unresolved3\n");flush();
+printf("%y\n", unresolved); flush();
 
         # finalize complex types
         foreach XsdAbstractType t in (tmap.iterator()) {
@@ -3768,7 +3858,6 @@ public class WSDL::WebService inherits WSDL::XsdBase {
 
             cast<XsdComplexType>(t).finalize(tmap, nsc);
         }
-
         # finalize complex types in elements
         foreach hash eh in (emap.iterator()) {
             foreach XsdElement el in (eh.iterator()) {
@@ -3782,12 +3871,15 @@ public class WSDL::WebService inherits WSDL::XsdBase {
 
         # resolve types
         map resolveType($1), unresolved.getList();
+parseTypeRecurse--;
     }
 
     private parseMessages(*softlist message) {
         # parse messages
         foreach hash m in (message) {
             WSMessage msg(m, emap, tmap, nsc);
+printf("msg created\n"); flush();
+printf("m:%N\n", msg);flush();
             foreach string arg in (msg.args.keyIterator()) {
                 #printf("DEBUG: WebService::parseMessages(): %y: %y\n", arg, msg);
                 #printf("DEBUG: WebService::parseMessages(): %y: %y\n", arg, msg.args{arg}.type);
@@ -3796,6 +3888,8 @@ public class WSDL::WebService inherits WSDL::XsdBase {
             }
             messages.(msg.name) = msg;
         }
+printf("parsemessages done\n"); flush();
+printf("m:%N\n", messages); flush();
     }
 
     private parseService(*softlist svcs) {
@@ -3844,6 +3938,8 @@ public class WSDL::WebService inherits WSDL::XsdBase {
     private parseBinding(*softlist bindings) {
         foreach hash data in (bindings) {
             WSDL::Binding b(data, nsc, \portType, \idocmap, messages);
+printf("bindingdone\n"); flush();
+printf("m:%N\n", messages);flush();
             binding.(b.getName()) = b;
         }
     }

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -335,7 +335,7 @@ public class WSDL::WSDLLib {
                     hh{hi} = ha;
                 }
                 if (!exists hh."content-id")
-                    throw "SOAP-MCESSAGE-ERROR", sprintf("expecting part header Content-ID in part %d; headers: %y", i, hh);
+                    throw "SOAP-MESSAGE-ERROR", sprintf("expecting part header Content-ID in part %d; headers: %y", i, hh);
 
                 any b;
                 if (hh."content-transfer-encoding" == "binary") {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -2286,7 +2286,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         else if (!exists body)
             throw SOAP_DESERIALIZATION_ERROR, sprintf("no %s body value given for operation %y", request ? "request" : "response", name);
 
-        *hash rv;
+        any rv;
         if (exists body) {
             (*hash mrh, hash msg) = processMultiRef(body);
 
@@ -2343,13 +2343,15 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         }
 
         if (exists rv) {
-            # for backward compatibility flat hash when there was only argument
-            # but we must be care of when the argument is type (not element) and header is present
-            if (rv.size() == 1 && (rv.firstValue().typeCode() == NT_HASH || !exists hrv)) {
+            # for backwards compatibility with a flat hash when there was only argument
+            # but we must be care of when the argument is a type (not element)
+            if (rv.size() == 1 && rv.typeCode() == NT_HASH) {
                 rv = rv.firstValue();
             }
         }
         if (exists hrv) {
+            if (rv.typeCode() != NT_HASH)
+                rv = ("^value^": rv);
             rv."^header^" = hrv;
         }
 

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1121,7 +1121,7 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
     }
 
     private any serializeAsIntern(XsdAbstractType type, any h, *softbool omitType, string key, string typename) {
-        printf("DEBUG: XsdElement::serializeAsIntern() name: %y (with type: %y) h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, ((!omitType || type != self.type) && type.hasRealName()), h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);  #XXX
+        #printf("DEBUG: XsdElement::serializeAsIntern() name: %y (with type: %y) h: %y key: %y typename: %y (%y) minOccurs: %y nillable: %y (%y %y)\n", name, ((!omitType || type != self.type) && type.hasRealName()), h, key, typename, type.getName(), minOccurs, nillable, !exists h, !minOccurs);
 
         int tc = h.typeCode();
         if (tc == NT_LIST && h.size() == 1)
@@ -1891,8 +1891,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         @throw WSDL-BINDING-ERROR unknown binding
      */
     hash getBinding(*string bname) {
-printf("getbinding: %y\n", bname);
-printf("bindings: %y\n", bindings);
         if (bindings && !exists bname)
             return bindings.firstValue();
         if (!exists bindings{bname})
@@ -1913,14 +1911,13 @@ printf("bindings: %y\n", bindings);
             throw "WSDL-BINDING-ERROR", sprintf("binding %y is already registered in operation %y", bname, name);
         }
         opparams.name = bname;
-printf("addBinding: %y, %y\n", bname, opparams);
         bindings{bname} = opparams;
     }
 
     private:internal hash serializeSoapMessage(any h, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
         string io = request ? "input" : "output";
         # setup namespaces for SOAP envelope
-        printf("DEBUG: serializeSoapMessage: io:%s, h: %y, header: %y, binding: %y\n", io, h, header, binding);  #XXX
+        #printf("DEBUG: serializeSoapMessage: io:%s, h: %y, header: %y, binding: %y\n", io, h, header, binding);
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
         string soapenvEnvelope = rh.firstKey();
         rh{soapenvEnvelope}."^attributes^" += nsc.getOutputNamespaceHash(nsh);
@@ -1929,26 +1926,30 @@ printf("addBinding: %y, %y\n", bname, opparams);
             hash outh;
             *hash header2 = header;  # non processed values will be added to soap header
             foreach hash hdr in (binding{io}.header) {
-                printf("DEBUG: hdr: %y, hdr.msg.name/part: %y/%y\n", hdr, hdr.msg.name, hdr.part);
+                #printf("DEBUG: hdr: %y, hdr.msg.name/part: %y/%y\n", hdr, hdr.msg.name, hdr.part);
                 if (binding.docstyle) {
-                    hash h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, \header);
-                    remove h."^attributes^".("soapenv:encodingStyle", "xmlns:soapenc");
-                    outh += h;
-                } else {
-                    hash h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, \header);
-                    #printf("DEBUG: result: %y\n", h);
-                    # tricky part, flatten hash, TODO: make it more transparently
-                    string fk = h.firstKey();
-                    h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
-                    #printf("DEBUG: flatten result: %y\n", h);
-                    if (exists outh{fk}) {
-                        # it could in theory happen when two message parts are equal
-                        if (outh{fk}.typeCode() != NT_LIST) {
-                            outh{fk} = () + outh{fk};
-                        }
-                        outh{fk} += h{fk};
-                    } else {
+                    *hash h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hdr.encoded, \header);
+                    if (h) {
+                        remove h."^attributes^".("soapenv:encodingStyle", "xmlns:soapenc");
                         outh += h;
+                    }
+                } else {
+                    *hash h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, hdr.encoded, \header);
+                    if (h) {
+                        #printf("DEBUG: result: %y\n", h);
+                        # tricky part, flatten hash, TODO: make it more transparently
+                        string fk = h.firstKey();
+                        h{fk} = h.firstValue().firstValue();   # "ns1:name" : ("ns1: name" | "name": val) -> "ns1:name": val
+                        #printf("DEBUG: flatten result: %y\n", h);
+                        if (exists outh{fk}) {
+                            # it could in theory happen when two message parts are equal
+                            if (outh{fk}.typeCode() != NT_LIST) {
+                                outh{fk} = () + outh{fk};
+                            }
+                            outh{fk} += h{fk};
+                        } else {
+                            outh += h;
+                        }
                     }
                 }
             }
@@ -1968,11 +1969,11 @@ printf("addBinding: %y, %y\n", bname, opparams);
         if (self{io}) {
             *hash body;
             if (binding.docstyle)
-                body = self{io}.serializeDocument(binding{io}.body.parts, binding{io}, mpm, \h);
+                body = self{io}.serializeDocument(binding{io}.body.parts, binding{io}, mpm, binding{io}.body.encoded, \h);
             else {
                 string mname = input_name ? input_name : name + (request ? "":"Response");
                 if (binding{io})
-                    body = self{io}.serializeRpc(binding{io}.body.parts, binding{io}, mpm, mname, \h);
+                    body = self{io}.serializeRpc(binding{io}.body.parts, binding{io}, mpm, mname, binding{io}.body.encoded, \h);
             }
             if (h.typeCode() == NT_HASH && h)
                 throw SOAP_SERIALIZATION_ERROR, sprintf("some data remains unserialized: %y", h.keys());
@@ -2018,8 +2019,7 @@ printf("addBinding: %y, %y\n", bname, opparams);
         } else if (binding{io}.mimeXml) {
             ct = MimeTypeXml;
             # in case of mimeXml is body content, i.e. XML tag based on element/type name, not part
-printf("mimexml: part: %y, h:%N\n", binding{io}.mimeXml.part, h);
-            return make_xml(self{io}.serializeRpc(binding{io}.mimeXml.part, NOTHING, NOTHING, binding{io}.mimeXml.part, \h));
+            return make_xml(self{io}.serializeRpc(binding{io}.mimeXml.part, NOTHING, NOTHING, binding{io}.mimeXml.part, False, \h));
         }
     }
 
@@ -2069,9 +2069,7 @@ printf("mimexml: part: %y, h:%N\n", binding{io}.mimeXml.part, h);
         - \c method: the HTTP request method
         */
     hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction, *string bname) {
-printf("serializeRequest %y\n", bname);
         hash binding = getBinding(bname);
-printf("serializeRequest %y\n", binding);
 
         if (!exists req_soapaction)
             req_soapaction = bindings{name}.soapAction;
@@ -2095,7 +2093,6 @@ printf("serializeRequest %y\n", binding);
             rv.body = serializeHttpMessage(h, binding, True, \ct, \enc);
         } else {
             MultiPartRelatedMessage mpm;
-printf("serializeRequest SSM\n");
             rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
             if (mpm) {
                 mpm.splicePart(rv.body, sprintf("<%s>", (binding.input.body.parts ? binding.input.body.parts : keys input.args).join(" ")), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
@@ -2447,7 +2444,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         #! part map; maps element names to part names
         #! maps part names to args key, all parts are in hash
         hash pmap;
-        bool encoded = False;
 
         # keep a reference to Namespaces
         Namespaces nsc;
@@ -2460,8 +2456,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
     constructor(hash m, ElementMap emap, TypeMap n_tmap, Namespaces n_nsc) : XsdNamedData(\m) {
         nsc = n_nsc;
         tmap = n_tmap;
-printf("message constructor\n"); flush();
-printf("m:%N\n", self);flush();
 
         #printf("DEBUG: WSMessage::constructor() m: %y emap: %y\n", m, emap);
 
@@ -2503,11 +2497,21 @@ printf("m:%N\n", self);flush();
      * @param n_name name of output key
      * @param h data to be serialized, keys are wsdl element names (optionally part name is also possible) and part names for simple types
      */
-    hash serializeRpc(*softlist key, any msginfo, any mpm, string n_name, reference h) {
+    *hash serializeRpc(*softlist key, any msginfo, any mpm, string n_name, bool encoded, reference h) {
         hash rh;
         #printf("DEBUG: message %s: keys: %y, h: %y\n", name , keys, h);
         foreach string k in (key ? key : keys args) {
             any v = getValueFromHash(k, \h, True);
+            if (!exists v) {
+                if (key || args.size() == 1) {
+                    v = getValueFromHash(args{k}.element, \h, True);
+                }
+                if (v.typeCode() == NT_NULL) {
+                    v = NOTHING;
+                } else {
+                    if (!exists v) continue;
+                }
+            }
 
             any hv;
             #printf("DEBUG: arg %y with %y\n", k, args{k});
@@ -2536,7 +2540,7 @@ printf("m:%N\n", self);flush();
             rh{en} = hv;
         }
 
-        if (encoded)
+        if (encoded && rh)
             rh."^attributes^" += (
                 "soapenv:encodingStyle": SOAP_ENCODING,
                 "xmlns:soapenc": SOAP_ENCODING,
@@ -2547,7 +2551,7 @@ printf("m:%N\n", self);flush();
         return rvh;
     }
 
-    hash serializeDocument(*softlist key, any msginfo, any mpm, reference h) {
+    *hash serializeDocument(*softlist key, any msginfo, any mpm, bool encoded, reference h) {
         hash rh;
 
         if (!key && args.size() == 1) {
@@ -2559,9 +2563,18 @@ printf("m:%N\n", self);flush();
                 h = nh;
             }
         }
-printf("args: %N\n", args); #XXX
         foreach string k in (key ? key : keys args) {
             any val = getValueFromHash(k, \h, True);
+            if (!exists val) {
+                if (key || args.size() == 1) {
+                    val = getValueFromHash(args{k}.element, \h, True);
+                }
+                if (val.typeCode() == NT_NULL) {
+                    val = NOTHING;
+                } else {
+                    if (!exists val) continue;
+                }
+            }
             if (val.typeCode() == NT_HASH)
                 XsdBase::removeNS2(\val);
             string ons;
@@ -2577,7 +2590,7 @@ printf("args: %N\n", args); #XXX
             }
         }
 
-        if (encoded)
+        if (encoded && rh)
             rh."^attributes^" += (
                 "soapenv:encodingStyle": SOAP_ENCODING,
                 "xmlns:soapenc": SOAP_ENCODING,
@@ -2730,6 +2743,27 @@ printf("args: %N\n", args); #XXX
         return rv;
     }
 
+    #! when only one arg then try get values based on element keys
+    /* private in module*/any getValueFromHash(*WSDL::XsdElement element, reference v, bool removeFound) {
+#printf("getValueFromHash(%N, %y)\n\n", element, v);
+        if (!element) return;
+        if (element.type instanceof WSDL::XsdComplexType) {
+            hash rv;
+            if (!cast<WSDL::XsdComplexType>(element.type).elementmap) {
+                # special case, empty complex type
+                return NULL;
+            } else {
+                foreach my string ename in (keys cast<WSDL::XsdComplexType>(element.type).elementmap) {
+                    any val = getValueFromHash(ename, \v, removeFound);
+                    if (exists val) {
+                        rv{ename} = val;
+                    }
+                }
+            }
+            return rv;
+        }
+    }
+
     #! check if pname is defined as message part
     /** @return translated part name to element/type name */
     /*private in module*/string checkPart(string pname) {
@@ -2865,8 +2899,8 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                     if (exists ophash{io}.body) {
                         *hash pa = ophash{io}.body."^attributes^";
                         op{io}.body.encoded = pa.use == "encoded";
-                        #op{io}.body.namespace = pa.namespace;
-                        #op{io}.encodingStyle = pa.encodingStyle;
+                        op{io}.body.namespace = pa.namespace;
+                        op{io}.encodingStyle = pa.encodingStyle;
                         op{io}.body.parts = pa.parts;
 
                         delete ophash{io}.body;
@@ -2952,17 +2986,9 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
 
                             ma.part = checkMessagePart(msg, ma.part, sprintf("header %s operation %y", io, opname));
-                            ma.msg.name = h.val;
-                            bool enc = ma.use == "encoded";
-                            if (enc != msg.encoded) {
-                                #ma.msg = msg;
-#printf("COPY message\n");
-                                ma.msg = msg.copy();  # XXX
-                                ma.msg.encoded = enc;
-                            } else {
-#printf("ASSIGN REFERENCE message: %y\n", messages);flush();  #ma.msg = \messages.(h.val); #msg;  # XXX
-                                ma.msg = msg;
-                            }
+                            ma.encoded = ma.use == "encoded";
+                            ma.msg = msg;
+
                             #printf("DEBUG: match part to message: %y, part: %y\n", msg.name, ma.part);
                             if (op{io}.header) {
                                 if (op{io}.header.typeCode() != NT_LIST) {
@@ -3534,8 +3560,6 @@ public class WSDL::WebService inherits WSDL::XsdBase {
         *code try_import;
         #! default path for retrieving XSD references
         *string def_path;
-
-        int parseTypeRecurse;  #XXX
     }
 
     private {
@@ -3569,28 +3593,21 @@ public class WSDL::WebService inherits WSDL::XsdBase {
         nsc = new Namespaces(h.definitions."^attributes^");
         #getNSPrefixes(h.definitions."^attributes^");
         #printf("%y\n", h.definitions.types);
-printf("nsc\n"); flush();
-#printf("m:%N\n", nsc);flush();
 
         if (exists h.definitions.types)
             parseTypes(h.definitions.types, opts.http_client instanceof HTTPClient ? opts.http_client : NOTHING, opts.http_headers);
-printf("parsedtypes\n"); flush();
-printf("m:%N\n", tmap);flush();
 
         if (exists h.definitions.message)
             parseMessages(h.definitions.message);
 
         if (exists h.definitions.portType)
             parsePortType(h.definitions.portType);
-printf("DEBUG:parse binding\n");
 
         if (exists h.definitions.binding)
             parseBinding(h.definitions.binding);
-printf("DEBUG:parse service\n");
 
         if (exists h.definitions.service)
             parseService(h.definitions.service);
-printf("DEBUG:done\n"); #exit();
 
     }
 
@@ -3708,35 +3725,41 @@ printf("DEBUG:done\n"); #exit();
             XsdElement e = emap.get(nsc.getNamespaceUri(ns), name);
             if (e.type.typeCode() == NT_HASH)
                 resolveType(e);
-            #printf("resolved to e: %y type: %y\n", e.name, e.type.name);
+            #printf("resolveType(XsdElement), resolved to e: %y type: %y\n", e.name, e.type.name);
             xe.assimilate(e);
             #throw "OOPS", sprintf("e: %y", xe);
         }
-        else if (xe.type.typeCode() == NT_HASH)
+        else if (xe.type.typeCode() == NT_HASH) {
             xe.type = resolveType(xe.type);
+           # printf("resolveType(XsdElement), %y\n", xe.type.name);
+        }
     }
 
     private resolveType(XsdTypedData xd) {
         xd.type = resolveType(xd.type);
+     #   printf("resolveType(XsdTypedData), %y\n", xd.type.name);
     }
 
     private resolveType(XsdComplexType ct) {
         ct.simpleType = resolveType(ct.simpleType);
+     #   printf("resolveType(XsdComplexType), %y\n", ct.simpleType.name);
     }
 
     private XsdAbstractType resolveType(hash v) {
-        if (exists v.ns && nsc.isSchema(v.ns))
-            return getBaseType(v.val);
-
-        # find type
-        return tmap.get(v.val);
+        XsdAbstractType rv;
+        if (exists v.ns && nsc.isSchema(v.ns)) {
+            rv = getBaseType(v.val);
+        } else {
+            # find type
+            rv = tmap.get(v.val);
+        }
+        #printf("resolveType(hash), ns: %y, val: %y -> %y\n", v.ns, v.val, rv.name);
+        return rv;
     }
 
     # parse XSD schema types
     private parseTypes(*hash data, any http_client, any http_headers) {
-    parseTypeRecurse++;
-        printf("DEBUG: parseTypes %y\n", parseTypeRecurse); #XXX
-        #printf("DEBUG: parseTypes data: %y, http_client: %y, http_headers: %y\n", data, http_client, http_headers); #XXX
+        #printf("DEBUG: parseTypes data: %y, http_client: %y, http_headers: %y\n", data, http_client, http_headers);
         WSDL::XsdBase::removeNS(\data);
 
         XsdLateResolverHelper unresolved();
@@ -3749,7 +3772,7 @@ printf("DEBUG:done\n"); #exit();
 
             bool usedocns = sa.elementFormDefault == "qualified";
 
-            printf("DEBUG: schema tn: %y\n", schema."^attributes^"."targetNamespace");
+            #printf("DEBUG: schema tn: %y\n", schema."^attributes^"."targetNamespace");
             WSDL::XsdBase::removeNS(\schema);
             #printf("DEBUG: WebService::parseTypes() schema: %y\n", schema);
 
@@ -3775,7 +3798,7 @@ printf("DEBUG:done\n"); #exit();
                     # get schema member name
                     any sk = xh.firstKey();
 
-                    printf("*** DEBUG %y: sk: %y a: %y\n", a.schemaLocation, sk, xh{sk}."^attributes^");
+                    #printf("*** DEBUG %y: sk: %y a: %y\n", a.schemaLocation, sk, xh{sk}."^attributes^");
 
                     # use temporary Namespaces object for import
                     Namespaces n_nsc = nsc;
@@ -3797,12 +3820,12 @@ printf("DEBUG:done\n"); #exit();
             foreach hash st in (schema.simpleType) {
                 XsdSimpleType t(st, nsc, unresolved, usedocns);
                 tmap.add(t);
-                printf("DEBUG: st: %y\n", t.name);
+                #printf("DEBUG: st: %y\n", t.name);
             }
             foreach hash ct in (schema.complexType) {
-                XsdComplexType t(ct, nsc, unresolved, usedocns);     # DEBUG: tady se to toci!
+                XsdComplexType t(ct, nsc, unresolved, usedocns);
                 tmap.add(t);
-                printf("DEBUG: ct: %y\n", t.name);
+                #printf("DEBUG: ct: %y\n", t.name);
             }
             # make element map
             foreach any el in (schema.element) {
@@ -3817,39 +3840,25 @@ printf("DEBUG:done\n"); #exit();
                         if (!et)
                             eattr.type = t;
 
-                        printf("DEBUG: adding element %y type %y\n", attr.name, t);
+                        #printf("DEBUG: adding element %y type %y\n", attr.name, t);
                         element = new WSDL::XsdElement(("^attributes^": eattr), nsc, et, unresolved, usedocns);
                     }
                     else {
-                        printf("DEBUG: adding element %y type %y\n", attr.name, t);
+                        #printf("DEBUG: adding element %y type %y\n", attr.name, t);
                         element = new WSDL::XsdElement(("^attributes^":("name":attr.name)), nsc, t, unresolved, usedocns);
                     }
                 }
                 else {
-                    printf("DEBUG: adding element %y\n", attr.name);
+                    #printf("DEBUG: adding element %y\n", attr.name);
                     element = new WSDL::XsdElement(el, nsc, NOTHING, unresolved, usedocns);
                 }
 
                 emap.add(element);
             }
         }
-printf("tmap\n");flush();
-printf("%y\n", tmap); flush();
-printf("emap\n");flush();
-printf("%y\n", emap); flush();
         # resolve types
-printf("unresolved\n\n");flush();
-printf("%N\n", unresolved); flush();
         map resolveType($1), unresolved.getList();
-printf("unresolved.getlist2\n");flush();
-printf("%y\n", unresolved.getList()); flush();
-printf("emap\n");flush();
-printf("%y\n", emap); flush();
-printf("unresolved2\n");flush();
-printf("%y\n", unresolved); flush();
         unresolved.clearResolved();
-printf("unresolved3\n");flush();
-printf("%y\n", unresolved); flush();
 
         # finalize complex types
         foreach XsdAbstractType t in (tmap.iterator()) {
@@ -3868,18 +3877,14 @@ printf("%y\n", unresolved); flush();
                 ct.finalize(tmap, nsc);
             }
         }
-
-        # resolve types
+ 
         map resolveType($1), unresolved.getList();
-parseTypeRecurse--;
     }
 
     private parseMessages(*softlist message) {
         # parse messages
         foreach hash m in (message) {
             WSMessage msg(m, emap, tmap, nsc);
-printf("msg created\n"); flush();
-printf("m:%N\n", msg);flush();
             foreach string arg in (msg.args.keyIterator()) {
                 #printf("DEBUG: WebService::parseMessages(): %y: %y\n", arg, msg);
                 #printf("DEBUG: WebService::parseMessages(): %y: %y\n", arg, msg.args{arg}.type);
@@ -3888,8 +3893,6 @@ printf("m:%N\n", msg);flush();
             }
             messages.(msg.name) = msg;
         }
-printf("parsemessages done\n"); flush();
-printf("m:%N\n", messages); flush();
     }
 
     private parseService(*softlist svcs) {
@@ -3938,8 +3941,6 @@ printf("m:%N\n", messages); flush();
     private parseBinding(*softlist bindings) {
         foreach hash data in (bindings) {
             WSDL::Binding b(data, nsc, \portType, \idocmap, messages);
-printf("bindingdone\n"); flush();
-printf("m:%N\n", messages);flush();
             binding.(b.getName()) = b;
         }
     }
@@ -3988,7 +3989,6 @@ printf("m:%N\n", messages);flush();
         w.printf("wsdl: %s\n", wsdl_name);
         foreach hash svc in (listServices()) {
             w.printf("  service: %s\n", svc.name);
-            #hash svc = getService(svc_name);
             foreach string port in (keys svc.port) {
                 w.printf("    port: %s\n", port);
                 w.printf("      binding: %s\n", svc.port{port}.binding.name);

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -2035,6 +2035,9 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             } else {
                 return convert_encoding(v.value, enc);
             }
+        } else if (binding{io}.mimeXml) {
+            ct = MimeTypeXml;
+            return make_xml(self{io}.serialize(binding{io}.mimeXml.msgpart, NOTHING, NOTHING, binding{io}.mimeXml.msgpart, h));
         }
     }
 
@@ -2358,7 +2361,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     private:internal *hash deserializeHttpMessage(hash v, hash binding, bool request) {
         string io = request ? "input" : "output";
         *string ct = v."content-type";
-        if (!exists ct) {
+        if (!exists ct && !binding{io}.mimeXml) {
             throw SOAP_DESERIALIZATION_ERROR, sprintf("missing content-type in input hash: %y", v);
         }
         if (binding{io}.urlEncoded) {
@@ -2375,11 +2378,14 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                 WSDLLib::checkContentType(ct, binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
             }
             hash v2;
-            v2{binding{io}.content.part} = v.body;
-            hash h = self{io}.deserialize(NOTHING, v2, binding{io}.content.part);
+            v2{binding{io}.content.msgpart} = v.body;
+            hash h = self{io}.deserialize(NOTHING, v2, binding{io}.content.msgpart);
             string k = h.firstKey();
             h{k}."^value^" = remove h{k};
             h{k}."^attributes^"."^content-type^" = ct;
+            return h;
+        } else if (binding{io}.mimeXml) {
+            *hash h = self{io}.deserialize(NOTHING, v, binding{io}.mimeXml.msgpart);
             return h;
         }
     }
@@ -2483,25 +2489,22 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         }
     }
 
+    #! serializes data into hash with SOAP soup as namespaces etc
+    /**
+     * @param if present then serializes only particular element or part, if NOTHING then serializes all message elements
+     * @param n_name name of output key
+     * @param h data to be serialized
+     */
     hash serialize(*string key, any msginfo, any mpm, string n_name, any h) {
         hash rh;
-        #printf("DEBUG: message %s: h: %y\n", name ,h);
+        #printf("DEBUG: message %s: key: %y, h: %y\n", name , key, h);
 
         foreach string k in (key ? key : args.keyIterator()) {
             any v;
             if (h.hasKey(k))
                 v = remove h{k};
-            else if (pmap{k} && !exists h{k})
+            else if (pmap{k})
                 v = remove h.(pmap{k});
-
-            /*
-            if (!exists h{k}) {
-                if (pmap{k} && !exists h{k})
-                    h{k} = remove h.(pmap{k});
-                else
-                    throw SOAP_SERIALIZATION_ERROR, sprintf("missing message argument %y (got %y instead)", k, h.keys());
-            }
-            */
 
             any hv;
             #printf("DEBUG: arg %y with %y\n", k, args{k});
@@ -2586,8 +2589,9 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
+    #! deserialize message with keys equal to element names and returns hash with root keys according part name
     *hash deserialize(*hash mrh, hash val, *string key) {
-        #printf("DBG WSMessage::deserialize() args: %y pmap: %y val: %y\n", args.keys(), pmap, val); #XXX
+        #printf("DBG WSMessage::deserialize() args: %y pmap: %y key: %y val: %y\n", args.keys(), pmap, key, val);
         hash ro;
 
         foreach string k in (exists key ? key : args.keyIterator()) {
@@ -2597,11 +2601,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             if (v.typeCode() == NT_HASH)
                 XsdBase::removeNS2(\v);
 
-            string rk = k;
-            if (pmap{k} && !args.(pmap{k}))
-                rk = pmap{k};
-
-            ro{rk} = args{k}.element
+            ro{getPartFromElement(k)} = args{k}.element
                 ? args{k}.element.deserialize(tmap, mrh, getValue(mrh, v), present)
                 : args{k}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
         }
@@ -2634,11 +2634,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             any v = remove val{k};
             XsdBase::removeNS2(\v);
 
-            string rk = k;
-            if (pmap{k} && !args.(pmap{k}))
-                rk = pmap{k};
-
-            rh{rk} = args{k}.element ?
+            rh{getPartFromElement(k)} = args{k}.element ?
                 args{k}.element.deserialize(tmap, mrh, v, present) :
                 args{k}.type.deserialize(name, tmap, mrh, getValue(mrh, v));
         }
@@ -2667,13 +2663,32 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         any v;
         if (h.hasKey(key))
             v = h{key};
-        else if (pmap{key} && !exists h{key})
+        else if (pmap{key})
             v = h.(pmap{key});
         rv.value = args{key}.type.serialize(v, False, keepBinary){"^value^"};
         if (v.typeCode() == NT_HASH) {
             rv."content-type" = v."^attributes^"."^content-type^";
         }
         return rv;
+    }
+
+    #! return element name corresponding to partname, if not exists then try return element name otherwise raise exception 
+    /*private in module*/string getElementFromPart(string partname) {
+        hash pmap2;
+        map pmap2{$1.value}=$1.key, pmap.pairIterator();
+        if (pmap2{partname}) {
+            return pmap2{partname};
+        } else if (exists args{partname}) {
+            return partname;
+        } else
+            throw WSDL_ERROR, sprintf("cannot resolve partname %y in message %y", partname, name);
+    }
+    #! return part name corresponding to element name, if not exists then return element name
+    /*private in module*/string getPartFromElement(string ename) {
+        string rk = ename;
+        if (pmap{ename} && !args.(pmap{ename}))
+            rk = pmap{ename};
+        return rk;
     }
 }
 
@@ -2792,6 +2807,13 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
             foreach string io in (("input", "output")) {
                 if (ophash{io}) {
                     WSDL::XsdBase::removeNS(\ophash{io});
+                    if (!exists portTypes{port}.operations{opname}{io}) {
+                        hash hk;
+                        map hk{$1}=True, keys ophash{io};
+                        remove hk.("header", "ns");
+                        if (hk)
+                            throw WSDL_ERROR, sprintf("binding %y for operation %y does not reference %s message in porttype %y",  name, opname, io, port);
+                    }
                     if (exists ophash{io}.body) {
                         # any pa = ophash{io}.body."^attributes^";
                         op{io}.body = ophash{io}.body."^attributes^";
@@ -2799,9 +2821,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
                         delete ophash{io}.body;
                     }
-
-                    if (ophash{io}.("body", "content", "part") && !exists portTypes{port}.operations{opname}{io})
-                        throw WSDL_ERROR, sprintf("cannot assign %s message definition in binding %y for operation %y with no %s: %y", io, name, opname, io, ophash);
 
                     if (exists ophash{io}.multipartRelated) {
                         if (exists op{io}.body)
@@ -2811,7 +2830,7 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                         op{io}.parts = {};
                         WSDL::XsdBase::removeNS(\ophash{io}.multipartRelated);
 
-                        if (!exists ophash{io}.multipartRelated.part)  # TODO: do I need explicite check or is is handled by validator ?
+                        if (!exists ophash{io}.multipartRelated.part)  # TODO: do I need explicite check or is handled by validator ?
                             throw WSDL_ERROR, sprintf("binding %y is missing part definition(s) in %s message definition for operation %y: %y", name, io, opname, ophash);
 
                         foreach any part in (ophash{io}.multipartRelated.part) {
@@ -2859,24 +2878,21 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                             if (!ma.message)
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'message' attribute (attr: %y)", io, name, opname, ma);
 
-                            if (!ma.part)
-                                throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'part' attribute (attr: %y)", io, name, opname, ma);
-
                             hash h = nsc.doType(ma.message);
                             *WSMessage msg = messages.(h.val);
                             if (!exists msg)
                                 throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
 
-                            bool enc  = ma.use == "encoded";
+                            ma.part = checkMessagePart(msg, ma.part, sprintf("header %s operation %y", io, opname));
+                            ma.msgpart = msg.getElementFromPart(ma.part);
+
+                            bool enc = ma.use == "encoded";
                             if (enc != msg.encoded) {
                                 ma.msg = msg.copy();
                                 ma.msg.encoded = enc;
                             } else {
                                 ma.msg = msg;
                             }
-                            hash pmap2;
-                            map pmap2{$1.value}=$1.key, msg.pmap.pairIterator();
-                            ma.msgpart = pmap2{ma.part} ?? ma.part;
                             #printf("DEBUG: match part to message: part: %y, msg.pmap: %y->%y, ma.msgpart: %y\n", ma.part, msg.pmap, pmap2, ma.msgpart);
                             if (op{io}.header) {
                                 if (op{io}.header.typeCode() != NT_LIST) {
@@ -2965,29 +2981,25 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                                 }
                             }
 
-                            if (!exists cnt.part) {
-                                cnt.part = "";
+                            cnt.part = checkMessagePart(portTypes{port}.operations{opname}{io}, cnt.part, sprintf("content %s operation %y", io, opname));
+                            if (exists p) {
+                                if (p != cnt.part) {
+                                    throw WSDL_ERROR, sprintf("ambiguous part %y in message %y in binding %y for %s operation %y", cnt.part, portTypes{port}.operations{opname}{io}.name, name, io, opname);
+                                }
+                            } else {
+                                op{io}.content.part = cnt.part;
+                                op{io}.content.msgpart = portTypes{port}.operations{opname}{io}.getElementFromPart(cnt.part);
+                                p = cnt.part;
                             }
-                            if (exists p && p != cnt.part) {
-                                throw WSDL_ERROR, sprintf("ambiguous part %y in message %y in binding %y for %s operation %y", cnt.part, portTypes{port}.operations{opname}{io}.name, name, io, opname);
-                            }
-                            p = cnt.part;
                         }
 
-                        if (exists p) {
-                            if (p == "") {
-                                if (portTypes{port}.operations{opname}{io}.args.size() != 1) {
-                                    throw WSDL_ERROR, sprintf("multiple parts %y in message %y in binding %y for %s operation %y", keys portTypes{port}.operations{opname}{io}.args, portTypes{port}.operations{opname}{io}.name, name, io, opname);
-                                }
-                                p = portTypes{port}.operations{opname}{io}.args.firstKey();
-                            } else {
-                                if (!exists portTypes{port}.operations{opname}{io}.args{p}) {
-                                    throw WSDL_ERROR, sprintf("missing part %y in message %y in binding %y for %s operation %y", p, portTypes{port}.operations{opname}{io}.name, name, io, opname);
-                                }
-                            }
-                            op{io}.content.part = p;
-                        }
                         delete ophash{io}.content;
+                    }
+
+                    if (ophash{io}.hasKey("mimeXml")) {
+                        op{io}.mimeXml.part = checkMessagePart(portTypes{port}.operations{opname}{io}, ophash{io}.mimeXml."^attributes^".part, sprintf("%s operation %y", io, opname));
+                        op{io}.mimeXml.msgpart = portTypes{port}.operations{opname}{io}.getElementFromPart(op{io}.mimeXml.part);
+                        delete ophash{io}.mimeXml;
                     }
 
                     delete ophash{io}.("^attributes^", "ns");
@@ -3013,6 +3025,19 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
         #binding = data;
     }
 
+    #! check if part exists in massage, if part is empty and message contains single part then return it otherwise raise exceptio
+    private:internal string checkMessagePart(WSMessage msg, *string partname, string errs) {
+        if (!msg.args)
+            throw WSDL_ERROR, sprintf("message %y has no part, binding %y, %s", msg.name, name, errs);
+        if (!exists partname) {
+            if (msg.args.size() == 1) {
+                partname = msg.getPartFromElement(msg.args.firstKey());
+            } else {
+                throw WSDL_ERROR, sprintf("message %y is multiparted so the part must be defined, binding %y, %s", msg.name, name, errs);
+            }
+        }
+        return partname;
+    }
 
     string getPort() {
         return port;
@@ -3504,14 +3529,24 @@ public class WSDL::WebService inherits WSDL::XsdBase {
         throw "WSDL-OPERATION-ERROR", sprintf("cannot retrieve operation %y; known operations: %y", opname, l);
     }
 
-    #! returns the given operation or throws an exception if it cannot be found
-    WSOperation getOperation(string port, string opname) {
-        *WSOperation op = portType{port}.operations{opname};
+    #! returns the given operation for particular porttype or throws an exception if it cannot be found
+    WSOperation getPortTypeOperation(string ptname, string opname) {
+        *WSOperation op = portType{ptname}.operations{opname};
         if (op)
             return op;
-        if (!portType{port})
-            throw "WSDL-OPERATION-ERROR", sprintf("port %y is not a defined port; known ports: %y", port, portType.keys());
-        throw "WSDL-OPERATION-ERROR", sprintf("operation %y is not known in port %y; known operations: %y", opname, port, portType{port}.operations.keys());
+        if (!portType{ptname})
+            throw "WSDL-OPERATION-ERROR", sprintf("port %y is not a defined port; known ports: %y", ptname, portType.keys());
+        throw "WSDL-OPERATION-ERROR", sprintf("operation %y is not known in port %y; known operations: %y", opname, ptname, portType{ptname}.operations.keys());
+    }
+
+    #! returns the given operation for particular binding or throws an exception if it cannot be found
+    WSOperation getBindingOperation(*string bname, string opname) {
+        if (!exists bname) {
+            return getOperation(opname);
+        } else {
+            WSDL::Binding b = getBinding(bname);
+            return getPortTypeOperation(b.getPort(), opname);
+        }
     }
 
     #! returns a list of hashes giving supported operation names for each port in the WSDL

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -29,7 +29,7 @@
 %requires xml
 
 # need mime definitions
-%requires Mime >= 1.1
+%requires Mime >= 1.3.4.1
 
 # do not use $ for vars
 %new-style
@@ -391,7 +391,7 @@ public class WSDL::WSDLLib {
     #! takes a hash representation returned by parseMultiPartSOAPMessage and parses it to a Qore data structure, checks the content-type, and handles hrefs in the message
     static hash parseSOAPMessage(hash msg) {
         # check content-type
-        WSDLLib::checkSOAPContentType(msg."content-type");
+        WSDLLib::checkContentType(msg."content-type", SoapMimeTypes);
         hash xmldata = parse_xml(msg.body);
         if (msg.parts) {
             # parse entire data structure to find "href"s or href attributes
@@ -400,13 +400,13 @@ public class WSDL::WSDLLib {
         return xmldata;
     }
 
-    private static checkSOAPContentType(string ct) {
-        foreach string sct in (SoapMimeTypes) {
+    private static checkContentType(string ct, list MimeTypes) {
+        foreach string sct in (MimeTypes) {
             if (bindex(ct, sct) != -1)
                 return;
         }
 
-        throw "SOAP-MESSAGE-ERROR", sprintf("don't know how to handle content-type %y (expecting one of: %y)", ct, SoapMimeTypes);
+        throw "SOAP-MESSAGE-ERROR", sprintf("don't know how to handle content-type %y (expecting one of: %y)", ct, MimeTypes);
     }
 
     private static processHref(reference xmldata, string hr, hash parts) {
@@ -1954,6 +1954,35 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return rh;
     }
 
+    #! serializes path part of URL.
+    *string serializePath(any h, hash binding) {
+        string path;
+        if (binding.location) {
+            path = binding.location;
+            if (binding.input.urlReplacement) {
+                path = "";
+                foreach string k in (keys binding.input.urlReplacement) {
+                    if (k =~ /^string/) {
+                        path += binding.input.urlReplacement{k};
+                    } else if (k =~ /^part/) {
+                        if (!input) {
+                            throw SOAP_SERIALIZATION_ERROR, sprintf("url replacement requested for operation %s with no message (%y)", name, h);
+                        }
+                        hash v = input.getNameValue(binding.input.urlReplacement{k}, h);
+                        path += encode_url(v.firstValue(), True);
+                    }
+                }
+            } else if (binding.input.urlEncoded) {
+                string s = input.serializeAsUrlEncodedString(h);
+                if (s) {
+                    path += binding.location =~ /\?/ ? "&" : "?";
+                    path += s;
+                }
+            }
+        }
+        return path;
+    }
+
     #! serializes a request to an XML string for the operation
     /** @param h the request to serialize
         @param bname SOAP binding name or empty to get the first assigned binding
@@ -1966,6 +1995,8 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         @return a hash with keys:
         - \c body: XML string in the SOAP request format
         - \c hdr: hash of HTTP headers
+        - \c path: the path part of URL
+        - \c method: the HTTP request method
         */
     hash serializeRequest(any h, *string bname, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
         hash binding = getBinding(bname);
@@ -1973,38 +2004,60 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (!exists req_soapaction)
             req_soapaction = bindings{name}.soapAction;
 
-        MultiPartRelatedMessage mpm;
-        string body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
-
-        if (mpm) {
-            mpm.splicePart(body, sprintf("<%s>", binding.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
-
-            hash rv = mpm.getMsgAndHeaders();
-            if (req_soapaction) {
-                if (nsc.hasSoap12())
-                    rv.hdr."Content-Type" += sprintf(";action: %s", req_soapaction);
-                rv.hdr += ("SOAPAction": req_soapaction);
-            }
-
-            rv.hdr."Content-Type" += sprintf(";charset=%s", exists enc ? enc : get_default_encoding());
-            return rv;
-        }
-
         string ct;
         if (nsc.hasSoap12()) {
             ct = MimeTypeSoapXml;
             if (req_soapaction)
                 ct += sprintf(";action: %s", req_soapaction);
-        }
-        else
+        } else
             ct = MimeTypeXml;
 
-        ct += sprintf(";charset=%s", exists enc ? enc : get_default_encoding());
+        enc = enc ?? get_default_encoding();
+
+        string body;
+        if (binding.input.content) {
+            ct = binding.input.content.type;
+            if (ct == MimeTypeFormUrlEncoded) {
+                body = input.serializeAsUrlEncodedString(h);
+            } else {
+                if (input.args.size() > 1) {
+                    throw SOAP_SERIALIZATION_ERROR, sprintf("messege %y related to input operation %y has more arguments so it's not possible assign to body", input.name, name);
+                }
+                if (ct !~ /^text\//) {
+                    delete ct;
+                }
+                # TODO: we need return raw value in case of binary
+                hash v = input.getNameValue(binding.input.content.part, h);
+                body = v.firstValue();
+            }
+        } else {
+            MultiPartRelatedMessage mpm;
+            body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
+            if (mpm) {
+                mpm.splicePart(body, sprintf("<%s>", binding.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
+
+                hash rv = mpm.getMsgAndHeaders();
+                if (req_soapaction) {
+                    if (nsc.hasSoap12())
+                        rv.hdr."Content-Type" += sprintf(";action: %s", req_soapaction);
+                    rv.hdr += ("SOAPAction": req_soapaction);
+                }
+
+                rv.hdr."Content-Type" += sprintf(";charset=%s", enc);
+                return rv;
+            }
+        }
+
+        if (exists enc) {
+            ct += sprintf(";charset=%s", enc);
+        }
 
         hash rv = (
             "hdr": ("Content-Type": ct),
             "body": body,
-            );
+            "path": serializePath(h, binding),
+            "method": binding.httpMethod ?? "POST",
+        );
 
         if (req_soapaction)
             rv.hdr += ("SOAPAction": req_soapaction);
@@ -2387,7 +2440,6 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
                     XsdBase::removeNS2(\val);
 
                 string ons;
-printf("args{key}: %N\n", args{key});
                 any th = args{key}.element.serialize(val, !encoded, key, name);
                 ons = nsc.getOutputNamespacePrefix(args{key}.element.ns);
                 rh.(ons + ":" + args{key}.element.name) = th;
@@ -2463,6 +2515,31 @@ printf("args{key}: %N\n", args{key});
 
         #printf("DBG WSMessage::deserializeDocument() args: %y val: %y\nRH: %y\n", args.keys(), val, rh);
         return rh;
+    }
+
+    hash getNameValue(*string key, any h) {
+        hash rv;
+        foreach string k in (key ? key : args.keyIterator()) {
+            if (args{k}.element) {
+                throw SOAP_SERIALIZATION_ERROR, sprintf("cannot get element value %y in message %y. Type part is needed", k, name);
+            }
+            any v;
+            if (h.hasKey(k))
+                v = h{k};
+            else if (pmap{k} && !exists h{k})
+                v = h.(pmap{k});
+            rv{k} = args{k}.type.serialize(v, True);
+        }
+        return rv;
+    }
+
+    string serializeAsUrlEncodedString(any h) {
+        hash nv = getNameValue(NOTHING, h);
+        list l;
+        foreach string k in (keys nv) {
+            push l, encode_url(k, True) + "=" + encode_url(nv{k}, True);
+        }
+        return l.join("&");
     }
 }
 
@@ -2581,7 +2658,6 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
             foreach string io in (("input", "output")) {
                 if (ophash{io}) {
                     WSDL::XsdBase::removeNS(\ophash{io});
-
                     if (exists ophash{io}.body) {
                         # any pa = ophash{io}.body."^attributes^";
                         op{io}.body = ophash{io}.body."^attributes^";
@@ -2675,12 +2751,38 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                         delete ophash{io}.header;
                     }
 
-                    if (exists ophash{io}.urlReplacement) {
-                        op{io}.urlReplacement = True;
+                    if (ophash{io}.hasKey("urlReplacement")) {
+                        string loc = op.location;
+                        int i = 0;
+                        hash l;
+                        while (i < loc.size()) {
+                            int j = index(loc, "(", i);
+                            if (j < 0) {
+                                j = loc.size();
+                            }
+                            if (j > i) {
+                                l{sprintf("string^%d", l.size()+1)} = substr(loc, i, j-i);
+                            }
+                            if (j < loc.size()) {
+                                i = j+1;
+                                j = index(loc, ")", i);
+                                if (j == i) {
+                                    throw WSDL_ERROR, sprintf("empty replace token in %y near %y", loc, substr(loc, i-1, loc.size()));
+                                } else if (j < 0) {
+                                    throw WSDL_ERROR, sprintf("missing close parentheses in %y near %y", loc, substr(loc, i-1, loc.size()));
+                                }
+                                string p = substr(loc, i, j-i);
+                                # if (messages)   TODO test messages / part here probably not ?
+                                l{sprintf("part^%d", l.size()+1)} = p;
+                                j++;
+                            }
+                            i = j;
+                        }
+                        op{io}.urlReplacement = l;
                         delete ophash{io}.urlReplacement;
                     }
 
-                    if (exists ophash{io}.urlEncoded) {
+                    if (ophash{io}.hasKey("urlEncoded")) {
                         op{io}.urlEncoded = True;
                         delete ophash{io}.urlEncoded;
                     }
@@ -2689,12 +2791,13 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                         op{io}.contents = ();
                         foreach any cnt in (ophash{io}.content) {
                             WSDL::XsdBase::removeNS(\cnt);
+                            cnt = remove cnt."^attributes^";
                             if (!cnt.type) {
                                 cnt.type = "*/*";
                             }
                             push op{io}.contents, cnt;
                         }
-                        # delete ophash{io}.content;  TODO: implement later
+                        delete ophash{io}.content;
                     }
 
                     delete ophash{io}.("^attributes^", "ns");
@@ -2705,6 +2808,28 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                 }
             }
 
+            if (op.input.contents) {
+                if (op.input.contents.size() > 1) {
+                    throw WSDL_ERROR, sprintf("multiple content types in binding %y for input operation %y", name, opname);
+                }
+                op.input.content = op.input.contents[0];
+                remove op.input.contents;
+                if (op.input.content.type != MimeTypeFormUrlEncoded) {
+                    if (exists op.input.content.part) {
+                        if (!exists portTypes{port}.operations{opname}.input.args{op.input.content.part}) {
+                            throw WSDL_ERROR, sprintf("missing part %y in message %y in binding %y for input operation %y", op.input.content.part, portTypes{port}.operations{opname}.input.name, name, opname);
+                        }
+                    } else {
+                        if (portTypes{port}.operations{opname}.input.args.size() != 1) {
+                            throw WSDL_ERROR, sprintf("multiple parts %y in message %y in binding %y for input operation %y", keys portTypes{port}.operations{opname}.input.args, portTypes{port}.operations{opname}.input.name, name, opname);
+                        }
+                        op.input.content.part = portTypes{port}.operations{opname}.input.args.firstKey();
+                    }
+                }
+            }
+            if (op.output.contents) {
+                throw WSDL_ERROR, sprintf("content types in binding %y for output operation %y is not yet supported", name, opname);
+            }
             portTypes{port}.operations{opname}.addBinding(name,
                 (
                 "httpMethod": httpMethod,

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1108,8 +1108,6 @@ public class WSDL::XsdElement inherits WSDL::XsdTypedData {
     */
 
     any serialize(any h, *softbool omitType, string key, string typename) {
-        if (type.typeCode() == NT_HASH)
-            printf("ERROR: %y\n", self);
 
         if (h."^type^" && h."^type^" instanceof XsdAbstractType && h.hasKey("^val^")) {
             XsdAbstractType ntype = cast<XsdAbstractType>(h."^type^");
@@ -2336,11 +2334,17 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         }
 
         if (exists hrv) {
-            foreach my string k in (keys hrv) {
-                if (exists rv{k}) {
-                    # name conflict
-                    rv{self{io}.name} = rv;
-                    break;
+            # for backwards compatibility with a flat hash when there was only argument
+            # but we must be care of when the argument is a type (not element)
+            if (rv.size() == 1 && rv.typeCode() == NT_HASH && !exists hrv{rv.firstKey()} ) {
+                rv = rv.firstValue();
+            } else {
+                foreach my string k in (keys hrv) {
+                    if (exists rv{k}) {
+                        # name conflict
+                        rv{self{io}.name} = rv;
+                        break;
+                    }
                 }
             }
             rv += hrv;
@@ -3747,18 +3751,18 @@ public class WSDL::WebService inherits WSDL::XsdBase {
         }
         else if (xe.type.typeCode() == NT_HASH) {
             xe.type = resolveType(xe.type);
-           # printf("resolveType(XsdElement), %y\n", xe.type.name);
+            #printf("resolveType(XsdElement), %y\n", xe.type.name);
         }
     }
 
     private resolveType(XsdTypedData xd) {
         xd.type = resolveType(xd.type);
-     #   printf("resolveType(XsdTypedData), %y\n", xd.type.name);
+        #printf("resolveType(XsdTypedData), %y\n", xd.type.name);
     }
 
     private resolveType(XsdComplexType ct) {
         ct.simpleType = resolveType(ct.simpleType);
-     #   printf("resolveType(XsdComplexType), %y\n", ct.simpleType.name);
+        #printf("resolveType(XsdComplexType), %y\n", ct.simpleType.name);
     }
 
     private XsdAbstractType resolveType(hash v) {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -149,7 +149,7 @@ public namespace WSDL {
                 "xmlns:xsi": XSI_NS,
             ),
         ),
-        );
+    );
 
     #! soap 1.2 envelope namespaces
     public const ENVELOPE_12_NS = (
@@ -160,7 +160,7 @@ public namespace WSDL {
               "xmlns:xsi": XSI_NS,
             ),
         ),
-        );
+    );
 
     #! soap encoding URI
     public const SOAP_ENCODING = "http://schemas.xmlsoap.org/soap/encoding/";
@@ -175,7 +175,7 @@ public namespace WSDL {
         Type::NothingType : "string",
         Type::NullType    : "string",
         Type::Binary      : "base64Binary",
-        );
+    );
 
     # error codes
     const SOAP_SERIALIZATION_ERROR = "SOAP-SERIALIZATION-ERROR";
@@ -1851,6 +1851,52 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return b;
     }
 
+    private hash serializeSoapMessage(any h, Binding binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
+        string io = request ? "input" : "output";
+        # setup namespaces for SOAP envelope
+        hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
+        string soapenvEnvelope = rh.firstKey();
+        rh{soapenvEnvelope}."^attributes^" += nsc.getOutputNamespaceHash(nsh);
+        if (header) {
+            #printf("DEBUG %s header: %y\n", io, header);
+
+            if (binding.operations{name}{io}.header.typeCode() == NT_LIST) {
+                throw "WSDL-BINDING-ERROR", sprintf("multi headers not yet implemented");  # TODO
+            }
+            *hash hdr = binding.operations{name}{io}.header;
+            hash h;
+            if (hdr) {
+                hash hh.(hdr.part) = header;
+                h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hh);
+            } else {
+                h = header;
+            }
+            rh{soapenvEnvelope}."soapenv:Header" = h;
+        }
+
+        # do we have mime/multipart io format?
+        if (exists binding.operations{name}{io}.multipart)
+            mpm = new MultiPartRelatedMessage();
+
+        #printf("DEBUG: docstyle: %y\n", binding.operations{name}.docstyle);
+        if (self{io}) {
+            *hash body;
+            if (binding.operations{name}.docstyle)
+                body = self{io}.serializeDocument(NOTHING, binding.operations{name}{io}, mpm, h);
+            else {
+                string mname = input_name ? input_name : name + (request ? "":"Response");
+                if (binding.operations{name}{io})
+                    body = self{io}.serialize(binding.operations{name}{io}, mpm, mname, h);
+            }
+            if (body) {
+                rh{soapenvEnvelope}."soapenv:Body" = body;
+            }
+        } else if (exists h)
+            throw SOAP_SERIALIZATION_ERROR, sprintf("%s value provided for operation %y with no %s message (%y)", request?"request":"response", name, io, h);
+
+        return rh;
+    }
+
     #! serializes a request to an XML string for the operation
     /** @param h the request to serialize
         @param binding SOAP binding
@@ -1865,46 +1911,12 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c hdr: hash of HTTP headers
         */
     hash serializeRequest(any h, Binding binding, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
-        # setup namespaces for SOAP envelope
-        hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
 
         if (!exists req_soapaction)
             req_soapaction = bindings{name}.soapAction;
 
-        rh."soapenv:Envelope"."^attributes^" += nsc.getOutputNamespaceHash(nsh);
-
-        #printf("DEBUG header: %y\n", header);
-
-        if (header) {
-            *hash hdr = binding.operations{name}.input.header;
-            if (hdr) {
-                hash hh.(hdr.part) = header;
-                rh."soapenv:Envelope"."soapenv:Header" = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hh);
-            }
-            else {
-                rh."soapenv:Envelope"."soapenv:Header" = header;
-            }
-        }
-
         MultiPartRelatedMessage mpm;
-        # do we have mime/multipart input format?
-        if (exists binding.operations{name}.input.multipart)
-            mpm = new MultiPartRelatedMessage();
-
-        #printf("DEBUG: docstyle: %y\n", binding.operations{name}.docstyle);
-        if (input) {
-            if (binding.operations{name}.docstyle)
-                rh."soapenv:Envelope"."soapenv:Body" = input.serializeDocument(NOTHING, binding.operations{name}.input, mpm, h);
-            else {
-                string mname = input_name ? input_name : name;
-                if (input)
-                    rh."soapenv:Envelope"."soapenv:Body" = input.serialize(binding.operations{name}.input, mpm, mname, h);
-            }
-        }
-        else if (exists h)
-            throw SOAP_SERIALIZATION_ERROR, sprintf("request value provided for operation %y with no input message (%y)", name, h);
-
-        string body = make_xml(rh, xml_opts, enc);
+        string body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
 
         if (mpm) {
             mpm.splicePart(body, sprintf("<%s>", binding.operations{name}.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
@@ -1974,40 +1986,13 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         else
             soap12 = nsc.hasSoap12();
 
-        # setup namespaces for SOAP envelope
-        hash rh = soap12 ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
-
-        rh."soapenv:Envelope"."^attributes^" += nsc.getOutputNamespaceHash(nsh);
-
-        if (header) {
-            *hash hdr = binding.operations{name}.output.header;
-            if (hdr) {
-                hash hh.(hdr.part) = header;
-                rh."soapenv:Envelope"."soapenv:Header" = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hh);
-            }
-            else {
-                rh."soapenv:Envelope"."soapenv:Header" = header;
-            }
-        }
 
         MultiPartRelatedMessage mpm;
         # do we have mime/multipart output format?
         if (exists binding.operations{name}.output.multipart)
             mpm = new MultiPartRelatedMessage();
 
-        #printf("DEBUG: docstyle: %y\n", binding.operations{name}.docstyle);
-        if (output) {
-            if (binding.operations{name}.docstyle)
-                rh."soapenv:Envelope"."soapenv:Body" = output.serializeDocument(NOTHING, binding.operations{name}.output, mpm, h);
-            else {
-                string mname = input_name ? input_name : name + "Response";
-                rh."soapenv:Envelope"."soapenv:Body" = output.serialize(binding.operations{name}.output, mpm, mname, h);
-            }
-        }
-        else if (exists h)
-            throw SOAP_SERIALIZATION_ERROR, sprintf("response value provided for operation %y with no outut message (%y)", name, h);
-
-        string body = make_xml(rh, xml_opts, enc);
+        string body = make_xml(serializeSoapMessage(h, binding, header, nsh, False, soap12, \mpm), xml_opts, enc);
 
         string ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
         if (exists mpm) {
@@ -2606,23 +2591,31 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
                     if (ophash{io} && !exists portTypes{port}.operations{opname}{io})
                         throw WSDL_ERROR, sprintf("cannot assign %s message definition in binding %y for operation %y with no %io: %y", io, name, opname, io, ophash);
 
-                    if (exists ophash{io}.header) {   # TODO: one or multi headers ?
-                        *hash ma = ophash{io}.header."^attributes^";
+                    if (exists ophash{io}.header) {
+                        foreach hash hdr in (ophash{io}.header) {
+                            *hash ma = ophash{io}.header."^attributes^";
 
-                        if (!ma.message)
-                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'message' attribute (attr: %y)", io, name, opname, ma);
+                            if (!ma.message)
+                                throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'message' attribute (attr: %y)", io, name, opname, ma);
 
-                        if (!ma.part)
-                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'part' attribute (attr: %y)", io, name, opname, ma);
+                            if (!ma.part)
+                                throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'part' attribute (attr: %y)", io, name, opname, ma);
 
-                        hash h = nsc.doType(ma.message);
-                        *WSMessage msg = messages.(h.val);
-                        if (!exists msg)
-                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
+                            hash h = nsc.doType(ma.message);
+                            *WSMessage msg = messages.(h.val);
+                            if (!exists msg)
+                                throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
 
-
-                        op{io}.header = ma;
-                        op{io}.header.encoded = ma.use == "encoded";   # TODO: move to WSOperation ???
+                            ma.encoded = ma.use == "encoded";   # TODO: move to WSOperation ???
+                            if (op{io}.header) {
+                                if (op{io}.header.typeCode() != NT_LIST) {
+                                    op{io}.header = () + op{io}.header;
+                                }
+                                op{io}.header += ma;
+                            } else {
+                                op{io}.header = ma;
+                            }
+                        }
                         delete ophash{io}.header;
                     }
 
@@ -2666,6 +2659,14 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
     string getPort() {
         return port;
+    }
+
+    bool isSoapBinding() {
+        return exists soapTransport;
+    }
+
+    bool isHttpBinding() {
+        return exists httpMethod;
     }
 }
 

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1838,14 +1838,14 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return request_name ? request_name : name;
     }
 
-    /** @param name the name of the binding
+    /** @param name the name of the binding, if not provided then uses the first assigned binding
 
         @return a @ref WSDL::Binding object
 
         @throw WSDL-BINDING-ERROR unknown binding
      */
-    WSDL::Binding getBinding(string bname) {
-        *Binding b = bindings{bname};
+    WSDL::Binding getBinding(*string bname) {
+        *Binding b = exists bname ? bindings{bname} : bindings.firstValue();
         if (!b)
             throw "WSDL-BINDING-ERROR", sprintf("binding %y is not a known binding for operation %y; known bindings: %y", bname, name, bindings.keys());
         return b;
@@ -1869,7 +1869,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
 
         if (!exists req_soapaction)
-            req_soapaction = bindings.operations{name}.soapAction;
+            req_soapaction = bindings{name}.soapAction;
 
         rh."soapenv:Envelope"."^attributes^" += nsc.getOutputNamespaceHash(nsh);
 
@@ -1943,7 +1943,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
-        return serializeRequest(h, bindings.firstValue(), header, enc, nsh, xml_opts, req_soapaction);
+        return serializeRequest(h, getBinding(), header, enc, nsh, xml_opts, req_soapaction);
 
     }
 
@@ -2024,7 +2024,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
-        return serializeResponse(h, bindings.firstValue(), header, enc, nsh, soap12, xml_opts);
+        return serializeResponse(h, getBinding(), header, enc, nsh, soap12, xml_opts);
     }
 
     private list processMultiRef(hash body) {
@@ -2119,7 +2119,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     any deserializeRequest(hash o) {
-        return deserializeRequest(o, bindings.firstValue());
+        return deserializeRequest(o, getBinding());
     }
 
     #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
@@ -2190,7 +2190,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     any deserializeResponse(hash o) {
-        return deserializeResponse(o, bindings.firstValue());
+        return deserializeResponse(o, getBinding());
     }
 
     private hash processNSValue(hash h) {
@@ -3449,7 +3449,7 @@ public class WSDL::WebService inherits WSDL::XsdBase {
 
     private parseBinding(*softlist bindings) {
         foreach hash data in (bindings) {
-            WSDL::Binding b(data, nsc, \portType, \idocmap, messages);   # TODO: portType reference when I need modify inner object ?
+            WSDL::Binding b(data, nsc, \portType, \idocmap, messages);
             binding.(b.getName()) = b;
         }
     }

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1968,6 +1968,37 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return rh;
     }
 
+
+    private *data serializeHttpMessage(any h, hash binding, bool request, reference ct, reference enc) {
+        string io = request ? "input" : "output";
+        if (binding{io}.content.formUrlEncoded) {
+            ct = MimeTypeFormUrlEncoded;
+            # application/x-www-form-urlencoded Content-Type does not have any parameters
+            delete enc;
+            # TODO: throws exception when character is > 127, discussed e.g. https://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
+            return mime_get_form_urlencoded_string(self{io}.getNameValue(NOTHING, h));
+        } else if (binding{io}.content) {
+            hash v = self{io}.resolveValue(binding{io}.content.part, h, True);
+            if (v."content-type") {
+                if (!binding{io}.content.acceptAllContentTypes) {
+                    WSDLLib::checkContentType(v."content-type", binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
+                }
+                ct = v."content-type";
+            } else {
+                if (binding{io}.content.acceptAllContentTypes || binding{io}.content.acceptedContentTypes || binding{io}.content.acceptedContentTypeSubtypes.size() != 1) {
+                    throw SOAP_SERIALIZATION_ERROR, sprintf("ambiguous content type in message %y related to %s operation %y", self{io}.name, io, name);
+                }
+                ct = binding{io}.content.acceptedContentTypeSubtypes[0];
+            }
+            if (v.value.typeCode() == NT_BINARY) {
+                delete enc;
+                return v.value;
+            } else {
+                return convert_encoding(v.value, enc);
+            }
+        }
+    }
+
     #! serializes path part of URL.
     *string serializePath(any h, hash binding) {
         string path;
@@ -2034,32 +2065,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         );
 
         if (binding.httpMethod) {
-            if (binding.input.content.formUrlEncoded) {
-                ct = MimeTypeFormUrlEncoded;
-                # TODO: throws exception when character is > 127, discussed e.g. https://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
-                rv.body = mime_get_form_urlencoded_string(input.getNameValue(NOTHING, h));
-                # application/x-www-form-urlencoded Content-Type does not have any parameters
-                delete enc;
-            } else if (binding.input.content) {
-                hash v = input.resolveValue(binding.input.content.part, h, True);
-                if (v."content-type") {
-                    if (!binding.input.content.acceptAllContentTypes) {
-                        WSDLLib::checkContentType(v."content-type", binding.input.content.acceptedContentTypeSubtypes + binding.input.content.acceptedContentTypes);
-                    }
-                    ct = v."content-type";
-                } else {
-                    if (binding.input.content.acceptAllContentTypes || binding.input.content.acceptedContentTypes || binding.input.content.acceptedContentTypeSubtypes.size() != 1) {
-                        throw SOAP_SERIALIZATION_ERROR, sprintf("ambiguous content type in message %y related to input operation %y", input.name, name);
-                    }
-                    ct = binding.input.content.acceptedContentTypeSubtypes[0];
-                }
-                if (v.value.typeCode() == NT_BINARY) {
-                    rv.body = v.value;
-                    delete enc;
-                } else {
-                    rv.body = convert_encoding(v.value, enc);
-                }
-            }
+            rv.body = serializeHttpMessage(h, binding, True, \ct, \enc);
         } else {
             MultiPartRelatedMessage mpm;
             rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, True, nsc.hasSoap12(), \mpm), xml_opts, enc);
@@ -2118,26 +2124,33 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         else
             soap12 = nsc.hasSoap12();
 
+        enc = enc ?? get_default_encoding();
+        hash rv;
+        string ct;
 
-        MultiPartRelatedMessage mpm;
-        # do we have mime/multipart output format?
-        if (exists binding.output.multipart)
-            mpm = new MultiPartRelatedMessage();
+        if (binding.httpMethod) {
+            rv.body = serializeHttpMessage(h, binding, False, \ct, \enc);
+        } else {
+            MultiPartRelatedMessage mpm;
+            # do we have mime/multipart output format?
+            if (exists binding.output.multipart)
+                mpm = new MultiPartRelatedMessage();
 
-        string body = make_xml(serializeSoapMessage(h, binding, header, nsh, False, soap12, \mpm), xml_opts, enc);
+            rv.body = make_xml(serializeSoapMessage(h, binding, header, nsh, False, soap12, \mpm), xml_opts, enc);
 
-        string ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
-        if (exists mpm) {
-            mpm.splicePart(body, sprintf("<%s>", binding.output.body.parts), ct);
-            return mpm.getMsgAndHeaders();
+            ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
+            if (exists mpm) {
+                mpm.splicePart(rv.body, sprintf("<%s>", binding.output.body.parts), ct);
+                return mpm.getMsgAndHeaders();
+            }
         }
 
-        ct += sprintf(";charset=%s", exists enc ? enc : get_default_encoding());
+        if (exists enc) {
+            ct += sprintf(";charset=%s", enc);
+        }
 
-        return (
-            "hdr": ("Content-Type": ct),
-            "body": body,
-            );
+        rv.hdr = ("Content-Type": ct);
+        return rv;
     }
 
     hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
@@ -2198,12 +2211,13 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return (mrh, body);
     }
 
-    hash parseSOAPMessage(hash msg, *string bname) {
+    hash parseSOAPMessage(hash msg, *string bname, bool request) {
+        string io = request ? "input": "output";
         hash binding = getBinding(bname);
         if (binding.httpMethod) {
             string ct = (msg."content-type" =~ x/^([^;]+)/)[0];
-            if (!binding.output.content.acceptAllContentTypes)
-                WSDLLib::checkContentType(ct, binding.output.content.acceptedContentTypeSubtypes + binding.output.content.acceptedContentTypes);
+            if (!binding{io}.acceptAllContentTypes)
+                WSDLLib::checkContentType(ct, binding{io}.content.acceptedContentTypeSubtypes + binding{io}.content.acceptedContentTypes);
             if (msg."content-type" =~ /charset=/) {
                 string c = (msg."content-type" =~ x/charset=([^;]+)/)[0];
                 msg.body = force_encoding(msg.body, c);

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -335,7 +335,7 @@ public class WSDL::WSDLLib {
                     hh{hi} = ha;
                 }
                 if (!exists hh."content-id")
-                    throw "SOAP-MESSAGE-ERROR", sprintf("expecting part header Content-ID in part %d; headers: %y", i, hh);
+                    throw "SOAP-MCESSAGE-ERROR", sprintf("expecting part header Content-ID in part %d; headers: %y", i, hh);
 
                 any b;
                 if (hh."content-transfer-encoding" == "binary") {
@@ -1920,23 +1920,23 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             hash outh;
             *hash header2 = header;  # non processed values will be added to soap header
             foreach hash hdr in (binding{io}.header) {
-                /*printf("DEBUG: hdr.message/part/msgpart: %y/%y/%y, exists: %y,%y,%y,%y, %y\n", hdr.message, hdr.part, hdr.msgpart,
-                       exists header{hdr.message}, exists header{hdr.message}{hdr.part},
-                       exists header{hdr.message}{hdr.msgpart}, exists header{hdr.part}, exists header{hdr.msgpart}
+                /*printf("DEBUG: hdr.msg.name/part/msgpart: %y/%y/%y, exists: %y,%y,%y,%y,%y\n", hdr.msg.name, hdr.part, hdr.msgpart,
+                       exists header{hdr.msg.name}, exists header{hdr.msg.name}{hdr.part},
+                       exists header{hdr.msg.name}{hdr.msgpart}, exists header{hdr.part}, exists header{hdr.msgpart}
                 );*/
                 # there is not unique part name space as it may contain parts from more message so let's do a little heuristic
                 any hh;
-                if (exists header{hdr.message} && exists header{hdr.message}{hdr.part}) {
-                    hh = header{hdr.message}{hdr.part};
-                    remove header2{hdr.message}{hdr.part};
-                    if (!header2{hdr.message}) {
-                        remove header2{hdr.message};
+                if (exists header{hdr.msg.name} && exists header{hdr.msg.name}{hdr.part}) {
+                    hh = header{hdr.msg.name}{hdr.part};
+                    remove header2{hdr.msg.name}{hdr.part};
+                    if (!header2{hdr.msg.name}) {
+                        remove header2{hdr.msg.name};
                     }
-                } else if (exists header{hdr.message} && exists header{hdr.message}{hdr.msgpart}) {
-                    hh = header{hdr.message}{hdr.msgpart};
-                    remove header2{hdr.message}{hdr.msgpart};
-                    if (!header2{hdr.message}) {
-                        remove header2{hdr.message};
+                } else if (exists header{hdr.msg.name} && exists header{hdr.msg.name}{hdr.msgpart}) {
+                    hh = header{hdr.msg.name}{hdr.msgpart};
+                    remove header2{hdr.msg.name}{hdr.msgpart};
+                    if (!header2{hdr.msg.name}) {
+                        remove header2{hdr.msg.name};
                     }
                 } else if (exists header{hdr.part}) {
                     hh = header{hdr.part};
@@ -2257,28 +2257,24 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         string io = request ? "input" : "output";
         WSDL::XsdBase::removeNS2(\o);
         WSDL::XsdBase::removeNS2(\o.Envelope);
-        hash rv;
+        hash hrv;
         if (binding{io}.header) {
             *hash header = o.Envelope.Header;
             WSDL::XsdBase::removeNS2(\header);
 
             #printf("DEBUG: Deserialize SOAP headers: %N\n", header);
-            hash hrv;
             foreach hash hdr in (binding{io}.header) {
                 if (header.hasKey(hdr.msgpart)) {
                     # seems it may appear part name conflict between messages when namespace is stripped
                     hash v;
                     if (binding.docstyle) {
-                        hrv{hdr.msg.name} += hdr.msg.deserializeDocument(NOTHING, header, hdr.msgpart, True);
+                        hrv{hdr.msg.name} += hdr.msg.deserializeDocument(NOTHING, header, hdr.msgpart);
                     } else {
-                        hrv{hdr.msg.name} += hdr.msg.deserialize(NOTHING, header, hdr.msgpart, True);
+                        hrv{hdr.msg.name} += hdr.msg.deserialize(NOTHING, header, hdr.msgpart);
                     }
                 }
             }
             #printf("DEBUG: Deserialized SOAP headers: %N\n", hrv);
-            if (exists hrv) {
-                rv."^header^" = hrv;
-            }
         }
 
         *hash body = o.Envelope.Body;
@@ -2286,70 +2282,78 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (!self{io}) {
             if (exists body)
                 throw SOAP_DESERIALIZATION_ERROR, sprintf("%s value given for operation %y with no %s message: %y", request ? "request" : "response", name, io, body);
-            return rv;
         }
         else if (!exists body)
             throw SOAP_DESERIALIZATION_ERROR, sprintf("no %s body value given for operation %y", request ? "request" : "response", name);
 
-        (*hash mrh, hash msg) = processMultiRef(body);
+        *hash rv;
+        if (exists body) {
+            (*hash mrh, hash msg) = processMultiRef(body);
 
-        if (!request) {
-            # check for Soap Fault, if so raise an exception immediately with the fault info
-            WSDL::XsdBase::removeNS2(\body);
+            if (!request) {
+                # check for Soap Fault, if so raise an exception immediately with the fault info
+                WSDL::XsdBase::removeNS2(\body);
 
-            if (body.Fault) {
-                WSDL::XsdBase::removeNS(\body.Fault);
-                delete body.Fault.".ns";
-                if (nsc.hasSoap12()) {
-                    WSDL::XsdBase::removeNS(\body.Fault.Code);
-                    WSDL::XsdBase::removeNS(\body.Fault.Reason);
-                    string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.Code.Value);
-                    any sc = body.Fault.Code.Subcode;
-                    while (exists sc) {
-                        WSDL::XsdBase::removeNS(\sc);
-                        desc += sprintf(", subcode: %y", sc.Value);
-                        sc = sc.Subcode;
+                if (body.Fault) {
+                    WSDL::XsdBase::removeNS(\body.Fault);
+                    delete body.Fault.".ns";
+                    if (nsc.hasSoap12()) {
+                        WSDL::XsdBase::removeNS(\body.Fault.Code);
+                        WSDL::XsdBase::removeNS(\body.Fault.Reason);
+                        string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.Code.Value);
+                        any sc = body.Fault.Code.Subcode;
+                        while (exists sc) {
+                            WSDL::XsdBase::removeNS(\sc);
+                            desc += sprintf(", subcode: %y", sc.Value);
+                            sc = sc.Subcode;
+                        }
+                        foreach any rn in (body.Fault.Reason.Text) {
+                            desc += sprintf(", text: %y", rn);
+                        }
+
+                        throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
                     }
-                    foreach any rn in (body.Fault.Reason.Text) {
-                        desc += sprintf(", text: %y", rn);
+                    else {
+                        string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.faultcode);
+                        if (exists body.Fault.faultstring)
+                            desc += sprintf(", faultstring: %y", body.Fault.faultstring);
+                        if (exists body.Fault.desc)
+                            desc += sprintf(", desc: %y", body.Fault.desc);
+
+                        throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
                     }
-
-                    throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
-                }
-                else {
-                    string desc = sprintf("The following fault response was received from the server: code: %y", body.Fault.faultcode);
-                    if (exists body.Fault.faultstring)
-                        desc += sprintf(", faultstring: %y", body.Fault.faultstring);
-                    if (exists body.Fault.desc)
-                        desc += sprintf(", desc: %y", body.Fault.desc);
-
-                    throw "SOAP-SERVER-FAULT-RESPONSE", desc, body.Fault;
                 }
             }
-        }
 
-        #any ns = msg.".ns";
-        msg -= ("ns", ".ns");
-        if (binding.docstyle) {
-            if (exists rv) {
-                return rv + self{io}.deserializeDocument(mrh, msg, NOTHING, True);
+            #any ns = msg.".ns";
+            msg -= ("ns", ".ns");
+            if (binding.docstyle) {
+                rv = self{io}.deserializeDocument(mrh, msg);
             } else {
-                return self{io}.deserializeDocument(mrh, msg);
+
+                string mname = input_name ? input_name : name + (request ? "" : "Response");
+                if (!msg{mname})
+                    throw SOAP_DESERIALIZATION_ERROR, sprintf("missing %s message name %y as top-level element; got elements: %y", io, mname, keys msg);
+                msg = remove msg{mname};
+                XsdBase::removeNS2(\msg);
+                msg -= (".ns", "ns");
+
+                rv = self{io}.deserialize(mrh, msg);
             }
         }
-
-        string mname = input_name ? input_name : name + (request ? "" : "Response");
-        if (!msg{mname})
-            throw SOAP_DESERIALIZATION_ERROR, sprintf("missing %s message name %y as top-level element; got elements: %y", io, mname, keys msg);
-        msg = remove msg{mname};
-        XsdBase::removeNS2(\msg);
-        msg -= (".ns", "ns");
 
         if (exists rv) {
-            return rv + self{io}.deserialize(mrh, msg, NOTHING, True);
-        } else {
-            return self{io}.deserialize(mrh, msg);
+            # for backward compatibility flat hash when there was only argument
+            # but we must be care of when the argument is type (not element) and header is present
+            if (rv.size() == 1 && (rv.firstValue().typeCode() == NT_HASH || !exists hrv)) {
+                rv = rv.firstValue();
+            }
         }
+        if (exists hrv) {
+            rv."^header^" = hrv;
+        }
+
+        return rv;
     }
 
     private *hash deserializeHttpMessage(hash v, hash binding, bool request) {
@@ -2365,7 +2369,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             WSDLLib::checkContentType(ct, list(MimeTypeFormUrlEncoded));
             v.body = binary_to_string(v.body);
             hash h = mime_parse_form_urlencoded_string(v.body); # TODO: data have no encoding
-            return self{io}.deserialize(NOTHING, h, NOTHING, True);
+            return self{io}.deserialize(NOTHING, h, NOTHING);
         } else if (binding{io}.content) {
 
             if (!binding{io}.content.acceptAllContentTypes) {
@@ -2373,7 +2377,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             }
             hash v2;
             v2{binding{io}.content.part} = v.body;
-            hash h = self{io}.deserialize(NOTHING, v2, binding{io}.content.part, True);
+            hash h = self{io}.deserialize(NOTHING, v2, binding{io}.content.part);
             string k = h.firstKey();
             h{k}."^value^" = remove h{k};
             h{k}."^attributes^"."^content-type^" = ct;
@@ -2583,7 +2587,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
         return rh;
     }
 
-    any deserialize(*hash mrh, hash val, *string key, bool keepHash = False) {
+    *hash deserialize(*hash mrh, hash val, *string key) {
         #printf("DBG WSMessage::deserialize() args: %y pmap: %y val: %y\n", args.keys(), pmap, val); #XXX
         hash ro;
 
@@ -2607,10 +2611,10 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             throw SOAP_DESERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", val.keys(), name);
 
         # if there is only one argument, return it directly
-        return (ro.size() == 1 && !keepHash) ? ro.firstValue() : ro;
+        return ro;
     }
 
-    any deserializeDocument(*hash mrh, any val, *string key, bool keepHash = False) {
+    *hash deserializeDocument(*hash mrh, any val, *string key) {
         hash rh;
 
         *hash attr = remove val."^attributes^";
@@ -2644,7 +2648,7 @@ public class WSDL::WSMessage inherits WSDL::XsdNamedData {
             throw SOAP_DESERIALIZATION_ERROR, sprintf("additional keys %y included in %y message hash", val.keys(), name);
 
         #printf("DBG WSMessage::deserializeDocument() args: %y val: %y\nRH: %y\n", args.keys(), val, rh);
-        return (rh.size() == 1 && !keepHash) ? rh.firstValue() : rh;
+        return rh;
     }
 
     hash getNameValue(*string key, any h, *softbool keepBinary) {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1881,9 +1881,12 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return request_name ? request_name : name;
     }
 
-    /** @param name the name of the binding, if not provided then uses the first assigned binding
+    #! returns a hash representing the given binding
+    /** @param bname the name of the binding, if not provided then uses the first assigned binding
 
-        @return a binding param hash
+        @return a binding param hash describing the binding with the following keys:
+        - \c "httpMethod"
+        - \c "soapTransport"
 
         @throw WSDL-BINDING-ERROR unknown binding
      */
@@ -1895,12 +1898,14 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return bindings{bname};
     }
 
+    #! adds the given binding
     /** @param bname binding name, must be unique in operation
-        @param opparams binding getOperationParams
+        @param opparams a hash with the following keys:
+        - \c "httpMethod"
+        - \c "soapTransport"
 
         @throw WSDL-BINDING-ERROR when binding already registered
      */
-
     addBinding(string bname, hash opparams) {
         if (bindings{bname}) {
             throw "WSDL-BINDING-ERROR", sprintf("binding %y is already registered in operation %y", bname, name);
@@ -2064,12 +2069,12 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
     #! serializes a request to an XML string or HTTP payload for the operation.
     /** @param h the request to serialize
-        @param bname SOAP binding name or empty to get the first assigned binding
         @param header optional soap header info to serialize if required (ex: authorization info). In the first step headers are matched to binding/input/header WSDL definition, remaining headers are passed as-is
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh an optional namespace hash for the output message
         @param xml_opts optional XML generation options
         @param req_soapaction if present will override any SOAPAction value for the request
+        @param bname SOAP binding name or empty to get the first assigned binding
 
         @return a hash with keys:
         - \c body: XML string in the SOAP request format or body part of HTTP message (string or binary). Target content type is evaluated from WSDL or in case of ambiguity
@@ -2078,7 +2083,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c path: the path part of URL. Used when urlEncoded is defined
         - \c method: the HTTP request method
         */
-    hash serializeRequest(any h, *string bname, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
+    hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction, *string bname) {
         hash binding = getBinding(bname);
 
         if (!exists req_soapaction)
@@ -2129,25 +2134,21 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return rv;
     }
 
-    hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
-        return serializeRequest(h, NOTHING, header, enc, nsh, xml_opts, req_soapaction);
-    }
-
     #! serializes a SOAP response to an XML string for the operation
     /** @param h the response to serialize
-        @param bname SOAP binding name, leave empty to get the first assigned binding
         @param header SOAP header hash. In the first step headers are matched to binding/input/header WSDL definition, remaining headers are passed as-is
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh namespace hash
         @param soap12 set to True if the response should use SOAP 1.2 encoding
         @param xml_opts optional XML generation options
+        @param bname SOAP binding name, leave empty to get the first assigned binding
 
         @return a hash with keys:
         - \c body: XML string in the SOAP request format or body part of HTTP message (string or binary). Target content type is evaluated from WSDL or in case of ambiguity
         using "^attributes^"."^content-type^". Provided content type must match allowed types in WSDL.
         - \c hdr: hash of HTTP headers
     */
-    hash serializeResponse(any h, *string bname, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
+    hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts, *string bname) {
         hash binding = getBinding(bname);
         if (exists soap12) {
             if (soap12) {
@@ -2192,10 +2193,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         }
 
         return rv;
-    }
-
-    hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
-        return serializeResponse(h, NOTHING, header, enc, nsh, soap12, xml_opts);
     }
 
     private list processMultiRef(hash body) {

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -1914,27 +1914,52 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         bindings{bname} = opparams;
     }
 
-    private:internal hash serializeSoapMessage(any h, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
+    private:internal hash serializeSoapMessage(any val, hash binding, *hash header, *hash nsh, bool request, bool soap12, reference mpm) {
         string io = request ? "input" : "output";
         # setup namespaces for SOAP envelope
-        #printf("DEBUG: serializeSoapMessage: io:%s, h: %y, header: %y, binding: %y\n", io, h, header, binding);
+        #printf("DEBUG: serializeSoapMessage: io:%s, h: %y, header: %y, binding: %y\n", io, val, header, binding);
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
         string soapenvEnvelope = rh.firstKey();
         rh{soapenvEnvelope}."^attributes^" += nsc.getOutputNamespaceHash(nsh);
-        if (header) {
+
+        # do we have mime/multipart io format?
+        if (exists binding{io}.multipart)
+            mpm = new MultiPartRelatedMessage();
+
+        #printf("DEBUG: docstyle: %y\n", binding.docstyle);
+        *hash body;
+        if (self{io}) {
+            if (binding.docstyle)
+                body = self{io}.serializeDocument(binding{io}.body.parts, binding{io}, mpm, binding{io}.body.encoded, \val);
+            else {
+                string mname = input_name ? input_name : name + (request ? "":"Response");
+                if (binding{io})
+                    body = self{io}.serializeRpc(binding{io}.body.parts, binding{io}, mpm, mname, binding{io}.body.encoded, \val);
+            }
+
+        }
+
+        if (binding{io}.header) {
             #printf("DEBUG: %s, header: %y\n", io, header);
             hash outh;
-            *hash header2 = header;  # non processed values will be added to soap header
             foreach hash hdr in (binding{io}.header) {
                 #printf("DEBUG: hdr: %y, hdr.msg.name/part: %y/%y\n", hdr, hdr.msg.name, hdr.part);
                 if (binding.docstyle) {
                     *hash h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hdr.encoded, \header);
+                    if (!h && val) {
+                        # data provided in val ?
+                        h = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hdr.encoded, \val);
+                    }
                     if (h) {
                         remove h."^attributes^".("soapenv:encodingStyle", "xmlns:soapenc");
                         outh += h;
                     }
                 } else {
                     *hash h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, hdr.encoded, \header);
+                    if (!h && val) {
+                        # data provided in val ?
+                        h = hdr.msg.serializeRpc(hdr.part, NOTHING, NOTHING, hdr.part, hdr.encoded, \val);
+                    }
                     if (h) {
                         #printf("DEBUG: result: %y\n", h);
                         # tricky part, flatten hash, TODO: make it more transparently
@@ -1953,37 +1978,22 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
                     }
                 }
             }
-            if (header) {
+/*            if (header) {
                 # append unprocessed values TODO: it's obsolete as it violates WSDL definition
                 outh += header;
-            }
+                header = NOTHING;
+            } */
             #printf("DEBUG: outh: %y\n", outh);
             rh{soapenvEnvelope}."soapenv:Header" = outh;
         }
+        if (header.typeCode() == NT_HASH && header)
+            throw SOAP_SERIALIZATION_ERROR, sprintf("some %s header data provided for operation %y remains unserialized: %y", io, name, header);
+        if (val.typeCode() == NT_HASH && val)
+            throw SOAP_SERIALIZATION_ERROR, sprintf("some %s data provided for operation %y remains unserialized: %y", io, name, val);
 
-        # do we have mime/multipart io format?
-        if (exists binding{io}.multipart)
-            mpm = new MultiPartRelatedMessage();
-
-        #printf("DEBUG: docstyle: %y\n", binding.docstyle);
-        if (self{io}) {
-            *hash body;
-            if (binding.docstyle)
-                body = self{io}.serializeDocument(binding{io}.body.parts, binding{io}, mpm, binding{io}.body.encoded, \h);
-            else {
-                string mname = input_name ? input_name : name + (request ? "":"Response");
-                if (binding{io})
-                    body = self{io}.serializeRpc(binding{io}.body.parts, binding{io}, mpm, mname, binding{io}.body.encoded, \h);
-            }
-            if (h.typeCode() == NT_HASH && h)
-                throw SOAP_SERIALIZATION_ERROR, sprintf("some data remains unserialized: %y", h.keys());
-
-            if (body) {
-                rh{soapenvEnvelope}."soapenv:Body" = body;
-            }
-        } else if (exists h)
-            throw SOAP_SERIALIZATION_ERROR, sprintf("%s value provided for operation %y with no %s message (%y)", request?"request":"response", name, io, h);
-
+        if (body) {
+            rh{soapenvEnvelope}."soapenv:Body" = body;
+        }
         return rh;
     }
 

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -37,7 +37,7 @@
 %disable-warning unreferenced-variable
 
 module WSDL {
-    version = "0.3.5.1";
+    version = "0.3.6";
     desc = "WSDL module providing functionality for SOAP";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -72,6 +72,9 @@ module WSDL {
     - <a href="../../SoapHandler/html/index.html">SoapHandler user module</a>
 
     @section wsdlrelnotes WSDL Module Release Notes
+
+    @subsection wsdl_0_3_6 WSDL v0.3.6
+    - reimplmented operation to support multi binding, operation can be assigned to more bindings
 
     @subsection wsdl_0_3_5_1 WSDL v0.3.5.1
     - supress emitting a SOAPAction header in requests if the binding gives an empty string (<a href="https://github.com/qorelanguage/qore/issues/1226">issue 1226</a>)
@@ -114,7 +117,7 @@ module WSDL {
 #! main WSDL namespace
 public namespace WSDL {
     #! this WSDL implementation version
-    public const version     = "0.3.5.1";
+    public const version     = "0.3.6";
 
     #! SOAP 1.1 envelope URI
     public const SOAP_11_ENV  = "http://schemas.xmlsoap.org/soap/envelope/";
@@ -1769,15 +1772,11 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         Namespaces nsc;
 
-        *string soapAction;
+        *string soapAction;  # TODO: remove   SoapHandler, SoapClient
         *string request_name;
-        *hash inp;
-         outp;
-        bool docstyle = False;
 
-        # info about soap header requirements
-        hash iheader;
-        hash oheader;
+        # link to binding
+        hash bindings;
     }
 
     constructor(any p, TypeMap n_tmap, Namespaces n_nsc, *hash messages) : XsdNamedData(\p) {
@@ -1816,7 +1815,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     }
 
     setDocStyle(reference idocmap) {
-        docstyle = True;
+        # docstyle = True;  # property of in binding
 
         foreach string key in (input.args.keyIterator()) {
             # FIXME: could be a type here instead of an element
@@ -1827,7 +1826,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             string element = input.args{key}.element.name;
             idocmap{element} = input.args{key}.element;
             if (!request_name)
-                request_name = element;
+                request_name = element;   # TODO: should not affect operation when calling from binding ??
         }
     }
 
@@ -1839,8 +1838,22 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return request_name ? request_name : name;
     }
 
+    /** @param name the name of the binding
+
+        @return a @ref WSDL::Binding object
+
+        @throw WSDL-BINDING-ERROR unknown binding
+     */
+    WSDL::Binding getBinding(string bname) {
+        *Binding b = bindings{bname};
+        if (!b)
+            throw "WSDL-BINDING-ERROR", sprintf("binding %y is not a known binding for operation %y; known bindings: %y", bname, name, bindings.keys());
+        return b;
+    }
+
     #! serializes a request to an XML string for the operation
     /** @param h the request to serialize
+        @param binding SOAP binding
         @param header optional soap header info to serialize if required (ex: authorization info)
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh an optional namespace hash for the output message
@@ -1851,21 +1864,22 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c body: XML string in the SOAP request format
         - \c hdr: hash of HTTP headers
         */
-    hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
+    hash serializeRequest(any h, Binding binding, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
         # setup namespaces for SOAP envelope
         hash rh = nsc.hasSoap12() ? WSDL::ENVELOPE_12_NS : WSDL::ENVELOPE_11_NS;
 
         if (!exists req_soapaction)
-            req_soapaction = soapAction;
+            req_soapaction = bindings.operations{name}.soapAction;
 
         rh."soapenv:Envelope"."^attributes^" += nsc.getOutputNamespaceHash(nsh);
 
         #printf("DEBUG header: %y\n", header);
 
         if (header) {
-            if (iheader) {
-                hash hh.(iheader.part) = header;
-                rh."soapenv:Envelope"."soapenv:Header" = iheader.msg.serializeDocument(iheader.part, NOTHING, NOTHING, hh);
+            *hash hdr = binding.operations{name}.input.header;
+            if (hdr) {
+                hash hh.(hdr.part) = header;
+                rh."soapenv:Envelope"."soapenv:Header" = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hh);
             }
             else {
                 rh."soapenv:Envelope"."soapenv:Header" = header;
@@ -1874,17 +1888,17 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         MultiPartRelatedMessage mpm;
         # do we have mime/multipart input format?
-        if (exists inp.multipart)
+        if (exists binding.operations{name}.input.multipart)
             mpm = new MultiPartRelatedMessage();
 
-        #printf("DEBUG: docstyle: %y\n", docstyle);
+        #printf("DEBUG: docstyle: %y\n", binding.operations{name}.docstyle);
         if (input) {
-            if (docstyle)
-                rh."soapenv:Envelope"."soapenv:Body" = input.serializeDocument(NOTHING, inp, mpm, h);
+            if (binding.operations{name}.docstyle)
+                rh."soapenv:Envelope"."soapenv:Body" = input.serializeDocument(NOTHING, binding.operations{name}.input, mpm, h);
             else {
                 string mname = input_name ? input_name : name;
                 if (input)
-                    rh."soapenv:Envelope"."soapenv:Body" = input.serialize(inp, mpm, mname, h);
+                    rh."soapenv:Envelope"."soapenv:Body" = input.serialize(binding.operations{name}.input, mpm, mname, h);
             }
         }
         else if (exists h)
@@ -1893,7 +1907,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         string body = make_xml(rh, xml_opts, enc);
 
         if (mpm) {
-            mpm.splicePart(body, sprintf("<%s>", inp.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
+            mpm.splicePart(body, sprintf("<%s>", binding.operations{name}.input.body.parts), nsc.hasSoap12() ? MimeTypeSoapXml : MimeTypeXml);
 
             hash rv = mpm.getMsgAndHeaders();
             if (req_soapaction) {
@@ -1928,8 +1942,14 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return rv;
     }
 
+    hash serializeRequest(any h, *hash header, *string enc, *hash nsh, *int xml_opts, *string req_soapaction) {
+        return serializeRequest(h, bindings.firstValue(), header, enc, nsh, xml_opts, req_soapaction);
+
+    }
+
     #! serializes a SOAP response to an XML string for the operation
     /** @param h the response to serialize
+        @param binding SOAP binding
         @param header SOAP header hash
         @param enc the optional encoding to use; if this argument is not present, then the default encoding will be used
         @param nsh namespace hash
@@ -1940,7 +1960,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         - \c body: XML string in the SOAP request format
         - \c hdr: hash of HTTP headers
     */
-    hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
+    hash serializeResponse(any h, Binding binding, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
         if (exists soap12) {
             if (soap12) {
                 if (!nsc.hasSoap12())
@@ -1960,9 +1980,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         rh."soapenv:Envelope"."^attributes^" += nsc.getOutputNamespaceHash(nsh);
 
         if (header) {
-            if (oheader) {
-                hash hh.(oheader.part) = header;
-                rh."soapenv:Envelope"."soapenv:Header" = oheader.msg.serializeDocument(oheader.part, NOTHING, NOTHING, hh);
+            *hash hdr = binding.operations{name}.output.header;
+            if (hdr) {
+                hash hh.(hdr.part) = header;
+                rh."soapenv:Envelope"."soapenv:Header" = hdr.msg.serializeDocument(hdr.part, NOTHING, NOTHING, hh);
             }
             else {
                 rh."soapenv:Envelope"."soapenv:Header" = header;
@@ -1971,16 +1992,16 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         MultiPartRelatedMessage mpm;
         # do we have mime/multipart output format?
-        if (exists outp.multipart)
+        if (exists binding.operations{name}.output.multipart)
             mpm = new MultiPartRelatedMessage();
 
-        #printf("DEBUG: docstyle: %y\n", docstyle);
+        #printf("DEBUG: docstyle: %y\n", binding.operations{name}.docstyle);
         if (output) {
-            if (docstyle)
-                rh."soapenv:Envelope"."soapenv:Body" = output.serializeDocument(NOTHING, outp, mpm, h);
+            if (binding.operations{name}.docstyle)
+                rh."soapenv:Envelope"."soapenv:Body" = output.serializeDocument(NOTHING, binding.operations{name}.output, mpm, h);
             else {
                 string mname = input_name ? input_name : name + "Response";
-                rh."soapenv:Envelope"."soapenv:Body" = output.serialize(outp, mpm, mname, h);
+                rh."soapenv:Envelope"."soapenv:Body" = output.serialize(binding.operations{name}.output, mpm, mname, h);
             }
         }
         else if (exists h)
@@ -1990,7 +2011,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
         string ct = soap12 ? MimeTypeSoapXml : MimeTypeXml;
         if (exists mpm) {
-            mpm.splicePart(body, sprintf("<%s>", outp.body.parts), ct);
+            mpm.splicePart(body, sprintf("<%s>", binding.operations{name}.output.body.parts), ct);
             return mpm.getMsgAndHeaders();
         }
 
@@ -2000,6 +2021,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             "hdr": ("Content-Type": ct),
             "body": body,
             );
+    }
+
+    hash serializeResponse(any h, *hash header, *string enc, *hash nsh, *bool soap12, *int xml_opts) {
+        return serializeResponse(h, bindings.firstValue(), header, enc, nsh, soap12, xml_opts);
     }
 
     private list processMultiRef(hash body) {
@@ -2058,9 +2083,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
 
     #! parses a hash representing a parsed XML request (parsed with parseXMLAsData()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed XML request (parsed with parseXMLAsData()) for the operation
+        @param binding SOAP binding
         @return the Qore data structure corresponding to the request data
     */
-    any deserializeRequest(hash o) {
+    any deserializeRequest(hash o, Binding binding) {
         WSDL::XsdBase::removeNS(\o);
         WSDL::XsdBase::removeNS(\o.Envelope);
 
@@ -2079,7 +2105,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         #any ns = msg.".ns";
         msg -= ("ns", ".ns");
 
-        if (docstyle)
+        if (binding.operations{name}.docstyle)
             return input.deserializeDocument(mrh, msg);
 
         string mname = input_name ? input_name : name;
@@ -2092,11 +2118,16 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         return input.deserialize(mrh, msg);
     }
 
+    any deserializeRequest(hash o) {
+        return deserializeRequest(o, bindings.firstValue());
+    }
+
     #! parses a hash representing a parsed XML response (parsed with parse_xml()) for the operation and returns the corresponding Qore data structure
     /** @param o the parsed XML response (parsed with parse_xml()) for the operation
+        @param binding SOAP binding
         @return the Qore data structure corresponding to the response data
     */
-    any deserializeResponse(hash o) {
+    any deserializeResponse(hash o, Binding binding) {
         WSDL::XsdBase::removeNS2(\o);
         WSDL::XsdBase::removeNS2(\o.Envelope);
 
@@ -2145,7 +2176,7 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             }
         }
 
-        if (docstyle)
+        if (binding.operations{name}.docstyle)
             return output.deserializeDocument(mrh, msg);
 
         string mname = input_name ? input_name : name + "Response";
@@ -2156,6 +2187,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         msg -= (".ns", "ns");
 
         return output.deserialize(mrh, msg);
+    }
+
+    any deserializeResponse(hash o) {
+        return deserializeResponse(o, bindings.firstValue());
     }
 
     private hash processNSValue(hash h) {
@@ -2183,72 +2218,6 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
     */
     string getTargetNS() {
         return nsc.getTargetNamespaceUri();
-    }
-
-    setOutputMultipart(any v) {
-        outp.multipart = v;
-        outp.parts = ();
-    }
-
-    private parsePart(reference msg, any part) {
-        WSDL::XsdBase::removeNS(\part);
-        #any a = part."^attributes^";
-        part -= "^attributes^";
-
-        if (exists part.body) {
-            any pa = part.body."^attributes^";
-            if (pa.use != "literal")
-                throw WSDL_ERROR, sprintf("unsupported body part without use=\"literal\": %y", part.body);
-            msg.body = pa;
-        }
-        else if (exists part.content) {
-            foreach any c in (part.content) {
-                any pa = c."^attributes^";
-                any name = pa.part;
-                if (!exists name)
-                    throw WSDL_ERROR, sprintf("unsupported content part without part attribute: %y", c);
-                any type = pa.type;
-                if (!exists type)
-                    throw WSDL_ERROR, sprintf("unsupported content part without type attribute: %y", c);
-
-                if (!exists msg.parts{name})
-                    msg.parts{name} = type;
-                else {
-                    if (msg.parts{name}.typeCode() != NT_LIST)
-                        msg.parts{name} = list(msg.parts{name});
-                    msg.parts{name} += type;
-                }
-            }
-        }
-        else
-            throw WSDL_ERROR, sprintf("cannot parse part: %y", part);
-
-        #printf("DEBUG: part: %y\nmsg: %y\n", part, msg);#exit();
-    }
-
-    addOutputPart(any part) {
-        if (!exists outp.multipart)
-            throw WSDL_ERROR, sprintf("WSOperation::addOutputPart(): internal error: cannot add a part to a non-multipart message; part: %y", part);
-
-        parsePart(\outp, part);
-    }
-
-    setInputMultipart(any v) {
-        inp.multipart = v;
-        inp.parts = ();
-    }
-
-    addInputPart(any part) {
-        if (!exists inp.multipart)
-            throw WSDL_ERROR, sprintf("WSOperation::addInputPart(): internal error: cannot add a part to a non-multipart message; part: %y", part);
-
-        parsePart(\inp, part);
-    }
-
-    setInputHeader(string part, WSMessage msg, bool encoded) {
-        # FIXME: additional header parts are ignored!!!
-        if (!iheader)
-            iheader = ("part": part, "msg": msg, "encoded": encoded);
     }
 }
 
@@ -2495,15 +2464,17 @@ class WSDL::XsdLateResolverHelper {
 
 #! class for WSDL bindings
 public class WSDL::Binding inherits WSDL::XsdNamedData {
-    public {
-        bool docStyle = False;
-    }
-
     private {
         string port;
     }
+    public {
+        bool docstyle = False;
+        *string httpMethod;
+        *string soapTransport;
+        hash operations = {};
+    }
 
-    constructor(hash data, Namespaces nsc, hash opmap, reference idocmap, *hash messages) : XsdNamedData(\data) {
+    constructor(hash data, Namespaces nsc, reference portTypes, reference idocmap, *hash messages) : XsdNamedData(\data) {
         # get binding attributes
         {
             *hash ba = data."^attributes^";
@@ -2516,117 +2487,182 @@ public class WSDL::Binding inherits WSDL::XsdNamedData {
 
         if (data.binding) {
             *hash bba = data.binding."^attributes^";
-            if (bba.verb)
-                throw WSDL_ERROR, sprintf("binding %y declares unsupported HTTP %y binding; support for HTTP bindings has not yet been implemented", name, bba.verb);
+            if (bba.verb) {
+                # HTTP binding
+                httpMethod = bba.verb;
+            }
 
             if (bba.transport) {
+                # SOAP binding
                 if (!SOAP_TRANSPORT.(bba.transport))
                     throw WSDL_ERROR, sprintf("unsupported transport %y in binding %y (known transports: %y)", bba.transport, name, SOAP_TRANSPORT.keys());
+                soapTransport = bba.transport;
             }
-            else
-                throw WSDL_ERROR, sprintf("missing SOAP transport in binding %y (known SOAP transports: %y)", bba.transport, name, SOAP_TRANSPORT.keys());
+            if (!soapTransport && !httpMethod)
+                throw WSDL_ERROR, sprintf("missing SOAP verb or transport in binding %y (known SOAP transports: %y)", name, SOAP_TRANSPORT.keys());
 
-            if (bba.style == "document")
-                docStyle = True;
+            if (bba.style == "document") {
+                docstyle = True;
+            }
         }
 
         foreach hash ophash in (data.operation) {
             string opname = ophash."^attributes^".name;
 
-            *WSOperation op = opmap{opname};
-            if (!exists op)
-                throw WSDL_ERROR, sprintf("binding %y for %y references unknown operation %y", name, data.name, opname);
+            if (!exists portTypes{port}.operations{opname})
+                throw WSDL_ERROR, sprintf("binding %y references unknown porttype %y operation %y", name, port, opname);
 
+            if (exists operations{opname}) {
+                throw WSDL_ERROR, sprintf("binding %y already contains operation %y", name, opname);
+            }
+            hash op;
+            op.name = opname;
             WSDL::XsdBase::removeNS(\ophash);
 
             *string sa = ophash.operation."^attributes^".soapAction;
             if (exists sa) {
                 #printf("GOT: %s sa: %y\n", opname, sa);
                 op.soapAction = sa;
+            } else {
+                *string op_ns = portTypes{port}.operations{opname}.nsc.getTargetNamespaceUri();
+                if (op_ns && op_ns !~ /\/$/)
+                    op_ns += "/";
+                op.soapAction = op_ns ? op_ns + opname : opname;
             }
 
-            if (docStyle || ophash.operation."^attributes^".style == "document") {
-                op.setDocStyle(\idocmap);
+            if (docstyle || ophash.operation."^attributes^".style == "document") {
+                op.docstyle = True;
+                portTypes{port}.operations{opname}.setDocStyle(\idocmap);  # TODO
             }
 
-            if (op.input) {
-                WSDL::WSMessage input = op.input;
+            if (httpMethod) {
+                *string loc = ophash.operation."^attributes^".location;
+                if (loc) {
+                    op.location = loc;
+                } else {
+                    throw WSDL_ERROR, sprintf("location is missing binding %y, operation %y", name, opname);
+                }
+            }
 
-                WSDL::XsdBase::removeNS(\ophash.input);
-                if (exists ophash.input.body) {
-                    if (ophash.input.body."^attributes^".use == "encoded") {
-                        input.encoded = True;
-                        #printf("DEBUG: setting encoding = True for %y.%y input\n", data.name, opname);
+            foreach string io in (("input", "output")) {
+                if (ophash{io}) {
+                    WSDL::XsdBase::removeNS(\ophash{io});
+
+                    if (exists ophash{io}.body) {
+                        # any pa = ophash{io}.body."^attributes^";
+                        op{io}.body = ophash{io}.body."^attributes^";
+                        op{io}.body.encoded = ophash{io}.body."^attributes^".use == "encoded";  # TODO: move to WSOperation
+
+                        delete ophash{io}.body;
+                    }
+                    if (exists ophash{io}.multipartRelated) {
+                        if (exists op{io}.body)
+                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies both body and multipart elements", io, name, opname);
+
+                        op{io}.multipart = Mime::MPT_RELATED;
+                        op{io}.parts = {};
+                        WSDL::XsdBase::removeNS(\ophash{io}.multipartRelated);
+
+                        if (!exists ophash{io}.multipartRelated.part)  # TODO: do I need explicite check or is is handled by validator ?
+                            throw WSDL_ERROR, sprintf("binding %y is missing part definition(s) in %s message definition for operation %y: %y", name, io, opname, ophash);
+
+                        foreach any part in (ophash{io}.multipartRelated.part) {
+                            WSDL::XsdBase::removeNS(\part);
+                            #any a = part."^attributes^";
+                            part -= "^attributes^";
+                            if (exists part.body) {
+                                any pa = part.body."^attributes^";
+                                if (pa.use != "literal")
+                                    throw WSDL_ERROR, sprintf("unsupported body part without use=\"literal\": %y", part.body);
+
+                                op{io}.body = pa;
+                            } else if (exists part.content) {
+                                foreach any c in (part.content) {
+                                    WSDL::XsdBase::removeNS(\c);
+                                    any pa = c."^attributes^";
+                                    any name = pa.part;
+                                    if (!exists name)
+                                        throw WSDL_ERROR, sprintf("unsupported content part without part attribute: %y", c);
+                                    any type = pa.type;
+                                    if (!exists type)
+                                        throw WSDL_ERROR, sprintf("unsupported content part without type attribute: %y", c);
+
+                                    if (!exists op{io}.parts{name})
+                                        op{io}.parts{name} = type;
+                                    else {
+                                        if (op{io}.parts{name}.typeCode() != NT_LIST)
+                                            op{io}.parts{name} = list(op{io}.parts{name});
+                                        op{io}.parts{name} += type;
+                                    }
+                                }
+                            } else
+                                throw WSDL_ERROR, sprintf("cannot parse part: %y", part);
+
+                                #printf("DEBUG: part: %y\nmsg: %y\n", part, op{io});;
+                        }
+                        delete ophash{io}.multipartRelated;
+                    }
+
+                    if (ophash{io} && !exists portTypes{port}.operations{opname}{io})
+                        throw WSDL_ERROR, sprintf("cannot assign %s message definition in binding %y for operation %y with no %io: %y", io, name, opname, io, ophash);
+
+                    if (exists ophash{io}.header) {   # TODO: one or multi headers ?
+                        *hash ma = ophash{io}.header."^attributes^";
+
+                        if (!ma.message)
+                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'message' attribute (attr: %y)", io, name, opname, ma);
+
+                        if (!ma.part)
+                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y specifies a soap header element without a 'part' attribute (attr: %y)", io, name, opname, ma);
+
+                        hash h = nsc.doType(ma.message);
+                        *WSMessage msg = messages.(h.val);
+                        if (!exists msg)
+                            throw WSDL_ERROR, sprintf("%s binding %y for operation %y references unknown message %y in the soap header element", io, name, opname, h.val);
+
+
+                        op{io}.header = ma;
+                        op{io}.header.encoded = ma.use == "encoded";   # TODO: move to WSOperation ???
+                        delete ophash{io}.header;
+                    }
+
+                    if (exists ophash{io}.urlReplacement) {
+                        op{io}.urlReplacement = True;
+                        delete ophash{io}.urlReplacement;
+                    }
+
+                    if (exists ophash{io}.urlEncoded) {
+                        op{io}.urlEncoded = True;
+                        delete ophash{io}.urlEncoded;
+                    }
+
+                    if (exists ophash{io}.content) {
+                        op{io}.contents = ();
+                        foreach any cnt in (ophash{io}.content) {
+                            WSDL::XsdBase::removeNS(\cnt);
+                            if (!cnt.type) {
+                                cnt.type = "*/*";
+                            }
+                            push op{io}.contents, cnt;
+                        }
+                        # delete ophash{io}.content;  TODO: implement later
+                    }
+
+                    delete ophash{io}.("^attributes^", "ns");
+
+                    if (ophash{io}) {
+                        throw WSDL_ERROR, sprintf("unknown element(s) in binding %y for %s operation %y: %y", name, io, opname, keys ophash{io});
                     }
                 }
-                else if (exists ophash.input.multipartRelated) {
-                    op.setInputMultipart(Mime::MPT_RELATED);
-                    WSDL::XsdBase::removeNS(\ophash.input.multipartRelated);
-
-                    if (!exists ophash.input.multipartRelated.part)
-                        throw WSDL_ERROR, sprintf("binding %y is missing part definition(s) in input message definition for operation %y: %y", name, opname, ophash);
-
-                    foreach any part in (ophash.input.multipartRelated.part) {
-                        WSDL::XsdBase::removeNS(\part);
-                        op.addInputPart(part);
-                    }
-                }
-                else
-                    throw WSDL_ERROR, sprintf("cannot parse input message definition in binding %y for operation %y: %y", name, opname, ophash);
-            }
-            else if (ophash.input.body || ophash.input.multipartRelated)
-                throw WSDL_ERROR, sprintf("cannot parse input message definition in binding %y for operation %y with no input: %y", name, opname, ophash);
-
-            # check for header
-            foreach hash hh in (ophash.input.header) {
-                *hash ma = hh."^attributes^";
-
-                if (!ma.message)
-                    throw WSDL_ERROR, sprintf("input binding %y for operation %y specifies a soap header element without a 'message' attribute (attr: %y)", name, opname, ma);
-
-                if (!ma.part)
-                    throw WSDL_ERROR, sprintf("input binding %y for operation %y specifies a soap header element without a 'part' attribute (attr: %y)", name, opname, ma);
-
-                hash h = nsc.doType(ma.message);
-                *WSMessage msg = messages.(h.val);
-                if (!exists msg)
-                    throw WSDL_ERROR, sprintf("input binding %y for operation %y references unknown message %y in the soap header element", name, opname, msg);
-
-                #printf("header msg: %y part: %y use: %y\n", ma.message, ma.part, ma.use);
-                #printf("op.input: %y\n", input);
-
-                op.setInputHeader(ma.part, msg, ma.use == "encoded");
             }
 
-            WSDL::XsdBase::removeNS(\ophash.output);
-            if (op.output) {
-                if (exists ophash.output.body) {
-                    if (ophash.output.body."^attributes^".use == "encoded") {
-                        op.output.encoded = True;
-                        #printf("DEBUG: setting encoding = True for %y.%y output\n", data.name, opname);
-                    }
-                }
-                else if (exists ophash.output.multipartRelated) {
-                    op.setOutputMultipart(Mime::MPT_RELATED);
-                    WSDL::XsdBase::removeNS(\ophash.output.multipartRelated);
-
-                    if (!exists ophash.output.multipartRelated.part)
-                        throw WSDL_ERROR, sprintf("missing part definition(s) in output message definition for operation %y: %y", opname, ophash);
-
-                    foreach any part in (ophash.output.multipartRelated.part) {
-                        WSDL::XsdBase::removeNS(\part);
-                        op.addOutputPart(part);
-                    }
-                }
-                else
-                    throw WSDL_ERROR, sprintf("cannot parse output message definition for operation %y: %y", opname, ophash);
-            }
-            else if (exists ophash.output.body || exists ophash.output.multipartRelated)
-                throw WSDL_ERROR, sprintf("cannot parse input message definition for operation %y with no input: %y", opname, ophash);
+            operations{opname} = op;
+            portTypes{port}.operations{opname}.bindings{name} = self;   # register itself in operation
         }
 
         #binding = data;
     }
+
 
     string getPort() {
         return port;
@@ -3155,8 +3191,8 @@ public class WSDL::WebService inherits WSDL::XsdBase {
     /** @return a list of hashes of services defined in the WSDL; each hash has the following keys:
         - \c "name": the name of the service
         - \c "port": a hash of port information; the keys are port names and the values have the following keys:
-          - \c "address": the location of the port
-          - \c "binding": the binding of the port
+        - \c "address": the location of the port
+        - \c "binding": the binding of the port
      */
     list listServices() {
         return services.values();
@@ -3413,8 +3449,7 @@ public class WSDL::WebService inherits WSDL::XsdBase {
 
     private parseBinding(*softlist bindings) {
         foreach hash data in (bindings) {
-            WSDL::Binding b(data, nsc, opmap, \idocmap, messages);
-
+            WSDL::Binding b(data, nsc, \portType, \idocmap, messages);   # TODO: portType reference when I need modify inner object ?
             binding.(b.getName()) = b;
         }
     }

--- a/qlib/WSDL.qm
+++ b/qlib/WSDL.qm
@@ -392,7 +392,11 @@ public class WSDL::WSDLLib {
 
     #! takes a hash representation returned by parseMultiPartSOAPMessage and parses it to a Qore data structure, checks the content-type, and handles hrefs in the message
     static *hash parseSOAPMessage(hash msg) {
-        if (WSDLLib::isContentType(msg."content-type", SoapMimeTypes)) {
+        if (!msg.body) {
+            hash h."content-type" = msg."content-type" ?? "text/plain";
+            h.body = NOTHING;
+            return h;
+        } else if (WSDLLib::isContentType(msg."content-type", SoapMimeTypes)) {
             hash xmldata;
             if (msg.body) {
                 xmldata = parse_xml(msg.body);
@@ -400,11 +404,6 @@ public class WSDL::WSDLLib {
             if (msg.parts) {
                 # parse entire data structure to find "href"s or href attributes
                 WSDLLib::substHref(\xmldata, msg.parts);
-            }
-            if (!exists xmldata) {
-                # fake data, e.g. when URLEncoded
-                xmldata."content-type" = msg."content-type";
-                xmldata.body = NOTHING;
             }
             return xmldata;
         } else {
@@ -2119,7 +2118,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
         if (exists enc) {
             ct += sprintf(";charset=%s", enc);
         }
-        rv.hdr."Content-Type" = ct;
+
+        if (exists rv.body) {
+            rv.hdr."Content-Type" = ct;
+        }
 
         if (req_soapaction)
             rv.hdr += ("SOAPAction": req_soapaction);
@@ -2185,7 +2187,10 @@ public class WSDL::WSOperation inherits WSDL::XsdNamedData {
             ct += sprintf(";charset=%s", enc);
         }
 
-        rv.hdr = ("Content-Type": ct);
+        if (exists rv.body) {
+            rv.hdr = ("Content-Type": ct);
+        }
+
         return rv;
     }
 

--- a/qlib/XmlRpcHandler.qm
+++ b/qlib/XmlRpcHandler.qm
@@ -152,7 +152,6 @@ ash), the method definition as passed in the methods argument to this constructo
             @param dbg this parameter is set to @ref Qore::True "True", then additional information will be logged when errors occur
             @param n_get_prefix prefix to add to derived methods with GET requests if no "." characters are in the path
             @param log an optional closure or call reference to be called when logging
-            @param cx an optional closure or call reference to set the call context before calling APIs
 
             @throw XML-RPC-CONSTRUCTOR-ERROR missing \c "name", \c "function", or \"text" key in method hash, \c "function" key not assigned to a callable value
          */

--- a/test/GlobalWeather.qtest
+++ b/test/GlobalWeather.qtest
@@ -29,7 +29,7 @@ class GlobalWeatherTest inherits QUnit::Test {
         const WsdlUrl = "file://" + normalize_dir(get_script_dir()) + "/globalweather.wsdl";
 
 		WebService ws;
-		
+
 		const MyOpts = Opts + {};
 	}
 
@@ -38,9 +38,9 @@ class GlobalWeatherTest inherits QUnit::Test {
 
         my hash svc = ws.getService("GlobalWeather");
         #my string port = "GlobalWeatherHttpGet";
-    	foreach my string port in (keys svc.port) {
-        	# add test cases
-	        addTestCase(sprintf("clientTest-%s", port), \clientTest(), (port));
+        foreach my string port in (keys svc.port) {
+            # add test cases
+            addTestCase(sprintf("clientTest-%s", port), \clientTest(), (port));
 		}
         # execute tests
         set_return_value(main());
@@ -52,11 +52,11 @@ class GlobalWeatherTest inherits QUnit::Test {
 		printf("Info: %y\n", h);
 		assertEq("GlobalWeather", h.service);
 		assertEq(port, h.port);
-		
+
         h = sc.callOperation("GetCitiesByCountry", ("CountryName": "Austria"), ("soapaction": ""));
         hash data = parse_xml(h.firstValue());
         assertEq("NewDataSet", data.firstKey());
-		#printf("Result: %N\n", data);        		
-    	
+		#printf("Result: %N\n", data);
+
     }
 }

--- a/test/GlobalWeather.qtest
+++ b/test/GlobalWeather.qtest
@@ -1,0 +1,62 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+# make sure we have the right version of qore
+%requires qore >= 0.8.12
+
+%new-style
+%require-types
+%strict-args
+%enable-all-warnings
+%no-child-restrictions
+%require-our
+
+# test deprecated functions as well
+%disable-warning deprecated
+
+%requires QUnit
+%requires ../qlib/WSDL.qm
+%requires ../qlib/SoapClient.qm
+
+%requires Util
+%requires xml
+
+%exec-class GlobalWeatherTest
+
+class GlobalWeatherTest inherits QUnit::Test {
+
+    private {
+        const WsdlUrl = "file://" + normalize_dir(get_script_dir()) + "/globalweather.wsdl";
+
+		WebService ws;
+		
+		const MyOpts = Opts + {};
+	}
+
+    constructor() : QUnit::Test("GlobalWeatherTest", "1.0", \ARGV, MyOpts) {
+        ws = new WebService(WSDLLib::getFileFromURL(WsdlUrl));
+
+        my hash svc = ws.getService("GlobalWeather");
+        #my string port = "GlobalWeatherHttpGet";
+    	foreach my string port in (keys svc.port) {
+        	# add test cases
+	        addTestCase(sprintf("clientTest-%s", port), \clientTest(), (port));
+		}
+        # execute tests
+        set_return_value(main());
+    }
+
+    clientTest(string port) {
+		SoapClient sc(("wsdl": WsdlUrl, "port": port));
+		hash h = sc.getInfo();
+		printf("Info: %y\n", h);
+		assertEq("GlobalWeather", h.service);
+		assertEq(port, h.port);
+		
+        h = sc.callOperation("GetCitiesByCountry", ("CountryName": "Austria"), ("soapaction": ""));
+        hash data = parse_xml(h.firstValue());
+        assertEq("NewDataSet", data.firstKey());
+		#printf("Result: %N\n", data);        		
+    	
+    }
+}

--- a/test/Salesforce.com.qtest
+++ b/test/Salesforce.com.qtest
@@ -73,7 +73,7 @@ class SalesforceTest inherits QUnit::Test {
 
     setupConnection() {
         date now = now_us();
-        doInfo("creating WSDL: ");
+        doInfo(sprintf("creating WSDL %y: ", getOption("wsdl")));
         WebService wsdl(WSDLLib::getFileFromURL(getOption("wsdl")));
         doInfo("done: %y\n", now_us() - now);
         opts = (

--- a/test/Salesforce.com.qtest
+++ b/test/Salesforce.com.qtest
@@ -73,7 +73,7 @@ class SalesforceTest inherits QUnit::Test {
 
     setupConnection() {
         date now = now_us();
-        doInfo(sprintf("creating WSDL %y: ", getOption("wsdl")));
+        doInfo("creating WSDL %y: ", getOption("wsdl"));
         WebService wsdl(WSDLLib::getFileFromURL(getOption("wsdl")));
         doInfo("done: %y\n", now_us() - now);
         opts = (

--- a/test/Salesforce.com.qtest
+++ b/test/Salesforce.com.qtest
@@ -92,11 +92,15 @@ class SalesforceTest inherits QUnit::Test {
             );
 
         now = now_us();
+        doInfo("SalesforceSoapClient\n");
         sc = new SalesforceSoapClient(opts);
+        doInfo("login\n");
         sc.login();
+        doInfo("logged\n");
 
         # delete all objects in case of a previous test failure
         try {
+            doInfo("getAccountIds\n");
             *list ids = getAccountIds(AcctNo1);
             if (ids)
                 sc.delete(("ids": ids));

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -45,6 +45,9 @@ class TestSoapServer inherits HttpServer {
 
     public {
         TestSoapHandler soap;
+        string opname;
+        any mdata;
+        any rdata;
     }
 
     private {
@@ -60,7 +63,20 @@ class TestSoapServer inherits HttpServer {
 
         # setup operation handler
         soap.addMethod(ws, ws.getOperation("getInfo"), \getInfo());
-        soap.addMethod(ws, ws.getOperation("urlRepl"), \urlRepl(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+        # not yet supported
+        soap.addMethod(ws, ws.getOperation("urlRepl"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("urlEncoded1"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+#        soap.addMethod(ws, ws.getOperation("urlEncoded2"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("getMimeXml"), \generalOutputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("getBinary"), \generalOutputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+
+        soap.addMethod(ws, ws.getOperation("postForm"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postText"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postImg"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postImg2"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postImg3"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postData"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+
         addListener(port);
     }
 
@@ -74,8 +90,14 @@ class TestSoapServer inherits HttpServer {
             );
     }
 
-    hash urlRepl(hash cx, hash h) {
-printf("URLREPL\n");
+    *hash generalInputOnly(hash cx, hash h) {
+        opname = cx.operation.name;
+        mdata = h;
+    }
+
+    *hash generalOutputOnly(hash cx) {  # no input params
+        opname = cx.operation.name;
+        return rdata;
     }
 
     errlog(string fmt) {
@@ -103,6 +125,7 @@ class TestSoapClient inherits SoapClient {
 class SoapClientTest inherits QUnit::Test {
     public {
         TestSoapServer server;
+        TestSoapClient sc;
     }
 
     private {
@@ -133,17 +156,22 @@ class SoapClientTest inherits QUnit::Test {
         # add test cases
         addTestCase("SoapClientTest", \soapClientTest());
         addTestCase("HttpGetClientTest", \httpGetClientTest());
+        addTestCase("HttpPostClientTest", \httpPostClientTest());
         addTestCase("SoapConnectionTest", \soapConnectionTest());
 
         # execute tests
-        set_return_value(main());
+        set_return_value(main()); exit();
     }
 
+    cleanMsgLog() {
+        sc.msglogs = ();
+        server.soap.msglogs = ();
+    }
     soapClientTest() {
         #printf("url: %y\n", url);
-        TestSoapClient sc(("wsdl": WsdlUrl, "port": "SoapPort", "url": url));
+        sc= new TestSoapClient(("wsdl": WsdlUrl, "port": "SoapPort", "url": url));
 
-        server.soap.msglogs = ();
+        cleanMsgLog();
 
         hash h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
         assertEq(99.9, h.body.result);
@@ -156,21 +184,20 @@ class SoapClientTest inherits QUnit::Test {
         assertEq(server.soap.msglogs[0].('reason', 'code', 'body'), sc.msglogs[0].('reason', 'code', 'body'));
         assertEq(server.soap.msglogs[1].('reason', 'code', 'body'), sc.msglogs[1].('reason', 'code', 'body'));
 
-        sc.msglogs = ();
-        server.soap.msglogs = ();
+        cleanMsgLog();
 
         h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "QOR")), ("soapaction": "TestAction"));
         assertEq(99.9, h.body.result);
         assertEq("QOR", h.docs);
         assertEq(binary("TestAction"), h.logo);
 
-        sc.msglogs = ();
-        server.soap.msglogs = ();
+        cleanMsgLog();
 
         assertThrows("HTTP-CLIENT-RECEIVE-ERROR", \sc.callOperation(), ("getInfo", ("GetInfo": ("tickerSymbol": "ERR"))));
         assertEq("error", sc.msglogs[1].reason);
         assertEq(500, sc.msglogs[1].code);
         assertEq(True, sc.msglogs[1].body =~ /Fault/);
+        assertEq("application/soap+xml,text/xml,application/xml", sc.msglogs[0]."accept");
         assertEq(server.soap.msglogs[0].('reason', 'code', 'body'), sc.msglogs[0].('reason', 'code', 'body'));
         assertEq(server.soap.msglogs[1].('reason', 'code', 'body'), sc.msglogs[1].('reason', 'code', 'body'));
 
@@ -183,25 +210,106 @@ class SoapClientTest inherits QUnit::Test {
 
     httpGetClientTest() {
         #printf("url: %y\n", url);
-        TestSoapClient sc(("wsdl": WsdlUrl, "port": "HttpGetPort", "url": url));
+        sc = new TestSoapClient(("wsdl": WsdlUrl, "port": "HttpGetPort", "url": url));
 
-        server.soap.msglogs = ();
-        hash *h;
-#        assertThrows("HTTP-CLIENT-RECEIVE-ERROR", \sc.callOperation(), ("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000), ("soapaction": "")));
+        cleanMsgLog();
+        *hash h;
+        assertThrows("HTTP-CLIENT-RECEIVE-ERROR", \sc.callOperation(), ("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000)));
+        assertEq("get/CZ/12000-Prague%202", sc.msglogs[0].path);
+        assertEq(sc.msglogs[0].method, "GET");
 
         try {
-        h = sc.callOperation("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000), ("soapaction": ""));
+            cleanMsgLog();
+            hash hi = ("country": "CZ", "city": "Prague_2", "zip": 12000);
+            h = sc.callOperation("urlEncoded1", hi);
+            assertEq(server.opname, "urlEncoded1");
+            assertEq(server.mdata, hi);
+            assertEq(server.soap.msglogs[0].('reason', 'method', 'path'), sc.msglogs[0].('reason', 'method', 'path'));
+
+            cleanMsgLog();
+            server.rdata = ("STR": "AbCdEf");
+            h = sc.callOperation("getMimeXml", ());
+            assertEq(server.opname, "getMimeXml");
+            assertEq(server.soap.msglogs[0].('reason', 'method'), sc.msglogs[0].('reason', 'method'));
+            assertEq("text/xml;charset=UTF-8", sc.msglogs[1]."content-type");
+            assertEq("text/xml", sc.msglogs[0]."accept");
+            assertEq(server.rdata, h);
+
+            cleanMsgLog();
+            server.rdata = ("payload": ("^attributes^": ("^content-type^": "application/plain"), "^value^": "ADATA"));
+            h = sc.callOperation("getBinary", ());
+            assertEq(server.opname, "getBinary");
+            assertEq("text/plain,text/html,image/*,application/*", sc.msglogs[0]."accept");
+            assertEq(server.rdata.payload."^attributes^"."^content-type^", sc.msglogs[1]."content-type");
+            server.rdata.payload."^value^" = binary(server.rdata.payload."^value^");
+            assertEq(server.rdata, h);
+
+            cleanMsgLog();
+            server.rdata = ("payload": "xxx");
+            assertThrows("HTTP-CLIENT-RECEIVE-ERROR", \sc.callOperation(), ("getBinary", ()));
+
         } catch (ex) {
             printf("Exception: %N\n\n", ex);
+            rethrow;
         }
 
-printf("client: %N\n", sc.msglogs);
-printf("server: %N\n", server.soap.msglogs);
-printf("result: %N\n", h);
-        assertEq("get/CZ/12000-Prague%202", sc.msglogs[0].path);
+    }
 
-        sc.msglogs = ();
-        server.soap.msglogs = ();
+    httpPostClientTest() {
+        #printf("url: %y\n", url);
+        sc = new TestSoapClient(("wsdl": WsdlUrl, "port": "HttpPostPort", "url": url));
+        *hash h;
+        try {
+            cleanMsgLog();
+            hash hi = ("country": "CZ", "city": "Prague_2", "zip": 12000);
+            h = sc.callOperation("postForm", hi);
+            assertEq(server.opname, "postForm");
+            assertEq(hi, server.mdata);
+            assertEq(sc.msglogs[0].method, "POST");
+
+            cleanMsgLog();
+            hi = ("info": "very important text");
+            h = sc.callOperation("postText", hi);
+            assertEq(server.opname, "postText");
+            assertEq("text/plain", sc.msglogs[0]."content-type");
+            assertEq(("info": ("^attributes^": ("^content-type^": "text/plain"), "^value^": hi.info)), server.mdata);
+
+            cleanMsgLog();
+            hi = ("img": "nice image");
+
+            cleanMsgLog();
+            hi = ("img": ("^attributes^": ("^content-type^": "image/png"), "^value^": <1234567890ABCDEF> ));
+            h = sc.callOperation("postImg", hi);
+            assertEq(server.opname, "postImg");
+            assertEq(hi.img."^attributes^"."^content-type^", sc.msglogs[0]."content-type");
+            assertEq(hi, server.mdata);
+
+            hi.img."^attributes^"."^content-type^" = "image/jpeg";
+            assertThrows("SOAP-MESSAGE-ERROR", \sc.callOperation(), ("postImg", hi));
+
+            cleanMsgLog();
+            h = sc.callOperation("postImg2", hi);
+            assertEq(server.opname, "postImg2");
+            assertEq(hi.img."^attributes^"."^content-type^", sc.msglogs[0]."content-type");
+            assertEq(hi, server.mdata);
+
+            cleanMsgLog();
+            h = sc.callOperation("postImg3", hi);
+            assertEq(server.opname, "postImg3");
+            assertEq(hi.img."^attributes^"."^content-type^", sc.msglogs[0]."content-type");
+            assertEq(hi, server.mdata);
+
+            cleanMsgLog();
+            hi = ("payload": ("^attributes^": ("^content-type^": "application/qore"), "^value^": <0ABCDEF01234567890>));
+            h = sc.callOperation("postData", hi);
+            assertEq(server.opname, "postData");
+            assertEq(hi.payload."^attributes^"."^content-type^", sc.msglogs[0]."content-type");
+            assertEq(hi, server.mdata);
+
+        } catch (ex) {
+            printf("Exception: %N\n\n", ex);
+            rethrow;
+        }
 
     }
 
@@ -212,8 +320,8 @@ printf("result: %N\n", h);
         printf("conn_url: %y\n", conn_url);
 
         SoapConnection conn("test", "test", conn_url, False, ("target_url": url, "port": "SoapPort"), parse_url(conn_url));
-        SoapClient sc = conn.get();
-        hash h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
+        SoapClient sc2 = conn.get();
+        hash h = sc2.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
         assertEq(99.9, h.body.result);
         assertEq("ABC", h.docs);
         assertEq(binary(), h.logo);

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -107,7 +107,7 @@ class SoapClientTest inherits QUnit::Test {
         #! command-line options
         const MyOpts = Opts + (
             "port": "p,port=i",
-            "verbose": "verbose=i",
+            #"verbose": "verbose=i",  # already in Opts
             "host": "host=s",
         );
 

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -186,7 +186,9 @@ class SoapClientTest inherits QUnit::Test {
         TestSoapClient sc(("wsdl": WsdlUrl, "port": "HttpGetPort", "url": url));
 
         server.soap.msglogs = ();
-        hash h;
+        hash *h;
+#        assertThrows("HTTP-CLIENT-RECEIVE-ERROR", \sc.callOperation(), ("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000), ("soapaction": "")));
+
         try {
         h = sc.callOperation("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000), ("soapaction": ""));
         } catch (ex) {

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -107,7 +107,9 @@ class SoapClientTest inherits QUnit::Test {
         #! command-line options
         const MyOpts = Opts + (
             "port": "p,port=i",
-            );
+            "verbose": "verbose=i",
+            "host": "host=s",
+        );
 
         const OptionColumn = 25;
         string url;
@@ -121,7 +123,8 @@ class SoapClientTest inherits QUnit::Test {
         server = new TestSoapServer(ws, m_options.port ?? DefaultPort, m_options.verbose);
         on_exit server.stop();
         serverPort = server.getListenerInfo(0).port;
-        url = sprintf("http://%s:%d", gethostname(), serverPort);
+        # when dual IPv4/IPv6 stack then may resolve gethostname() with unsupposed IP address where server is not listening
+        url = sprintf("http://%s:%d", m_options.host ? m_options.host : gethostname(), serverPort);
 
         # add test cases
         addTestCase("SoapClientTest", \soapClientTest());

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -60,7 +60,7 @@ class TestSoapServer inherits HttpServer {
 
         # setup operation handler
         soap.addMethod(ws, ws.getOperation("getInfo"), \getInfo());
-
+        soap.addMethod(ws, ws.getOperation("urlRepl"), \urlRepl(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
         addListener(port);
     }
 
@@ -72,6 +72,10 @@ class TestSoapServer inherits HttpServer {
             "docs": h.tickerSymbol,
             "logo": binary(cx.http_header.soapaction),
             );
+    }
+
+    hash urlRepl(hash cx, hash h) {
+printf("URLREPL\n");
     }
 
     errlog(string fmt) {
@@ -128,6 +132,7 @@ class SoapClientTest inherits QUnit::Test {
 
         # add test cases
         addTestCase("SoapClientTest", \soapClientTest());
+        addTestCase("HttpGetClientTest", \httpGetClientTest());
         addTestCase("SoapConnectionTest", \soapConnectionTest());
 
         # execute tests
@@ -136,7 +141,9 @@ class SoapClientTest inherits QUnit::Test {
 
     soapClientTest() {
         #printf("url: %y\n", url);
-        TestSoapClient sc(("wsdl": WsdlUrl, "url": url));
+        TestSoapClient sc(("wsdl": WsdlUrl, "port": "SoapPort", "url": url));
+
+        server.soap.msglogs = ();
 
         hash h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
         assertEq(99.9, h.body.result);
@@ -170,8 +177,30 @@ class SoapClientTest inherits QUnit::Test {
         assertThrows("WSDL-OPERATION-ERROR", \sc.callOperation(), "xxx");
 
         WebService ws(WSDLLib::getWSDL(WsdlUrl));
-        sc = new TestSoapClient(("wsdl": ws));
+        sc = new TestSoapClient(("wsdl": ws, "port": "SoapPort"));
         assertEq(True, sc instanceof SoapClient, "issue 1424");
+    }
+
+    httpGetClientTest() {
+        #printf("url: %y\n", url);
+        TestSoapClient sc(("wsdl": WsdlUrl, "port": "HttpGetPort", "url": url));
+
+        server.soap.msglogs = ();
+        hash h;
+        try {
+        h = sc.callOperation("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000), ("soapaction": ""));
+        } catch (ex) {
+            printf("Exception: %N\n\n", ex);
+        }
+
+printf("client: %N\n", sc.msglogs);
+printf("server: %N\n", server.soap.msglogs);
+printf("result: %N\n", h);
+        assertEq("get/CZ/12000-Prague%202", sc.msglogs[0].path);
+
+        sc.msglogs = ();
+        server.soap.msglogs = ();
+
     }
 
     soapConnectionTest() {
@@ -180,7 +209,7 @@ class SoapClientTest inherits QUnit::Test {
 
         printf("conn_url: %y\n", conn_url);
 
-        SoapConnection conn("test", "test", conn_url, False, ("target_url": url), parse_url(conn_url));
+        SoapConnection conn("test", "test", conn_url, False, ("target_url": url, "port": "SoapPort"), parse_url(conn_url));
         SoapClient sc = conn.get();
         hash h = sc.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
         assertEq(99.9, h.body.result);

--- a/test/enterprise.wsdl
+++ b/test/enterprise.wsdl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Salesforce.com Enterprise Web Services API Version 29.0
-Generated on 2014-03-01 16:18:22 +0000.
+Salesforce.com Enterprise Web Services API Version 38.0
+Generated on 2017-01-03 18:33:45 +0000.
 
-Copyright 1999-2014 salesforce.com, inc.
+Copyright 1999-2017 salesforce.com, inc.
 All Rights Reserved
 -->
 
@@ -76,23 +76,30 @@ All Rights Reserved
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="AnnualRevenue" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="Assets" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="BillingAddress" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="BillingCity" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BillingCountry" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="BillingGeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BillingLatitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="BillingLongitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="BillingPostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BillingState" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BillingStreet" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Cases" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ChildAccounts" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Contacts" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Contracts" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="CustomerPriority__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Fax" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -106,6 +113,7 @@ All Rights Reserved
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="MasterRecord" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="MasterRecordId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -124,6 +132,7 @@ All Rights Reserved
                         <element name="PartnersFrom" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="PartnersTo" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Rating" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -131,8 +140,10 @@ All Rights Reserved
                         <element name="SLASerialNumber__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SLA__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Shares" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ShippingAddress" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="ShippingCity" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ShippingCountry" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ShippingGeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ShippingLatitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="ShippingLongitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="ShippingPostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -144,8 +155,10 @@ All Rights Reserved
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="TickerSymbol" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="UpsellOpportunity__c" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         <element name="Website" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
@@ -234,7 +247,65 @@ All Rights Reserved
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="OpportunityAccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ActionLinkGroupTemplate">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ActionLinkTemplates" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Category" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExecutionsAllowed" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HoursUntilExpiration" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsPublished" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ActionLinkTemplate">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ActionLinkGroupTemplate" nillable="true" minOccurs="0" type="ens:ActionLinkGroupTemplate"/>
+                        <element name="ActionLinkGroupTemplateId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ActionUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Headers" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsConfirmationRequired" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsGroupDefault" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LabelKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LinkType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Method" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Position" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="RequestBody" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserAlias" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserVisibility" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -247,7 +318,10 @@ All Rights Reserved
                         <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ActivityDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="ActivitySubtype" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ActivityType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AlternateDetail" nillable="true" minOccurs="0" type="ens:EmailMessage"/>
+                        <element name="AlternateDetailId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CallDisposition" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CallDurationInSeconds" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="CallObject" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -261,6 +335,7 @@ All Rights Reserved
                         <element name="IsAllDayEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsClosed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHighPriority" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsReminderSet" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -354,6 +429,26 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="ApexEmailNotification">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="ApexLog">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -402,6 +497,23 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="ApexPageInfo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApexPageId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ApiVersion" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsAvailableInTouch" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NameSpacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="ApexTestQueueItem">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -415,6 +527,7 @@ All Rights Reserved
                         <element name="ParentJobId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TestRunResultId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -428,6 +541,9 @@ All Rights Reserved
                         <element name="ApexClassId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ApexLog" nillable="true" minOccurs="0" type="ens:ApexLog"/>
                         <element name="ApexLogId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ApexTestResults" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ApexTestRunResult" nillable="true" minOccurs="0" type="ens:ApexTestRunResult"/>
+                        <element name="ApexTestRunResultId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="AsyncApexJob" nillable="true" minOccurs="0" type="ens:AsyncApexJob"/>
                         <element name="AsyncApexJobId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Message" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -435,9 +551,94 @@ All Rights Reserved
                         <element name="Outcome" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="QueueItem" nillable="true" minOccurs="0" type="ens:ApexTestQueueItem"/>
                         <element name="QueueItemId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RunTime" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="StackTrace" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="TestTimestamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ApexTestResultLimits">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApexTestResult" nillable="true" minOccurs="0" type="ens:ApexTestResult"/>
+                        <element name="ApexTestResultId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="AsyncCalls" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Callouts" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Cpu" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Dml" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="DmlRows" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Email" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LimitContext" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LimitExceptions" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MobilePush" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="QueryRows" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Soql" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Sosl" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ApexTestRunResult">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AsyncApexJob" nillable="true" minOccurs="0" type="ens:AsyncApexJob"/>
+                        <element name="AsyncApexJobId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ClassesCompleted" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ClassesEnqueued" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="EndTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsAllTests" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="JobName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MethodsCompleted" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="MethodsEnqueued" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="MethodsFailed" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Source" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="StartTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TestTime" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ApexTestSuite">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApexClassIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
+                        <element name="ApexClassJunctions" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TestSuiteName" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -480,15 +681,24 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApplicationId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CanvasAccessMethod" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CanvasEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="CanvasOptions" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CanvasReferenceId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CanvasSelectedLocations" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CanvasUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IconUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="InfoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsAccessible" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsRegisteredDeviceOnly" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsUsingAdminAuthorization" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsVisible" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -509,6 +719,7 @@ All Rights Reserved
                         <element name="StartUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserSortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -545,26 +756,36 @@ All Rights Reserved
                         <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Cases" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ChildAssets" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Contact" nillable="true" minOccurs="0" type="ens:Contact"/>
                         <element name="ContactId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="InstallDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="IsCompetitorProduct" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Notes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="NotesAndAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="OpenActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:Asset"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Price" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -572,11 +793,33 @@ All Rights Reserved
                         <element name="Product2Id" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="PurchaseDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="Quantity" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="RootAsset" nillable="true" minOccurs="0" type="ens:Asset"/>
+                        <element name="RootAssetId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="SerialNumber" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="UsageEndDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AssetHistory">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Asset" nillable="true" minOccurs="0" type="ens:Asset"/>
+                        <element name="AssetId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Field" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="NewValue" nillable="true" minOccurs="0" type="xsd:anyType"/>
+                        <element name="OldValue" nillable="true" minOccurs="0" type="xsd:anyType"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -607,6 +850,7 @@ All Rights Reserved
                         <sequence>
                         <element name="ApexClass" nillable="true" minOccurs="0" type="ens:ApexClass"/>
                         <element name="ApexClassId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="AsyncApex" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CompletedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -621,6 +865,34 @@ All Rights Reserved
                         <element name="ParentJobId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="TotalJobItems" nillable="true" minOccurs="0" type="xsd:int"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AttachedContentDocument">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentDocument" nillable="true" minOccurs="0" type="ens:ContentDocument"/>
+                        <element name="ContentDocumentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ContentUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalDataSourceName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalDataSourceType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LinkedEntity" nillable="true" minOccurs="0" type="ens:Contract"/>
+                        <element name="LinkedEntityId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SharingOption" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -653,6 +925,134 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="AuraDefinition">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AuraDefinitionBundle" nillable="true" minOccurs="0" type="ens:AuraDefinitionBundle"/>
+                        <element name="AuraDefinitionBundleId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DefType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Format" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Source" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AuraDefinitionBundle">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApiVersion" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AuraDefinitionBundleInfo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApiVersion" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="AuraDefinitionBundleId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Bundle" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AuraDefinitionInfo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AuraDefinitionBundleInfo" nillable="true" minOccurs="0" type="ens:AuraDefinitionBundleInfo"/>
+                        <element name="AuraDefinitionBundleInfoId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AuraDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DefType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Format" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Source" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AuthConfig">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AuthOptionsAuthProvider" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="AuthOptionsSaml" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="AuthOptionsUsernamePassword" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="AuthProvidersForConfig" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Url" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="AuthConfigProviders">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AuthConfig" nillable="true" minOccurs="0" type="ens:AuthConfig"/>
+                        <element name="AuthConfigId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="AuthProvider" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="AuthProviderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="AuthProvider">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -661,11 +1061,19 @@ All Rights Reserved
                         <element name="ConsumerKey" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ConsumerSecret" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomMetadataTypeRecord" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DefaultScopes" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ErrorUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ExecutionUserId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="FriendlyName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IconUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IdTokenIssuer" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogoutUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OptionsIncludeOrgIdInId" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsSendAccessTokenInHeader" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsSendClientCredentialsInHeader" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PluginId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ProviderType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="RegistrationHandlerId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="TokenUrl" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -680,15 +1088,62 @@ All Rights Reserved
                     <extension base="ens:sObject">
                         <sequence>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsCurrent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LoginGeo" nillable="true" minOccurs="0" type="ens:LoginGeo"/>
+                        <element name="LoginGeoId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LoginHistory" nillable="true" minOccurs="0" type="ens:LoginHistory"/>
+                        <element name="LoginHistoryId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LoginType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogoutUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="NumSecondsValid" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SessionPermSetActivations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="SessionSecurityLevel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SessionType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SourceIp" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="UserType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Users" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="UsersId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="BackgroundOperation">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Error" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExecutionGroup" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExpiresAt" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="FinishedAt" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="GroupLeader" nillable="true" minOccurs="0" type="ens:BackgroundOperation"/>
+                        <element name="GroupLeaderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MergedOperations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NumFollowers" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ParentKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ProcessAfter" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="RetryBackoff" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="RetryCount" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="RetryLimit" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SequenceGroup" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SequenceNumber" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="StartedAt" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SubmittedAt" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Timeout" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        <element name="WorkerUri" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -801,16 +1256,20 @@ All Rights Reserved
                         <element name="ActualCost" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="AmountAllOpportunities" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="AmountWonOpportunities" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="BudgetedCost" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="CampaignMemberRecordType" nillable="true" minOccurs="0" type="ens:RecordType"/>
                         <element name="CampaignMemberRecordTypeId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CampaignMembers" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ChildCampaigns" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EndDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ExpectedResponse" nillable="true" minOccurs="0" type="xsd:double"/>
@@ -824,6 +1283,7 @@ All Rights Reserved
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Leads" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="NumberOfContacts" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="NumberOfConvertedLeads" nillable="true" minOccurs="0" type="xsd:int"/>
@@ -845,7 +1305,9 @@ All Rights Reserved
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -857,21 +1319,45 @@ All Rights Reserved
                         <sequence>
                         <element name="Campaign" nillable="true" minOccurs="0" type="ens:Campaign"/>
                         <element name="CampaignId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CompanyOrAccount" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Contact" nillable="true" minOccurs="0" type="ens:Contact"/>
                         <element name="ContactId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Country" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DoNotCall" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Fax" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FirstName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FirstRespondedDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="HasOptedOutOfEmail" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="HasOptedOutOfFax" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="HasResponded" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Lead" nillable="true" minOccurs="0" type="ens:Lead"/>
                         <element name="LeadId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LeadOrContactId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LeadOrContactOwner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="LeadOrContactOwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LeadSource" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MobilePhone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Salutation" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="State" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Street" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -911,6 +1397,7 @@ All Rights Reserved
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
@@ -926,6 +1413,7 @@ All Rights Reserved
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Asset" nillable="true" minOccurs="0" type="ens:Asset"/>
                         <element name="AssetId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CaseComments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CaseContactRoles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -935,11 +1423,18 @@ All Rights Reserved
                         <element name="ClosedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Contact" nillable="true" minOccurs="0" type="ens:Contact"/>
+                        <element name="ContactEmail" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ContactFax" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ContactId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContactMobile" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ContactPhone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EmailMessages" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EngineeringReqNumber__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="HasCommentsUnreadByOwner" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -953,6 +1448,7 @@ All Rights Reserved
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="OpenActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Origin" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
@@ -978,7 +1474,9 @@ All Rights Reserved
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="TeamMembers" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="TeamTemplateRecords" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1057,6 +1555,7 @@ All Rights Reserved
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
@@ -1085,6 +1584,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -1256,9 +1756,15 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ContentUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalDataSourceName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalDataSourceType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -1266,6 +1772,7 @@ All Rights Reserved
                         <element name="Parent" nillable="true" minOccurs="0" type="ens:Contract"/>
                         <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="RecordType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SharingOption" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
@@ -1281,10 +1788,39 @@ All Rights Reserved
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsPublished" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ConnectedApplication">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="InstalledMobileApps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MobileSessionTimeout" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MobileStartUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OptionsAllowAdminApprovedUsersOnly" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsHasSessionLevelPolicy" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsIsInternal" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsRefreshTokenValidityMetric" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PinLength" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RefreshTokenValidityPeriod" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SetupEntityAccessItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="StartUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
@@ -1303,12 +1839,14 @@ All Rights Reserved
                         <element name="Assets" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="AssistantName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="AssistantPhone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Birthdate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="CampaignMembers" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CaseContactRoles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Cases" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ContractContactRoles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ContractsSigned" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -1317,9 +1855,11 @@ All Rights Reserved
                         <element name="DeclinedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Department" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="EmailBouncedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="EmailBouncedReason" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EmailMessageRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EmailStatuses" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -1343,8 +1883,11 @@ All Rights Reserved
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LeadSource" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Level__c" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="MailingAddress" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="MailingCity" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="MailingCountry" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MailingGeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="MailingLatitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="MailingLongitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="MailingPostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -1359,8 +1902,10 @@ All Rights Reserved
                         <element name="OpenActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Opportunities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="OpportunityContactRoles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="OtherAddress" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="OtherCity" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="OtherCountry" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OtherGeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="OtherLatitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="OtherLongitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="OtherPhone" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -1370,6 +1915,7 @@ All Rights Reserved
                         <element name="Owner" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ReportsTo" nillable="true" minOccurs="0" type="ens:Contact"/>
@@ -1379,7 +1925,9 @@ All Rights Reserved
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="UndecidedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1415,7 +1963,90 @@ All Rights Reserved
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentAsset">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentDocument" nillable="true" minOccurs="0" type="ens:ContentDocument"/>
+                        <element name="ContentDocumentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentDistribution">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentDistributionViews" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentVersion" nillable="true" minOccurs="0" type="ens:ContentVersion"/>
+                        <element name="ContentVersionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DistributionPublicUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExpiryDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="FirstViewDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Password" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PreferencesAllowOriginalDownload" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesAllowPDFDownload" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesAllowViewInBrowser" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesExpires" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesLinkLatestVersion" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesNotifyOnVisit" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesNotifyRndtnComplete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesPasswordRequired" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="RelatedRecord" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="RelatedRecordId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ViewCount" nillable="true" minOccurs="0" type="xsd:int"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentDistributionView">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Distribution" nillable="true" minOccurs="0" type="ens:ContentDistribution"/>
+                        <element name="DistributionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDownload" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsInternal" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="ParentViewId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1427,9 +2058,19 @@ All Rights Reserved
                         <sequence>
                         <element name="ArchivedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ArchivedDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="ContentAsset" nillable="true" minOccurs="0" type="ens:ContentAsset"/>
+                        <element name="ContentAssetId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentDistributions" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ContentVersions" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsArchived" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -1444,8 +2085,10 @@ All Rights Reserved
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="PublishStatus" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SharingOption" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1480,6 +2123,87 @@ All Rights Reserved
                         <element name="LinkedEntityId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ShareType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Visibility" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentFolder">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentFolderLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ParentContentFolder" nillable="true" minOccurs="0" type="ens:ContentFolder"/>
+                        <element name="ParentContentFolderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentFolderItem">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsFolder" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ParentContentFolder" nillable="true" minOccurs="0" type="ens:ContentFolder"/>
+                        <element name="ParentContentFolderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentFolderLink">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentFolder" nillable="true" minOccurs="0" type="ens:ContentFolder"/>
+                        <element name="ContentFolderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="ParentEntityId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ContentFolderMember">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ChildRecord" nillable="true" minOccurs="0" type="ens:ContentDocument"/>
+                        <element name="ChildRecordId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ParentContentFolder" nillable="true" minOccurs="0" type="ens:ContentFolder"/>
+                        <element name="ParentContentFolderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1492,6 +2216,7 @@ All Rights Reserved
                         <element name="Checksum" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ContentDocument" nillable="true" minOccurs="0" type="ens:ContentDocument"/>
                         <element name="ContentDocumentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentLocation" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ContentModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ContentModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
@@ -1500,14 +2225,21 @@ All Rights Reserved
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalDataSource" nillable="true" minOccurs="0" type="ens:ExternalDataSource"/>
+                        <element name="ExternalDataSourceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ExternalDocumentInfo1" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalDocumentInfo2" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FeaturedContentBoost" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="FeaturedContentDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FirstPublishLocation" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="FirstPublishLocationId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="IsAssetEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsLatest" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsMajorVersion" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -1520,8 +2252,10 @@ All Rights Reserved
                         <element name="PublishStatus" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="RatingCount" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="ReasonForChange" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SharingOption" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="TagCsv" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TextPreview" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="VersionData" nillable="true" minOccurs="0" type="xsd:base64Binary"/>
                         <element name="VersionNumber" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -1552,6 +2286,10 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentFolderLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -1562,6 +2300,7 @@ All Rights Reserved
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastWorkspaceActivityDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="TagModel" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -1598,9 +2337,12 @@ All Rights Reserved
                         <element name="ActivatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Approvals" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="BillingAddress" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="BillingCity" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BillingCountry" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="BillingGeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BillingLatitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="BillingLongitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="BillingPostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -1610,6 +2352,7 @@ All Rights Reserved
                         <element name="CompanySigned" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CompanySignedDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="CompanySignedId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ContractContactRoles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ContractNumber" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ContractTerm" nillable="true" minOccurs="0" type="xsd:int"/>
@@ -1621,6 +2364,7 @@ All Rights Reserved
                         <element name="CustomerSignedId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CustomerSignedTitle" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EndDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -1632,9 +2376,11 @@ All Rights Reserved
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Notes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="NotesAndAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="OpenActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Opportunities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Owner" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="OwnerExpirationNotice" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -1646,6 +2392,8 @@ All Rights Reserved
                         <element name="StatusCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1696,6 +2444,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -1707,6 +2456,28 @@ All Rights Reserved
                         <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="StatusCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="CorsWhitelistEntry">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UrlPattern" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1748,21 +2519,129 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="CustomBrand">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomBrandAssets" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="CustomBrandAsset">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AssetCategory" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomBrand" nillable="true" minOccurs="0" type="ens:CustomBrand"/>
+                        <element name="CustomBrandId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ForeignKeyAssetId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TextAsset" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="CustomObjectUserLicenseMetrics">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CustomObjectId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CustomObjectName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CustomObjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MetricsDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="ObjectCount" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserLicense" nillable="true" minOccurs="0" type="ens:UserLicense"/>
+                        <element name="UserLicenseId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="CustomPermission">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomPermissionDependencyItem" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CustomPermissionItem" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GrantedByLicenses" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsProtected" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SetupEntityAccessItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="CustomPermissionDependency">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomPermission" nillable="true" minOccurs="0" type="ens:CustomPermission"/>
+                        <element name="CustomPermissionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="RequiredCustomPermission" nillable="true" minOccurs="0" type="ens:CustomPermission"/>
+                        <element name="RequiredCustomPermissionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="Dashboard">
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="BackgroundDirection" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BackgroundEnd" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="BackgroundStart" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="DashboardComponents" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="DashboardResultRefreshedDate" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DashboardResultRunningUser" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Folder" nillable="true" minOccurs="0" type="ens:Folder"/>
                         <element name="FolderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="FolderName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -1790,9 +2669,61 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Dashboard" nillable="true" minOccurs="0" type="ens:Dashboard"/>
                         <element name="DashboardId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="DataStatistics">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ExternalId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="StatType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="StatValue" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="DataType">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContextServiceDataTypeId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ContextWsdlDataTypeId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsComplex" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="DatacloudAddress">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AddressLine1" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AddressLine2" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Country" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GeoAccuracyCode" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GeoAccuracyNum" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Latitude" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Longitude" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="State" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -1886,6 +2817,7 @@ All Rights Reserved
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="OptionsExternalHttps" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
@@ -1907,6 +2839,176 @@ All Rights Reserved
                         <element name="PathPrefix" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Site" nillable="true" minOccurs="0" type="ens:Site"/>
                         <element name="SiteId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="DuplicateRecordItem">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DuplicateRecordSet" nillable="true" minOccurs="0" type="ens:DuplicateRecordSet"/>
+                        <element name="DuplicateRecordSetId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Record" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="RecordId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="DuplicateRecordSet">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="DuplicateRule" nillable="true" minOccurs="0" type="ens:DuplicateRule"/>
+                        <element name="DuplicateRuleId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="RecordCount" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="DuplicateRule">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DuplicateRecordSets" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SobjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="EmailDomainKey">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Domain" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DomainMatch" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PrivateKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PublicKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Selector" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="EmailMessage">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ActivityId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="BccAddress" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="BccIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
+                        <element name="CcAddress" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CcIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="EmailMessageRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="FromAddress" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FromName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HasAttachment" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Headers" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HtmlBody" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Incoming" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsExternallyVisible" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MessageDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:Case"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="RelatedTo" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="RelatedToId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ReplyToEmailMessage" nillable="true" minOccurs="0" type="ens:EmailMessage"/>
+                        <element name="ReplyToEmailMessageId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Subject" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TextBody" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ToAddress" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ToIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
+                        <element name="ValidatedFromAddress" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="EmailMessageRelation">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="EmailMessage" nillable="true" minOccurs="0" type="ens:EmailMessage"/>
+                        <element name="EmailMessageId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Relation" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="RelationAddress" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelationId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RelationObjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelationType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
@@ -1996,16 +3098,19 @@ All Rights Reserved
                     <extension base="ens:sObject">
                         <sequence>
                         <element name="ApiVersion" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Body" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="BrandTemplateId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Encoding" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Folder" nillable="true" minOccurs="0" type="ens:Folder"/>
                         <element name="FolderId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="HtmlValue" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2024,6 +3129,136 @@ All Rights Reserved
                         <element name="TemplateStyle" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="TemplateType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="TimesUsed" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="UiType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="EntityDefinition">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ChildRelationships" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="DefaultCompactLayoutId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DetailUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EditDefinitionUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EditUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalSharingModel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Fields" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="HasSubtypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="HelpSettingPageName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HelpSettingPageUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InternalSharingModel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsApexTriggerable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCompactLayoutable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCustomSetting" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCustomizable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeprecatedAndHidden" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsEverCreatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsEverDeletable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsEverUpdatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsFeedEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsIdEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsLayoutable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsMruEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsProcessEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsQueryable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsReplicateable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsRetrieveable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsSearchLayoutable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsSearchable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsTriggerable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsWorkflowEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="KeyPrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NewUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Particles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="PluralLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Publisher" nillable="true" minOccurs="0" type="ens:Publisher"/>
+                        <element name="PublisherId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="QualifiedApiName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RecordTypesSupported" nillable="true" minOccurs="0" type="tns:RecordTypesSupported"/>
+                        <element name="RelationshipDomains" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="RunningUserEntityAccess" nillable="true" minOccurs="0" type="ens:UserEntityAccess"/>
+                        <element name="RunningUserEntityAccessId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SearchLayouts" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="EntityParticle">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ByteLength" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="DataType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DefaultValueFormula" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Digits" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityDefinition" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="EntityDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExtraTypeInfo" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FieldDefinition" nillable="true" minOccurs="0" type="ens:FieldDefinition"/>
+                        <element name="FieldDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InlineHelpText" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsApiFilterable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsApiGroupable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsApiSortable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsAutonumber" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCalculated" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCaseSensitive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCompactLayoutable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsComponent" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCompound" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCreatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDefaultedOnCreate" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDependentPicklist" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeprecatedAndHidden" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDisplayLocationInDecimal" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsEncrypted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsFieldHistoryTracked" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHighScaleNumber" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHtmlFormatted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsIdLookup" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsLayoutable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsListVisible" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsNameField" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsNamePointing" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsNillable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsPermissionable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsUnique" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsUpdatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsWorkflowFilterable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsWriteRequiresMasterRead" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Length" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Mask" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MaskType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PicklistValues" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Precision" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="QualifiedApiName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ReferenceTargetField" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ReferenceTo" nillable="true" minOccurs="0" type="tns:RelationshipReferenceTo"/>
+                        <element name="RelationshipName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelationshipOrder" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Scale" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ServiceDataType" nillable="true" minOccurs="0" type="ens:DataType"/>
+                        <element name="ServiceDataTypeId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ValueType" nillable="true" minOccurs="0" type="ens:DataType"/>
+                        <element name="ValueTypeId" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2033,21 +3268,26 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AcceptedEventInviteeIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
                         <element name="AcceptedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ActivityDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="ActivityDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeclinedEventInviteeIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
                         <element name="DeclinedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DurationInMinutes" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="EndDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="EventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="EventSubtype" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="GroupEventType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsAllDayEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsArchived" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -2079,11 +3319,38 @@ All Rights Reserved
                         <element name="StartDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Subject" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UndecidedEventInviteeIds" nillable="true" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
                         <element name="UndecidedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="What" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="WhatId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Who" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="WhoId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="EventLogFile">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApiVersion" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="EventType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LogDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LogFile" nillable="true" minOccurs="0" type="xsd:base64Binary"/>
+                        <element name="LogFileContentType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogFileFieldNames" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogFileFieldTypes" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogFileLength" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2113,6 +3380,121 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="ExternalDataSource">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomConfiguration" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Endpoint" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsWritable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LargeIcon" nillable="true" minOccurs="0" type="ens:StaticResource"/>
+                        <element name="LargeIconId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PrincipalType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Protocol" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Repository" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SetupEntityAccessItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SmallIcon" nillable="true" minOccurs="0" type="ens:StaticResource"/>
+                        <element name="SmallIconId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserAuths" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ExternalDataUserAuth">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalDataSource" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="ExternalDataSourceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Password" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Protocol" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Username" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="FieldDefinition">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ControlledFields" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ControllingFieldDefinition" nillable="true" minOccurs="0" type="ens:FieldDefinition"/>
+                        <element name="ControllingFieldDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DataType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityDefinition" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="EntityDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExtraTypeInfo" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsApiFilterable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsApiGroupable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsApiSortable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCalculated" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCompactLayoutable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCompound" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsFieldHistoryTracked" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHighScaleNumber" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHtmlFormatted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsIndexed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsListFilterable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsListSortable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsListVisible" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsNameField" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsNillable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsWorkflowFilterable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Length" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Particles" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Precision" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Publisher" nillable="true" minOccurs="0" type="ens:Publisher"/>
+                        <element name="PublisherId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="QualifiedApiName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ReferenceTargetField" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ReferenceTo" nillable="true" minOccurs="0" type="tns:RelationshipReferenceTo"/>
+                        <element name="RelationshipDomains" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="RelationshipName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RunningUserFieldAccess" nillable="true" minOccurs="0" type="ens:UserFieldAccess"/>
+                        <element name="RunningUserFieldAccessId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Scale" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ServiceDataType" nillable="true" minOccurs="0" type="ens:DataType"/>
+                        <element name="ServiceDataTypeId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ValueType" nillable="true" minOccurs="0" type="ens:DataType"/>
+                        <element name="ValueTypeId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="FieldPermissions">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -2124,6 +3506,33 @@ All Rights Reserved
                         <element name="PermissionsRead" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="SobjectType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="FileSearchActivity">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AvgNumResults" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ClickRank" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="CountQueries" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CountUsers" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Period" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="QueryDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="QueryLanguage" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SearchTerm" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2153,6 +3562,64 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="FlexQueueItem">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AsyncApexJob" nillable="true" minOccurs="0" type="ens:AsyncApexJob"/>
+                        <element name="AsyncApexJobId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="FlexQueueItemId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="JobPosition" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="JobType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="FlowInterview">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CurrentElement" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Guid" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InterviewLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="PauseLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="FlowInterviewShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:FlowInterview"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="Folder">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -2170,6 +3637,33 @@ All Rights Reserved
                         <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="FolderedContentDocument">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentDocument" nillable="true" minOccurs="0" type="ens:ContentDocument"/>
+                        <element name="ContentDocumentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsFolder" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ParentContentFolder" nillable="true" minOccurs="0" type="ens:ContentFolder"/>
+                        <element name="ParentContentFolderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2187,6 +3681,27 @@ All Rights Reserved
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="UserRoleId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="GrantedByLicense">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomPermission" nillable="true" minOccurs="0" type="ens:CustomPermission"/>
+                        <element name="CustomPermissionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PermissionSetLicense" nillable="true" minOccurs="0" type="ens:PermissionSetLicense"/>
+                        <element name="PermissionSetLicenseId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2212,6 +3727,7 @@ All Rights Reserved
                         <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="QueueSobjects" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Related" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="RelatedId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2298,6 +3814,7 @@ All Rights Reserved
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         <element name="VoteScore" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="VoteTotal" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="Votes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -2330,15 +3847,44 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="InstalledMobileApp">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ConnectedApplication" nillable="true" minOccurs="0" type="ens:ConnectedApplication"/>
+                        <element name="ConnectedApplicationId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        <element name="Version" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="Invoice__c">
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Invoice_Total__c" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -2347,6 +3893,7 @@ All Rights Reserved
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Line_Items__r" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Notes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="NotesAndAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -2356,6 +3903,8 @@ All Rights Reserved
                         <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Status__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2367,13 +3916,16 @@ All Rights Reserved
                         <sequence>
                         <element name="AcceptedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Address" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="AnnualRevenue" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Campaign" nillable="true" minOccurs="0" type="ens:Campaign"/>
                         <element name="CampaignMembers" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Company" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ConvertedAccount" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="ConvertedAccountId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ConvertedContact" nillable="true" minOccurs="0" type="ens:Contact"/>
@@ -2388,14 +3940,17 @@ All Rights Reserved
                         <element name="CurrentGenerators__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DeclinedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="EmailBouncedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="EmailBouncedReason" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EmailMessageRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EmailStatuses" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Fax" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FirstName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Industry" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsConverted" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -2413,6 +3968,7 @@ All Rights Reserved
                         <element name="Latitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="LeadSource" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Longitude" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="MasterRecord" nillable="true" minOccurs="0" type="ens:Lead"/>
                         <element name="MasterRecordId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="MobilePhone" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2425,6 +3981,7 @@ All Rights Reserved
                         <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="PostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Primary__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -2440,7 +3997,9 @@ All Rights Reserved
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="UndecidedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         <element name="Website" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
@@ -2477,6 +4036,7 @@ All Rights Reserved
                         <element name="LeadAccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LeadId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
@@ -2487,6 +4047,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -2507,11 +4068,15 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Invoice__c" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Invoice__r" nillable="true" minOccurs="0" type="ens:Invoice__c"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -2519,6 +4084,7 @@ All Rights Reserved
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Line_Item_Total__c" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Merchandise__c" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Merchandise__r" nillable="true" minOccurs="0" type="ens:Merchandise__c"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2528,7 +4094,109 @@ All Rights Reserved
                         <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Quantity__c" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Unit_Price__c" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ListView">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsSoqlCompatible" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SobjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ListViewChart">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AggregateField" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AggregateType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ChartType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GroupingField" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SobjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ListViewChartInstance">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AggregateField" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AggregateType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ChartType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DataQuery" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GroupingField" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeletable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsEditable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsLastViewed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ListViewChart" nillable="true" minOccurs="0" type="ens:ListViewChart"/>
+                        <element name="ListViewChartId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ListViewContext" nillable="true" minOccurs="0" type="ens:ListView"/>
+                        <element name="ListViewContextId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SourceEntity" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="LoginGeo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Country" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CountryIso" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Latitude" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="LoginTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Longitude" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="PostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Subdivision" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2541,14 +4209,20 @@ All Rights Reserved
                         <element name="ApiType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ApiVersion" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Application" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AuthenticationServiceId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Browser" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CipherSuite" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ClientVersion" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CountryIso" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LoginGeo" nillable="true" minOccurs="0" type="ens:LoginGeo"/>
+                        <element name="LoginGeoId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LoginTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LoginType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LoginUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Platform" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SourceIp" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TlsProtocol" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
@@ -2571,6 +4245,141 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="LookedUpFromActivity">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
+                        <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ActivityDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="ActivitySubtype" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ActivityType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CallDisposition" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CallDurationInSeconds" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CallObject" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CallType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurationInMinutes" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="EndDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsAllDayEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsClosed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHighPriority" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsReminderSet" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsVisibleInSelfService" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Location" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Priority" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ReminderDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="StartDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Subject" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="What" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="WhatId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Who" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="WhoId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="Macro">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="MacroHistory">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Field" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Macro" nillable="true" minOccurs="0" type="ens:Macro"/>
+                        <element name="MacroId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="NewValue" nillable="true" minOccurs="0" type="xsd:anyType"/>
+                        <element name="OldValue" nillable="true" minOccurs="0" type="xsd:anyType"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="MacroInstruction">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Macro" nillable="true" minOccurs="0" type="ens:Macro"/>
+                        <element name="MacroId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Operation" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Target" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ValueRecord" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="MacroShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:Macro"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="MailmergeTemplate">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -2588,6 +4397,60 @@ All Rights Reserved
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastUsedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SecurityOptionsAttachmentHasFlash" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SecurityOptionsAttachmentHasXSSThreat" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SecurityOptionsAttachmentScannedForXSS" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SecurityOptionsAttachmentScannedforFlash" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="MatchingRule">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="BooleanFilter" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MatchEngine" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MatchingRuleItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RuleStatus" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SobjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="MatchingRuleItem">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="BlankValueBehavior" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Field" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MatchingMethod" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MatchingRule" nillable="true" minOccurs="0" type="ens:MatchingRule"/>
+                        <element name="MatchingRuleId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
@@ -2599,11 +4462,15 @@ All Rights Reserved
                     <extension base="ens:sObject">
                         <sequence>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DuplicateRecordItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastActivityDate" nillable="true" minOccurs="0" type="xsd:date"/>
@@ -2613,6 +4480,7 @@ All Rights Reserved
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Line_Items__r" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Notes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="NotesAndAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -2625,6 +4493,8 @@ All Rights Reserved
                         <element name="Quantity__c" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2652,6 +4522,34 @@ All Rights Reserved
                         <element name="UserRole" nillable="true" minOccurs="0" type="ens:UserRole"/>
                         <element name="UserRoleId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Username" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="NamedCredential">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CalloutOptionsAllowMergeFieldsInBody" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="CalloutOptionsAllowMergeFieldsInHeader" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="CalloutOptionsGenerateAuthorizationHeader" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Endpoint" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PrincipalType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SetupEntityAccessItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserAuths" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2705,6 +4603,26 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="OauthToken">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessToken" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AppMenuItem" nillable="true" minOccurs="0" type="ens:AppMenuItem"/>
+                        <element name="AppMenuItemId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="AppName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeleteToken" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastUsedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="RequestToken" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UseCount" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="ObjectPermissions">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -2737,7 +4655,10 @@ All Rights Reserved
                         <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ActivityDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="ActivitySubtype" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ActivityType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AlternateDetail" nillable="true" minOccurs="0" type="ens:EmailMessage"/>
+                        <element name="AlternateDetailId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CallDisposition" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CallDurationInSeconds" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="CallObject" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2751,6 +4672,7 @@ All Rights Reserved
                         <element name="IsAllDayEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsClosed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHighPriority" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsReminderSet" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -2783,17 +4705,20 @@ All Rights Reserved
                         <element name="AccountPartners" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Amount" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Campaign" nillable="true" minOccurs="0" type="ens:Campaign"/>
                         <element name="CampaignId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CloseDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="CurrentGenerators__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DeliveryInstallationStatus__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ExpectedRevenue" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="Fiscal" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2801,7 +4726,9 @@ All Rights Reserved
                         <element name="FiscalYear" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="ForecastCategory" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ForecastCategoryName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HasOpenActivity" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="HasOpportunityLineItem" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="HasOverdueTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsClosed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -2814,6 +4741,7 @@ All Rights Reserved
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LeadSource" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="MainCompetitors__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="NextStep" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -2838,9 +4766,11 @@ All Rights Reserved
                         <element name="StageName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="TotalOpportunityQuantity" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="TrackingNumber__c" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2944,16 +4874,21 @@ All Rights Reserved
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="ListPrice" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Opportunity" nillable="true" minOccurs="0" type="ens:Opportunity"/>
                         <element name="OpportunityId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="PricebookEntry" nillable="true" minOccurs="0" type="ens:PricebookEntry"/>
                         <element name="PricebookEntryId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Product2" nillable="true" minOccurs="0" type="ens:Product2"/>
+                        <element name="Product2Id" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProductCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Quantity" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="ServiceDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="TotalPrice" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="UnitPrice" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -2995,6 +4930,7 @@ All Rights Reserved
                         <element name="OpportunityAccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="OpportunityId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
@@ -3005,6 +4941,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3049,12 +4986,17 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="Address" nillable="true" minOccurs="0" type="tns:address"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ComplianceBccEmail" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Country" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomBrands" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="DefaultAccountAccess" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DefaultCalendarAccess" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DefaultCampaignAccess" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -3067,6 +5009,10 @@ All Rights Reserved
                         <element name="Division" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Fax" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FiscalYearStartMonth" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="GeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InstanceName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsReadOnly" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsSandbox" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LanguageLocaleKey" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -3076,14 +5022,17 @@ All Rights Reserved
                         <element name="MonthlyPageViewsEntitlement" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="MonthlyPageViewsUsed" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="OrganizationType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="PostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="PreferencesRequireOpportunityProducts" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="PreferencesS1BrowserEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesTerminateOldestSession" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PreferencesTransactionSecurityPolicy" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PrimaryContact" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ReceivesAdminInfoEmails" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="ReceivesInfoEmails" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SignupCountryIsoCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="State" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Street" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3091,6 +5040,126 @@ All Rights Reserved
                         <element name="UiSkin" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="UsesStartDateAsFiscalYearName" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="WebToCaseDefaultOrigin" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="OwnedContentDocument">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentDocument" nillable="true" minOccurs="0" type="ens:ContentDocument"/>
+                        <element name="ContentDocumentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentSize" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ContentUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalDataSourceName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalDataSourceType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileExtension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FileType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PackageBooleanValue">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsBlacktabEditable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsBlacktabReadable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsProtected" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PackageDateValue">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsBlacktabEditable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsBlacktabReadable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsProtected" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PackageIntegerValue">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsBlacktabEditable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsBlacktabReadable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsProtected" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:int"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PackageLicense">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AllowedLicenses" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExpirationDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsProvisioned" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UsedLicenses" nillable="true" minOccurs="0" type="xsd:int"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -3126,6 +5195,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3148,6 +5218,7 @@ All Rights Reserved
                         <element name="EndDate" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="FiscalYearSettings" nillable="true" minOccurs="0" type="ens:FiscalYearSettings"/>
                         <element name="FiscalYearSettingsId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="FullyQualifiedLabel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsForecastPeriod" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="Number" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="PeriodLabel" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -3170,66 +5241,119 @@ All Rights Reserved
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FieldPerms" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="HasActivationRequired" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsOwnedByProfile" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="License" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="LicenseId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ObjectPerms" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="PermissionsAccessCMC" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsActivateContract" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsAllowUniversalSearch" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsAllowViewKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsApiEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsAssignPermissionSets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsAssignTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsAuthorApex" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsBulkApiHardDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsBulkMacrosAllowed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCampaignInfluence2" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCanApproveFeedPost" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCanUseNewDashboardBuilder" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsChatterFileLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsConfigCustomRecs" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsConnectOrgToEnvironmentHub" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsContentAdministrator" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsConvertLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCreateCustomizeFilters" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCreatePackaging" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCreateTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCreateWorkspaces" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCustomMobileAppsAccess" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCustomSidebarOnAllPages" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCustomizeApplication" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsDelegatedTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsDeleteActivatedContract" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsDeleteTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsDistributeFromPersWksp" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditBrandTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditCaseComments" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditHtmlTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditOppLineItemUnitPrice" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditPublicDocuments" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditPublicTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditReadonlyFields" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEmailAdministration" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEmailMass" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEmailSingle" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEmailTemplateManagement" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEnableNotifications" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsExportReport" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsFlowUFLRequired" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsForceTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsGovernNetworks" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsIdentityConnect" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsIdentityEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsImportCustomObjects" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsImportLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsImportPersonal" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsInstallPackaging" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsLightningExperienceUser" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageAnalyticSnapshots" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageAuthProviders" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageBusinessHourHolidays" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCallCenters" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCases" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageContentPermissions" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageContentProperties" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageContentTypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCssUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageCustomPermissions" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCustomReportTypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDataCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDataIntegrations" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDynamicDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageEmailClientConfig" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageExchangeConfig" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageInteraction" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageInternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageIpAddresses" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageKnowledgeImportExport" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageLoginAccessPolicies" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageMobile" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageNetworks" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManagePasswordPolicies" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageProfilesPermissionsets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManagePvtRptsAndDashbds" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageRemoteAccess" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageRoles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageSearchPromotionRules" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageSelfService" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageSessionPermissionSets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageSharing" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageSolutions" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageSynonyms" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsMassInlineEdit" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsMergeTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsModerateNetworkUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsModifyAllData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsModifySecureAgents" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsNewReportBuilder" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsPasswordNeverExpires" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsPublishPackaging" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -3238,22 +5362,31 @@ All Rights Reserved
                         <element name="PermissionsRunReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsSalesConsole" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsScheduleReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsSelectFilesFromSalesforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsSendSitRequests" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsShareInternalArticles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsShowCompanyNameAsUserBadge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsSolutionImport" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsSubmitMacrosAllowed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsTransferAnyCase" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsTransferAnyEntity" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsTransferAnyLead" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsTwoFactorApi" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsUseTeamReassignWizards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewAllData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewAllUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewContent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewDataCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewEncryptedData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewEventLogFiles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewHelpLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewMyTeamsDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewSetup" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="Profile" nillable="true" minOccurs="0" type="ens:Profile"/>
                         <element name="ProfileId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SessionActivations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="SetupEntityAccessItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
-                        <element name="UserLicense" nillable="true" minOccurs="0" type="ens:UserLicense"/>
-                        <element name="UserLicenseId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -3282,64 +5415,115 @@ All Rights Reserved
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ExpirationDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="GrantedByLicenses" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MaximumPermissionsAccessCMC" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsActivateContract" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsAllowUniversalSearch" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsAllowViewKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsApiEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsAssignPermissionSets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsAssignTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsAuthorApex" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsBulkApiHardDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsBulkMacrosAllowed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsCampaignInfluence2" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsCanApproveFeedPost" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsCanUseNewDashboardBuilder" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsChatterFileLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsConfigCustomRecs" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsConnectOrgToEnvironmentHub" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsContentAdministrator" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsConvertLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsCreateCustomizeFilters" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsCreatePackaging" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsCreateTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsCreateWorkspaces" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsCustomMobileAppsAccess" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsCustomSidebarOnAllPages" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsCustomizeApplication" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsDelegatedTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsDeleteActivatedContract" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsDeleteTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsDistributeFromPersWksp" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsEditBrandTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditCaseComments" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsEditHtmlTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditOppLineItemUnitPrice" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditPublicDocuments" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsEditPublicTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditReadonlyFields" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEditTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsEditTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEmailAdministration" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsEmailMass" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsEmailSingle" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEmailTemplateManagement" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsEnableNotifications" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsExportReport" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsFlowUFLRequired" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsForceTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsGovernNetworks" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsIdentityConnect" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsIdentityEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsImportCustomObjects" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsImportLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsImportPersonal" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsInstallPackaging" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsLightningExperienceUser" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageAnalyticSnapshots" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageAuthProviders" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageBusinessHourHolidays" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageCallCenters" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageCases" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageContentPermissions" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageContentProperties" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageContentTypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageCssUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageCustomPermissions" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageCustomReportTypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageDataCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageDataIntegrations" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageDynamicDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageEmailClientConfig" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageExchangeConfig" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageInteraction" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageInternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageIpAddresses" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageKnowledgeImportExport" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageLoginAccessPolicies" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageMobile" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageNetworks" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManagePasswordPolicies" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageProfilesPermissionsets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManagePvtRptsAndDashbds" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageRemoteAccess" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageRoles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageSearchPromotionRules" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageSelfService" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageSessionPermissionSets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageSharing" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageSolutions" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageSynonyms" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsManageTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsManageUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsMassInlineEdit" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsMergeTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsModerateNetworkUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsModifyAllData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsModifySecureAgents" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsNewReportBuilder" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsPasswordNeverExpires" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsPublishPackaging" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -3348,14 +5532,24 @@ All Rights Reserved
                         <element name="MaximumPermissionsRunReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsSalesConsole" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsScheduleReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsSelectFilesFromSalesforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsSendSitRequests" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsShareInternalArticles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsShowCompanyNameAsUserBadge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsSolutionImport" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsSubmitMacrosAllowed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsTransferAnyCase" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsTransferAnyEntity" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsTransferAnyLead" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsTwoFactorApi" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsUseTeamReassignWizards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsViewAllData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsViewAllUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsViewContent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsViewDataCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsViewEncryptedData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsViewEventLogFiles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MaximumPermissionsViewHelpLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsViewMyTeamsDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="MaximumPermissionsViewSetup" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionSetLicenseAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
@@ -3390,6 +5584,106 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="PicklistValueInfo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityParticle" nillable="true" minOccurs="0" type="ens:EntityParticle"/>
+                        <element name="EntityParticleId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDefaultValue" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ValidFor" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PlatformAction">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ActionListContext" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ActionTarget" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ActionTargetType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Category" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ConfirmationMessage" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeviceFormat" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IconContentType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IconHeight" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="IconUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IconWidth" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="InvocationStatus" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InvokedByUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="InvokedByUserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IsGroupDefault" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsMassAction" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PrimaryColor" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelatedListRecordId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelatedSourceEntity" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Section" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SourceEntity" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Subtype" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PlatformCachePartition">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDefaultPartition" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PlatforCachePartitionTypes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="PlatformCachePartitionType">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AllocatedCapacity" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="AllocatedPurchasedCapacity" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="AllocatedTrialCapacity" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CacheType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PlatformCachePartition" nillable="true" minOccurs="0" type="ens:PlatformCachePartition"/>
+                        <element name="PlatformCachePartitionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="Pricebook2">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -3411,6 +5705,7 @@ All Rights Reserved
                         <element name="Opportunities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="PricebookEntries" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -3461,20 +5756,54 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
-            <complexType name="ProcessInstance">
+            <complexType name="ProcessDefinition">
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
-                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LockType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="State" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TableEnumOrId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ProcessInstance">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CompletedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ElapsedTimeInDays" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInHours" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInMinutes" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastActor" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastActorId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Nodes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ProcessDefinition" nillable="true" minOccurs="0" type="ens:ProcessDefinition"/>
+                        <element name="ProcessDefinitionId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Steps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="StepsAndWorkitems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SubmittedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="SubmittedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="TargetObject" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="TargetObjectId" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -3494,17 +5823,52 @@ All Rights Reserved
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ElapsedTimeInDays" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInHours" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInMinutes" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsPending" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OriginalActor" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="OriginalActorId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ProcessInstance" nillable="true" minOccurs="0" type="ens:ProcessInstance"/>
                         <element name="ProcessInstanceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProcessNode" nillable="true" minOccurs="0" type="ens:ProcessNode"/>
+                        <element name="ProcessNodeId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="RemindersSent" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="StepStatus" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="TargetObject" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="TargetObjectId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ProcessInstanceNode">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CompletedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ElapsedTimeInDays" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInHours" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInMinutes" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastActor" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastActorId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="NodeStatus" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ProcessInstance" nillable="true" minOccurs="0" type="ens:ProcessInstance"/>
+                        <element name="ProcessInstanceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProcessNode" nillable="true" minOccurs="0" type="ens:ProcessNode"/>
+                        <element name="ProcessNodeId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProcessNodeName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -3520,10 +5884,14 @@ All Rights Reserved
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ElapsedTimeInDays" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInHours" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInMinutes" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="OriginalActor" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="OriginalActorId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ProcessInstance" nillable="true" minOccurs="0" type="ens:ProcessInstance"/>
                         <element name="ProcessInstanceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="StepNodeId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="StepStatus" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
@@ -3540,11 +5908,29 @@ All Rights Reserved
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ElapsedTimeInDays" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInHours" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ElapsedTimeInMinutes" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OriginalActor" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="OriginalActorId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ProcessInstance" nillable="true" minOccurs="0" type="ens:ProcessInstance"/>
                         <element name="ProcessInstanceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ProcessNode">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ProcessDefinition" nillable="true" minOccurs="0" type="ens:ProcessDefinition"/>
+                        <element name="ProcessDefinitionId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
@@ -3557,30 +5943,55 @@ All Rights Reserved
                         <sequence>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Assets" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Family" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Notes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="NotesAndAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="OpenActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
-                        <element name="OpportunityLineItems" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="PricebookEntries" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ProductCode" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="Product2History">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Field" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="NewValue" nillable="true" minOccurs="0" type="xsd:anyType"/>
+                        <element name="OldValue" nillable="true" minOccurs="0" type="xsd:anyType"/>
+                        <element name="Product2" nillable="true" minOccurs="0" type="ens:Product2"/>
+                        <element name="Product2Id" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -3600,58 +6011,108 @@ All Rights Reserved
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PermissionsAccessCMC" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsActivateContract" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsAllowUniversalSearch" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsAllowViewKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsApiEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsAssignPermissionSets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsAssignTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsAuthorApex" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsBulkApiHardDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsBulkMacrosAllowed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCampaignInfluence2" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCanApproveFeedPost" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCanUseNewDashboardBuilder" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsChatterFileLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsConfigCustomRecs" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsConnectOrgToEnvironmentHub" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsContentAdministrator" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsConvertLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCreateCustomizeFilters" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCreateMultiforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCreateTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCreateWorkspaces" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsCustomMobileAppsAccess" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCustomSidebarOnAllPages" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsCustomizeApplication" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsDelegatedTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsDeleteActivatedContract" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsDeleteTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsDistributeFromPersWksp" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditBrandTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditCaseComments" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditEvent" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditHtmlTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditOppLineItemUnitPrice" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditPublicDocuments" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditPublicTemplates" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditReadonlyFields" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEditTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEditTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEmailAdministration" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEmailMass" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsEmailSingle" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEmailTemplateManagement" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsEnableNotifications" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsExportReport" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsFlowUFLRequired" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsForceTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsGovernNetworks" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsIdentityConnect" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsIdentityEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsImportCustomObjects" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsImportLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsImportPersonal" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsInstallMultiforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsLightningExperienceUser" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageAnalyticSnapshots" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageAuthProviders" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageBusinessHourHolidays" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCallCenters" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCases" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageContentPermissions" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageContentProperties" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageContentTypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCssUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageCustomPermissions" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageCustomReportTypes" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDataCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDataIntegrations" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageDynamicDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageEmailClientConfig" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageExchangeConfig" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageInteraction" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageInternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageIpAddresses" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageKnowledge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageKnowledgeImportExport" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageLeads" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageLoginAccessPolicies" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageMobile" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageNetworks" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManagePasswordPolicies" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageProfilesPermissionsets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManagePvtRptsAndDashbds" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageRemoteAccess" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageRoles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageSearchPromotionRules" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageSelfService" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageSessionPermissionSets" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageSharing" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageSolutions" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageSynonyms" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsManageTwoFactor" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsManageUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsMassInlineEdit" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsMergeTopics" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsModerateNetworkUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsModifyAllData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsModifySecureAgents" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsNewReportBuilder" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsPasswordNeverExpires" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsPublishMultiforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -3660,14 +6121,24 @@ All Rights Reserved
                         <element name="PermissionsRunReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsSalesConsole" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsScheduleReports" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsSelectFilesFromSalesforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsSendSitRequests" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsShareInternalArticles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsShowCompanyNameAsUserBadge" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsSolutionImport" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsSubmitMacrosAllowed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsTransferAnyCase" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsTransferAnyEntity" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsTransferAnyLead" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsTwoFactorApi" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsUseTeamReassignWizards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewAllData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewAllUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewContent" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewDataCategories" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewEncryptedData" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewEventLogFiles" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="PermissionsViewHelpLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewMyTeamsDashboards" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="PermissionsViewSetup" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3675,6 +6146,23 @@ All Rights Reserved
                         <element name="UserLicenseId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="UserType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Users" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="Publisher">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InstalledEntityDefinitions" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="InstalledFieldDefinitions" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="IsSalesforce" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="MajorVersion" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="MinorVersion" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -3731,6 +6219,7 @@ All Rights Reserved
                         <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FirstName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3772,15 +6261,61 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="RelationshipDomain">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ChildSobject" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="ChildSobjectId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Field" nillable="true" minOccurs="0" type="ens:FieldDefinition"/>
+                        <element name="FieldId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsCascadeDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeprecatedAndHidden" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsRestrictedDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="JunctionIdListNames" nillable="true" minOccurs="0" type="tns:JunctionIdListNames"/>
+                        <element name="ParentSobject" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="ParentSobjectId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelationshipInfo" nillable="true" minOccurs="0" type="ens:RelationshipInfo"/>
+                        <element name="RelationshipInfoId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RelationshipName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="RelationshipInfo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ChildSobject" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="ChildSobjectId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Field" nillable="true" minOccurs="0" type="ens:FieldDefinition"/>
+                        <element name="FieldId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsCascadeDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeprecatedAndHidden" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsRestrictedDelete" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="JunctionIdListNames" nillable="true" minOccurs="0" type="tns:JunctionIdListNames"/>
+                        <element name="RelationshipDomains" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="Report">
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FolderName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Format" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -3791,7 +6326,235 @@ All Rights Reserved
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SamlSsoConfig">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AttributeFormat" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AttributeName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Audience" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ErrorUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExecutionUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="ExecutionUserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="IdentityLocation" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IdentityMapping" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Issuer" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LoginUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogoutUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OptionsSpInitBinding" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsUserProvisioning" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="RequestSignatureMethod" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SamlJitHandler" nillable="true" minOccurs="0" type="ens:ApexClass"/>
+                        <element name="SamlJitHandlerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ValidationCert" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Version" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="Scontrol">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Binary" nillable="true" minOccurs="0" type="xsd:base64Binary"/>
+                        <element name="BodyLength" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ContentSource" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EncodingKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Filename" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HtmlWrapper" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SupportsCaching" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SearchActivity">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AvgNumResults" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ClickRank" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ClickedRecordName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CountQueries" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CountUsers" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="KbChannel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Period" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="QueryDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="QueryLanguage" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SearchTerm" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SearchLayout">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ButtonsDisplayed" nillable="true" minOccurs="0" type="tns:SearchLayoutButtonsDisplayed"/>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityDefinition" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="EntityDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FieldsDisplayed" nillable="true" minOccurs="0" type="tns:SearchLayoutFieldsDisplayed"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LayoutType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SearchPromotionRule">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Query" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SecureAgent">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AgentKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Priority" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="ProxyUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="ProxyUserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SecureAgentPlugins" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SecureAgentsCluster" nillable="true" minOccurs="0" type="ens:SecureAgentsCluster"/>
+                        <element name="SecureAgentsClusterId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SecureAgentPlugin">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PluginName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PluginType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RequestedVersion" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SecureAgent" nillable="true" minOccurs="0" type="ens:SecureAgent"/>
+                        <element name="SecureAgentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SecureAgentPluginProperties" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UpdateWindowEnd" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UpdateWindowStart" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SecureAgentPluginProperty">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PropertyName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="PropertyValue" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SecureAgentPlugin" nillable="true" minOccurs="0" type="ens:SecureAgentPlugin"/>
+                        <element name="SecureAgentPluginId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SecureAgentsCluster">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
@@ -3826,6 +6589,46 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="SessionPermSetActivation">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AuthSession" nillable="true" minOccurs="0" type="ens:AuthSession"/>
+                        <element name="AuthSessionId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PermissionSet" nillable="true" minOccurs="0" type="ens:PermissionSet"/>
+                        <element name="PermissionSetId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SetupAuditTrail">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Action" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DelegateUser" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Display" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Section" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="SetupEntityAccess">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -3847,6 +6650,10 @@ All Rights Reserved
                         <element name="Admin" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="AdminId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="AnalyticsTrackingCode" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ClickjackProtectionLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3855,6 +6662,8 @@ All Rights Reserved
                         <element name="DailyRequestTimeLimit" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="DailyRequestTimeUsed" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GuestUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="GuestUserId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -3862,12 +6671,14 @@ All Rights Reserved
                         <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="MonthlyPageViewsEntitlement" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OptionsAllowGuestSupportApi" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OptionsAllowHomePage" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OptionsAllowStandardAnswersPages" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OptionsAllowStandardIdeasPages" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OptionsAllowStandardLookups" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OptionsAllowStandardSearch" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="OptionsEnableFeeds" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="OptionsRequireHttps" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="SiteDomainPaths" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="SiteType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -3902,12 +6713,15 @@ All Rights Reserved
                     <extension base="ens:sObject">
                         <sequence>
                         <element name="ActivityHistories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CaseSolutions" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Emails" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Events" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Histories" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -3920,6 +6734,7 @@ All Rights Reserved
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LookedUpFromActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="OpenActivities" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Owner" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
@@ -3932,6 +6747,8 @@ All Rights Reserved
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Tasks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="TimesUsed" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
                         <element name="Votes" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         </sequence>
                     </extension>
@@ -3960,6 +6777,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -3999,6 +6817,52 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="StreamingChannel">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDynamic" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReferencedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="StreamingChannelShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:StreamingChannel"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="Task">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -4006,12 +6870,14 @@ All Rights Reserved
                         <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="ActivityDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Attachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CallDisposition" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CallDurationInSeconds" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="CallObject" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CallType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -4019,6 +6885,7 @@ All Rights Reserved
                         <element name="IsArchived" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsClosed" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsHighPriority" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsRecurrence" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="IsReminderSet" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -4034,6 +6901,7 @@ All Rights Reserved
                         <element name="RecurrenceInstance" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="RecurrenceInterval" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="RecurrenceMonthOfYear" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RecurrenceRegeneratedType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="RecurrenceStartDateOnly" nillable="true" minOccurs="0" type="xsd:date"/>
                         <element name="RecurrenceTimeZoneSidKey" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="RecurrenceType" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -4042,6 +6910,8 @@ All Rights Reserved
                         <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Subject" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TaskSubtype" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="TopicAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="What" nillable="true" minOccurs="0" type="ens:Name"/>
                         <element name="WhatId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="Who" nillable="true" minOccurs="0" type="ens:Name"/>
@@ -4055,6 +6925,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -4075,6 +6946,7 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="ApiName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
@@ -4086,6 +6958,156 @@ All Rights Reserved
                         <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="TenantUsageEntitlement">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AmountUsed" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CurrentAmountAllowed" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="EndDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="Frequency" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="HasRollover" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsPersistentResource" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OverageGrace" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ResourceGroupKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Setting" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="StartDate" nillable="true" minOccurs="0" type="xsd:date"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UsageDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="TestSuiteMembership">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApexClass" nillable="true" minOccurs="0" type="ens:ApexClass"/>
+                        <element name="ApexClassId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ApexTestSuite" nillable="true" minOccurs="0" type="ens:ApexTestSuite"/>
+                        <element name="ApexTestSuiteId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="ThirdPartyAccountLink">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Handle" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsNotSsoUsable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Provider" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="RemoteIdentifier" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SsoProvider" nillable="true" minOccurs="0" type="ens:AuthProvider"/>
+                        <element name="SsoProviderId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SsoProviderName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ThirdPartyAccountLinkKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="TodayGoal">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:double"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="TodayGoalShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:TodayGoal"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="Topic">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="CustomBrands" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="TalkingAbout" nillable="true" minOccurs="0" type="xsd:int"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="TopicAssignment">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Entity" nillable="true" minOccurs="0" type="ens:Contract"/>
+                        <element name="EntityId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="EntityKeyPrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Topic" nillable="true" minOccurs="0" type="ens:Topic"/>
+                        <element name="TopicId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -4119,38 +7141,54 @@ All Rights Reserved
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
+                        <element name="AboutMe" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="AcceptedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Account" nillable="true" minOccurs="0" type="ens:Account"/>
                         <element name="AccountId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Address" nillable="true" minOccurs="0" type="tns:address"/>
                         <element name="Alias" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="AttachedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="BadgeText" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="BannerPhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CallCenterId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CombinedAttachments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="CommunityNickname" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CompanyName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Contact" nillable="true" minOccurs="0" type="ens:Contact"/>
                         <element name="ContactId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ContentDocumentLinks" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="ContractsSigned" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Country" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="DeclinedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="DefaultGroupNotificationFrequency" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="DelegatedApproverId" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="DelegatedUsers" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Department" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="DigestFrequency" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Division" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="EmailEncodingKey" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EmailMessageRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="EmailPreferencesAutoBcc" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="EmailPreferencesAutoBccStayInTouch" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="EmailPreferencesStayInTouchReminder" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="EmployeeNumber" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="EventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Extension" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalDataUserAuths" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Fax" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FederationIdentifier" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="FirstName" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="ForecastEnabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="FullPhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="GeocodeAccuracy" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InstalledMobileApps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsProfilePhotoActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LanguageLocaleKey" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="LastLoginDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
@@ -4163,12 +7201,16 @@ All Rights Reserved
                         <element name="Latitude" nillable="true" minOccurs="0" type="xsd:double"/>
                         <element name="LocaleSidKey" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Longitude" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="ManagedUsers" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Manager" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="ManagerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="MediumBannerPhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MediumPhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="MobilePhone" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="OfflinePdaTrialExpirationDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="OfflineTrialExpirationDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="OwnedContentDocuments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="PermissionSetAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="PermissionSetLicenseAssignments" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -4179,7 +7221,11 @@ All Rights Reserved
                         <element name="ReceivesInfoEmails" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="SenderEmail" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SenderName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SessionPermSetActivations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="Shares" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="Signature" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SmallBannerPhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SmallPhotoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="State" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="StayInTouchNote" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="StayInTouchSignature" nillable="true" minOccurs="0" type="xsd:string"/>
@@ -4189,6 +7235,8 @@ All Rights Reserved
                         <element name="TimeZoneSidKey" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="UndecidedEventRelations" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserEntityAccessRights" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="UserFieldAccessRights" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="UserPermissionsCallCenterAutoLogin" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPermissionsChatterAnswersUser" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPermissionsInteractionUser" nillable="true" minOccurs="0" type="xsd:boolean"/>
@@ -4203,38 +7251,185 @@ All Rights Reserved
                         <element name="UserPreferences" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="UserPreferencesActivityRemindersPopup" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesApexPagesDeveloperMode" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesCacheDiagnostics" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesContentEmailAsAndWhen" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesContentNoEmail" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesCreateLEXAppsWTShown" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesDisableAllFeedsEmail" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesEventRemindersCheckboxDefault" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesGlobalNavBarWTShown" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesGlobalNavGridMenuWTShown" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesHideBiggerPhotoCallout" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesHideCSNDesktopTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesHideCSNGetChatterMobileTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesHideChatterOnboardingSplash" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesHideEndUserOnboardingAssistantModal" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesHideLightningMigrationModal" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesHideS1BrowserUI" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesHideSecondChatterOnboardingSplash" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesOptOutOfTouch" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesHideSfxWelcomeMat" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesLightningExperiencePreferred" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesPathAssistantCollapsed" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesPreviewLightning" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesReminderSoundOff" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowCityToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowCityToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowCountryToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowCountryToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowEmailToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesShowEmailToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowFaxToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesShowFaxToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowManagerToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesShowManagerToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowMobilePhoneToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesShowMobilePhoneToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowPostalCodeToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowPostalCodeToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowProfilePicToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowStateToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowStateToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowStreetAddressToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesShowStreetAddressToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowTitleToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowTitleToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesShowWorkPhoneToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserPreferencesShowWorkPhoneToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserPreferencesTaskRemindersCheckboxDefault" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="UserRole" nillable="true" minOccurs="0" type="ens:UserRole"/>
                         <element name="UserRoleId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserSites" nillable="true" minOccurs="0" type="tns:QueryResult"/>
                         <element name="UserType" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Username" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserAppInfo">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="FormFactor" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserAppMenuCustomization">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Application" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="ApplicationId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserAppMenuCustomizationShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:UserAppMenuCustomization"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserAppMenuItem">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AppMenuItemId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ApplicationId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Description" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IconUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="InfoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsUsingAdminAuthorization" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsVisible" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Label" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LogoUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="MobileStartUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="StartUrl" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Type" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserSortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserEntityAccess">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityDefinition" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="EntityDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsActivateable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCreatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsDeletable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsEditable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsFlsUpdatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsMergeable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsReadable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsUndeletable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsUpdatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserFieldAccess">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="DurableId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="EntityDefinition" nillable="true" minOccurs="0" type="ens:EntityDefinition"/>
+                        <element name="EntityDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="FieldDefinition" nillable="true" minOccurs="0" type="ens:FieldDefinition"/>
+                        <element name="FieldDefinitionId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsAccessible" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsCreatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsUpdatable" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -4255,6 +7450,52 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="UserListView">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastViewedChart" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ListView" nillable="true" minOccurs="0" type="ens:ListView"/>
+                        <element name="ListViewId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SobjectType" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserListViewCriterion">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ColumnName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Operation" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SortOrder" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserListView" nillable="true" minOccurs="0" type="ens:UserListView"/>
+                        <element name="UserListViewId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Value" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
             <complexType name="UserLogin">
                 <complexContent>
                     <extension base="ens:sObject">
@@ -4264,6 +7505,25 @@ All Rights Reserved
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserPackageLicense">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="PackageLicense" nillable="true" minOccurs="0" type="ens:PackageLicense"/>
+                        <element name="PackageLicenseId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
@@ -4283,64 +7543,208 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
-            <complexType name="UserProfile">
+            <complexType name="UserProvAccount">
                 <complexContent>
                     <extension base="ens:sObject">
                         <sequence>
-                        <element name="City" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="CompanyName" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="Country" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="Email" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="Fax" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="FirstName" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="IsBadged" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="ConnectedApp" nillable="true" minOccurs="0" type="ens:ConnectedApplication"/>
+                        <element name="ConnectedAppId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeletedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalEmail" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalFirstName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalLastName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUserId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUsername" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="IsKnownLink" nillable="true" minOccurs="0" type="xsd:boolean"/>
                         <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
                         <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
-                        <element name="LastName" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="Latitude" nillable="true" minOccurs="0" type="xsd:double"/>
-                        <element name="Longitude" nillable="true" minOccurs="0" type="xsd:double"/>
+                        <element name="LinkState" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SalesforceUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="SalesforceUserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserProvAccountStaging">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ConnectedApp" nillable="true" minOccurs="0" type="ens:ConnectedApplication"/>
+                        <element name="ConnectedAppId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalEmail" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalFirstName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalLastName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUserId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUsername" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LinkState" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SalesforceUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="SalesforceUserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserProvMockTarget">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalEmail" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalFirstName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalLastName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUserId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUsername" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserProvisioningConfig">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="ApprovalRequired" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ConnectedApp" nillable="true" minOccurs="0" type="ens:ConnectedApplication"/>
+                        <element name="ConnectedAppId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="DeveloperName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Enabled" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="EnabledOperations" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="Language" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LastReconDateTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="MasterLabel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="NamedCredential" nillable="true" minOccurs="0" type="ens:NamedCredential"/>
+                        <element name="NamedCredentialId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="NamespacePrefix" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Notes" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="OnUpdateAttributes" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ReconFilter" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="UserAccountMapping" nillable="true" minOccurs="0" type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserProvisioningLog">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Details" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUserId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ExternalUsername" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserProvisioningRequest" nillable="true" minOccurs="0" type="ens:UserProvisioningRequest"/>
+                        <element name="UserProvisioningRequestId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserProvisioningRequest">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AppName" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ApprovalStatus" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="ConnectedApp" nillable="true" minOccurs="0" type="ens:ConnectedApplication"/>
+                        <element name="ConnectedAppId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="ExternalUserId" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Manager" nillable="true" minOccurs="0" type="ens:User"/>
                         <element name="ManagerId" nillable="true" minOccurs="0" type="tns:ID"/>
-                        <element name="MobilePhone" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="Name" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="Phone" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="PostalCode" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Operation" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Owner" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="OwnerId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:UserProvisioningRequest"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ProcessInstances" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="ProcessSteps" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        <element name="RetryCount" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="SalesforceUser" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="SalesforceUserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="ScheduleDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="State" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="Street" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
-                        <element name="Title" nillable="true" minOccurs="0" type="xsd:string"/>
-                        <element name="UserPreferencesActivityRemindersPopup" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesApexPagesDeveloperMode" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesContentEmailAsAndWhen" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesContentNoEmail" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesEventRemindersCheckboxDefault" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesHideCSNDesktopTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesHideCSNGetChatterMobileTask" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesHideChatterOnboardingSplash" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesHideS1BrowserUI" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesHideSecondChatterOnboardingSplash" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesOptOutOfTouch" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesReminderSoundOff" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowCityToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowCityToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowCountryToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowCountryToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowEmailToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowFaxToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowManagerToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowMobilePhoneToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowPostalCodeToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowPostalCodeToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowProfilePicToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowStateToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowStateToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowStreetAddressToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowTitleToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowTitleToGuestUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesShowWorkPhoneToExternalUsers" nillable="true" minOccurs="0" type="xsd:boolean"/>
-                        <element name="UserPreferencesTaskRemindersCheckboxDefault" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="UserProvAccount" nillable="true" minOccurs="0" type="ens:UserProvAccount"/>
+                        <element name="UserProvAccountId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserProvConfig" nillable="true" minOccurs="0" type="ens:UserProvisioningConfig"/>
+                        <element name="UserProvConfigId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserRecordAccess" nillable="true" minOccurs="0" type="ens:UserRecordAccess"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserProvisioningRequestShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="AccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="Parent" nillable="true" minOccurs="0" type="ens:UserProvisioningRequest"/>
+                        <element name="ParentId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -4384,6 +7788,58 @@ All Rights Reserved
                         <element name="RollupDescription" nillable="true" minOccurs="0" type="xsd:string"/>
                         <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         <element name="Users" nillable="true" minOccurs="0" type="tns:QueryResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="UserShare">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="IsActive" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="RowCause" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserAccessLevel" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="UserOrGroup" nillable="true" minOccurs="0" type="ens:Name"/>
+                        <element name="UserOrGroupId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="VerificationHistory">
+                <complexContent>
+                    <extension base="ens:sObject">
+                        <sequence>
+                        <element name="Activity" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="CreatedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="CreatedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="CreatedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="EventGroup" nillable="true" minOccurs="0" type="xsd:int"/>
+                        <element name="IsDeleted" nillable="true" minOccurs="0" type="xsd:boolean"/>
+                        <element name="LastModifiedBy" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="LastModifiedById" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LastModifiedDate" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="LoginGeo" nillable="true" minOccurs="0" type="ens:LoginGeo"/>
+                        <element name="LoginGeoId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="LoginHistory" nillable="true" minOccurs="0" type="ens:LoginHistory"/>
+                        <element name="LoginHistoryId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="Policy" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Remarks" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Resource" nillable="true" minOccurs="0" type="ens:ConnectedApplication"/>
+                        <element name="ResourceId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="SourceIp" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="Status" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="SystemModstamp" nillable="true" minOccurs="0" type="xsd:dateTime"/>
+                        <element name="User" nillable="true" minOccurs="0" type="ens:User"/>
+                        <element name="UserId" nillable="true" minOccurs="0" type="tns:ID"/>
+                        <element name="VerificationMethod" nillable="true" minOccurs="0" type="xsd:string"/>
+                        <element name="VerificationTime" nillable="true" minOccurs="0" type="xsd:dateTime"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -4459,6 +7915,35 @@ All Rights Reserved
                 </restriction>
             </simpleType>
 
+            
+
+            <!-- Compound datatype: Address -->
+            <complexType name="address">
+                <complexContent>
+                    <extension base="tns:location">
+                        <sequence>
+                            <element name="city" type="xsd:string"  nillable="true" />
+                            <element name="country" type="xsd:string"  nillable="true" />
+                            <element name="countryCode" type="xsd:string"  nillable="true" />
+                            <element name="geocodeAccuracy" type="xsd:string"  nillable="true" />
+                            <element name="postalCode" type="xsd:string"  nillable="true" />
+                            <element name="state" type="xsd:string"  nillable="true" />
+                            <element name="stateCode" type="xsd:string"  nillable="true" />
+                            <element name="street" type="xsd:string"  nillable="true" />
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <!-- Compound datatype: Location -->
+            <complexType name="location">
+                <sequence>
+                    <element name="latitude" type="xsd:double"  nillable="true" />
+                    <element name="longitude" type="xsd:double"  nillable="true" />
+                </sequence>
+            </complexType>
+
+            
             <simpleType name="QueryLocator">
                 <restriction base="xsd:string"/>
             </simpleType>
@@ -4478,23 +7963,119 @@ All Rights Reserved
             <!-- Search Result -->
             <complexType name="SearchResult">
                 <sequence>
-                    <element name="searchRecords"  minOccurs="0" maxOccurs="unbounded" type="tns:SearchRecord"/>
-                    <element name="sforceReserved" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+                    
+                        <element name="queryId" type="xsd:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+                    
+                    <element name="searchRecords" minOccurs="0" maxOccurs="unbounded" type="tns:SearchRecord"/>
+                    
+                        <element name="searchResultsMetadata" type="tns:SearchResultsMetadata" nillable="true" minOccurs="0" maxOccurs="1"/>
+                    
+                    
                 </sequence>
             </complexType>
 
             <complexType name="SearchRecord">
                 <sequence>
                     <element name="record" type="ens:sObject"/>
+                    <element name="snippet" nillable="true" minOccurs="0" maxOccurs="1" type="tns:SearchSnippet"/>
                 </sequence>
             </complexType>
+
+            <complexType name="SearchSnippet">
+                <sequence>
+                    <element name="text" nillable="true" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+                    <element name="wholeFields" minOccurs="0" maxOccurs="unbounded" type="tns:NameValuePair"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="SearchResultsMetadata">
+                <sequence>
+                	<element name="entityLabelMetadata" nillable="false" minOccurs="0" maxOccurs="unbounded" type="tns:LabelsSearchMetadata"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="LabelsSearchMetadata">
+                <sequence>
+                	<element name="entityFieldLabels" nillable="false" minOccurs="0" maxOccurs="unbounded" type="tns:NameValuePair"/>
+                    <element name="entityName" nillable="false" minOccurs="1" maxOccurs="1" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="RelationshipReferenceTo">
+                <sequence>
+                    <element name="referenceTo" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="RecordTypesSupported">
+                <sequence>
+                    <element name="recordTypeInfos" minOccurs="0" maxOccurs="unbounded" type="tns:RecordTypeInfo"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="JunctionIdListNames">
+                <sequence>
+                    <element name="names" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+           <complexType name="SearchLayoutButtonsDisplayed">
+                <sequence>
+                    <element name="applicable" type="xsd:boolean"/>
+                    <element name="buttons" minOccurs="0" maxOccurs="unbounded" type="tns:SearchLayoutButton"/>
+                </sequence>
+           </complexType>
+
+           <complexType name="SearchLayoutButton">
+                <sequence>
+                    <element name="apiName" type="xsd:string"/>
+                    <element name="label" type="xsd:string"/>
+                </sequence>
+           </complexType>
+
+           <complexType name="SearchLayoutFieldsDisplayed">
+                <sequence>
+                    <element name="applicable" type="xsd:boolean"/>
+                    <element name="fields" minOccurs="0" maxOccurs="unbounded" type="tns:SearchLayoutField"/>
+                </sequence>
+           </complexType>
+
+           <complexType name="SearchLayoutField">
+                <sequence>
+                    <element name="apiName" type="xsd:string"/>
+                    <element name="label" type="xsd:string"/>
+                    <element name="sortable" type="xsd:boolean"/>
+                </sequence>
+           </complexType>
+
+            <!-- Common name-value pair -->
+            <complexType name="NameValuePair">
+                <sequence>
+                    <element name="name" type="xsd:string" />
+                    <element name="value" type="xsd:string" />
+                </sequence>
+            </complexType>
+
+            <complexType name="NameObjectValuePair">
+                <sequence>
+                    <element name="name" type="xsd:string"/>
+                    <element name="value" type="xsd:anyType" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
 
             <!-- GetUpdated Result -->
             <complexType name="GetUpdatedResult">
                 <sequence>
                     <element name="ids" minOccurs="0" maxOccurs="unbounded" type="tns:ID"/>
                     <element name="latestDateCovered" type="xsd:dateTime"/>
-                    <element name="sforceReserved" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+                    
                 </sequence>
             </complexType>
 
@@ -4504,7 +8085,7 @@ All Rights Reserved
                     <element name="deletedRecords" minOccurs="0" maxOccurs="unbounded" type="tns:DeletedRecord"/>
                     <element name="earliestDateAvailable" type="xsd:dateTime"/>
                     <element name="latestDateCovered" type="xsd:dateTime"/>
-                    <element name="sforceReserved" minOccurs="0" maxOccurs="1" type="xsd:string"/>
+                    
                 </sequence>
             </complexType>
 
@@ -4544,8 +8125,10 @@ All Rights Reserved
                 <sequence>
                     <element name="accessibilityMode"          type="xsd:boolean"/>
                     <element name="currencySymbol"             type="xsd:string" nillable="true"/>
+
                     <element name="orgAttachmentFileSizeLimit" type="xsd:int"/>
                     <element name="orgDefaultCurrencyIsoCode"  type="xsd:string" nillable="true"/>
+                    <element name="orgDefaultCurrencyLocale"   type="xsd:string" nillable="true"/>
                     <element name="orgDisallowHtmlAttachments" type="xsd:boolean"/>
                     <element name="orgHasPersonAccounts"       type="xsd:boolean"/>
                     <element name="organizationId"             type="tns:ID"/>
@@ -4580,11 +8163,14 @@ All Rights Reserved
                 </sequence>
             </complexType>
 
+
             <simpleType name="StatusCode">
                 <restriction base="xsd:string">
                     <enumeration value="ALL_OR_NONE_OPERATION_ROLLED_BACK"/>
                     <enumeration value="ALREADY_IN_PROCESS"/>
+                    <enumeration value="APEX_DATA_ACCESS_RESTRICTION"/>
                     <enumeration value="ASSIGNEE_TYPE_REQUIRED"/>
+                    <enumeration value="AURA_COMPILE_ERROR"/>
                     <enumeration value="BAD_CUSTOM_ENTITY_PARENT_DOMAIN"/>
                     <enumeration value="BCC_NOT_ALLOWED_IF_BCC_COMPLIANCE_ENABLED"/>
                     <enumeration value="CANNOT_CASCADE_PRODUCT_ACTIVE"/>
@@ -4592,6 +8178,7 @@ All Rights Reserved
                     <enumeration value="CANNOT_CHANGE_FIELD_TYPE_OF_REFERENCED_FIELD"/>
                     <enumeration value="CANNOT_CREATE_ANOTHER_MANAGED_PACKAGE"/>
                     <enumeration value="CANNOT_DEACTIVATE_DIVISION"/>
+                    <enumeration value="CANNOT_DELETE_GLOBAL_ACTION_LIST"/>
                     <enumeration value="CANNOT_DELETE_LAST_DATED_CONVERSION_RATE"/>
                     <enumeration value="CANNOT_DELETE_MANAGED_OBJECT"/>
                     <enumeration value="CANNOT_DISABLE_LAST_ADMIN"/>
@@ -4601,6 +8188,7 @@ All Rights Reserved
                     <enumeration value="CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY"/>
                     <enumeration value="CANNOT_MODIFY_MANAGED_OBJECT"/>
                     <enumeration value="CANNOT_PASSWORD_LOCKOUT"/>
+                    <enumeration value="CANNOT_POST_TO_ARCHIVED_GROUP"/>
                     <enumeration value="CANNOT_RENAME_APEX_REFERENCED_FIELD"/>
                     <enumeration value="CANNOT_RENAME_APEX_REFERENCED_OBJECT"/>
                     <enumeration value="CANNOT_RENAME_REFERENCED_FIELD"/>
@@ -4611,8 +8199,11 @@ All Rights Reserved
                     <enumeration value="CANT_UNSET_CORP_CURRENCY"/>
                     <enumeration value="CHILD_SHARE_FAILS_PARENT"/>
                     <enumeration value="CIRCULAR_DEPENDENCY"/>
+                    <enumeration value="CLEAN_SERVICE_ERROR"/>
                     <enumeration value="COLLISION_DETECTED"/>
                     <enumeration value="COMMUNITY_NOT_ACCESSIBLE"/>
+                    <enumeration value="CONFLICTING_ENVIRONMENT_HUB_MEMBER"/>
+                    <enumeration value="CONFLICTING_SSO_USER_MAPPING"/>
                     <enumeration value="CUSTOM_APEX_ERROR"/>
                     <enumeration value="CUSTOM_CLOB_FIELD_LIMIT_EXCEEDED"/>
                     <enumeration value="CUSTOM_ENTITY_OR_FIELD_LIMIT"/>
@@ -4620,11 +8211,16 @@ All Rights Reserved
                     <enumeration value="CUSTOM_INDEX_EXISTS"/>
                     <enumeration value="CUSTOM_LINK_LIMIT_EXCEEDED"/>
                     <enumeration value="CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
                     <enumeration value="CUSTOM_TAB_LIMIT_EXCEEDED"/>
+                    <enumeration value="DATACLOUDADDRESS_NO_RECORDS_FOUND"/>
+                    <enumeration value="DATACLOUDADDRESS_PROCESSING_ERROR"/>
+                    <enumeration value="DATACLOUDADDRESS_SERVER_ERROR"/>
                     <enumeration value="DELETE_FAILED"/>
                     <enumeration value="DELETE_OPERATION_TOO_LARGE"/>
                     <enumeration value="DELETE_REQUIRED_ON_CASCADE"/>
                     <enumeration value="DEPENDENCY_EXISTS"/>
+                    <enumeration value="DUPLICATES_DETECTED"/>
                     <enumeration value="DUPLICATE_CASE_SOLUTION"/>
                     <enumeration value="DUPLICATE_COMM_NICKNAME"/>
                     <enumeration value="DUPLICATE_CUSTOM_ENTITY_DEFINITION"/>
@@ -4635,27 +8231,54 @@ All Rights Reserved
                     <enumeration value="DUPLICATE_SENDER_DISPLAY_NAME"/>
                     <enumeration value="DUPLICATE_USERNAME"/>
                     <enumeration value="DUPLICATE_VALUE"/>
+                    <enumeration value="EMAIL_ADDRESS_BOUNCED"/>
+                    <enumeration value="EMAIL_EXTERNAL_TRANSPORT_CONNECTION_ERROR"/>
+                    <enumeration value="EMAIL_EXTERNAL_TRANSPORT_TOKEN_ERROR"/>
+                    <enumeration value="EMAIL_EXTERNAL_TRANSPORT_TOO_MANY_REQUESTS_ERROR"/>
+                    <enumeration value="EMAIL_EXTERNAL_TRANSPORT_UNKNOWN_ERROR"/>
                     <enumeration value="EMAIL_NOT_PROCESSED_DUE_TO_PRIOR_ERROR"/>
+                    <enumeration value="EMAIL_OPTED_OUT"/>
+                    <enumeration value="EMAIL_TEMPLATE_FORMULA_ERROR"/>
+                    <enumeration value="EMAIL_TEMPLATE_MERGEFIELD_ACCESS_ERROR"/>
+                    <enumeration value="EMAIL_TEMPLATE_MERGEFIELD_ERROR"/>
+                    <enumeration value="EMAIL_TEMPLATE_MERGEFIELD_VALUE_ERROR"/>
+                    <enumeration value="EMAIL_TEMPLATE_PROCESSING_ERROR"/>
                     <enumeration value="EMPTY_SCONTROL_FILE_NAME"/>
                     <enumeration value="ENTITY_FAILED_IFLASTMODIFIED_ON_UPDATE"/>
                     <enumeration value="ENTITY_IS_ARCHIVED"/>
                     <enumeration value="ENTITY_IS_DELETED"/>
                     <enumeration value="ENTITY_IS_LOCKED"/>
+                    <enumeration value="ENTITY_SAVE_ERROR"/>
+                    <enumeration value="ENTITY_SAVE_VALIDATION_ERROR"/>
                     <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
                     <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_ERROR_JOINING_HUB"/>
                     <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_USER_ALREADY_IN_HUB"/>
                     <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_USER_NOT_ORG_ADMIN"/>
                     <enumeration value="ERROR_IN_MAILER"/>
+                    <enumeration value="EXCHANGE_WEB_SERVICES_URL_INVALID"/>
                     <enumeration value="FAILED_ACTIVATION"/>
                     <enumeration value="FIELD_CUSTOM_VALIDATION_EXCEPTION"/>
                     <enumeration value="FIELD_FILTER_VALIDATION_EXCEPTION"/>
                     <enumeration value="FIELD_INTEGRITY_EXCEPTION"/>
+                    <enumeration value="FIELD_KEYWORD_LIST_MATCH_LIMIT"/>
+                    <enumeration value="FIELD_MAPPING_ERROR"/>
+                    <enumeration value="FIELD_MODERATION_RULE_BLOCK"/>
+                    <enumeration value="FIELD_NOT_UPDATABLE"/>
+                    <enumeration value="FILE_EXTENSION_NOT_ALLOWED"/>
+                    <enumeration value="FILE_SIZE_LIMIT_EXCEEDED"/>
                     <enumeration value="FILTERED_LOOKUP_LIMIT_EXCEEDED"/>
+                    <enumeration value="FIND_DUPLICATES_ERROR"/>
+                    <enumeration value="FUNCTIONALITY_NOT_ENABLED"/>
+                    <enumeration value="HAS_PUBLIC_REFERENCES"/>
                     <enumeration value="HTML_FILE_UPLOAD_NOT_ALLOWED"/>
                     <enumeration value="IMAGE_TOO_LARGE"/>
                     <enumeration value="INACTIVE_OWNER_OR_USER"/>
+                    <enumeration value="INACTIVE_RULE_ERROR"/>
+                    <enumeration value="INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE"/>
                     <enumeration value="INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY"/>
                     <enumeration value="INSUFFICIENT_ACCESS_OR_READONLY"/>
+                    <enumeration value="INSUFFICIENT_ACCESS_TO_INSIGHTSEXTERNALDATA"/>
+                    <enumeration value="INSUFFICIENT_CREDITS"/>
                     <enumeration value="INVALID_ACCESS_LEVEL"/>
                     <enumeration value="INVALID_ARGUMENT_TYPE"/>
                     <enumeration value="INVALID_ASSIGNEE_TYPE"/>
@@ -4672,6 +8295,12 @@ All Rights Reserved
                     <enumeration value="INVALID_DATA_URI"/>
                     <enumeration value="INVALID_EMAIL_ADDRESS"/>
                     <enumeration value="INVALID_EMPTY_KEY_OWNER"/>
+                    <enumeration value="INVALID_ENTITY_FOR_MATCH_ENGINE_ERROR"/>
+                    <enumeration value="INVALID_ENTITY_FOR_MATCH_OPERATION_ERROR"/>
+                    <enumeration value="INVALID_ENTITY_FOR_UPSERT"/>
+                    <enumeration value="INVALID_ENVIRONMENT_HUB_MEMBER"/>
+                    <enumeration value="INVALID_EVENT_DELIVERY"/>
+                    <enumeration value="INVALID_EVENT_SUBSCRIPTION"/>
                     <enumeration value="INVALID_FIELD"/>
                     <enumeration value="INVALID_FIELD_FOR_INSERT_UPDATE"/>
                     <enumeration value="INVALID_FIELD_WHEN_USING_TEMPLATE"/>
@@ -4679,29 +8308,40 @@ All Rights Reserved
                     <enumeration value="INVALID_GOOGLE_DOCS_URL"/>
                     <enumeration value="INVALID_ID_FIELD"/>
                     <enumeration value="INVALID_INET_ADDRESS"/>
+                    <enumeration value="INVALID_INPUT"/>
                     <enumeration value="INVALID_LINEITEM_CLONE_STATE"/>
+                    <enumeration value="INVALID_MARKUP"/>
                     <enumeration value="INVALID_MASTER_OR_TRANSLATED_SOLUTION"/>
                     <enumeration value="INVALID_MESSAGE_ID_REFERENCE"/>
+                    <enumeration value="INVALID_NAMESPACE_PREFIX"/>
                     <enumeration value="INVALID_OAUTH_URL"/>
                     <enumeration value="INVALID_OPERATION"/>
                     <enumeration value="INVALID_OPERATOR"/>
                     <enumeration value="INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST"/>
                     <enumeration value="INVALID_OWNER"/>
+                    <enumeration value="INVALID_PACKAGE_LICENSE"/>
                     <enumeration value="INVALID_PACKAGE_VERSION"/>
                     <enumeration value="INVALID_PARTNER_NETWORK_STATUS"/>
                     <enumeration value="INVALID_PERSON_ACCOUNT_OPERATION"/>
                     <enumeration value="INVALID_QUERY_LOCATOR"/>
                     <enumeration value="INVALID_READ_ONLY_USER_DML"/>
+                    <enumeration value="INVALID_RUNTIME_VALUE"/>
                     <enumeration value="INVALID_SAVE_AS_ACTIVITY_FLAG"/>
                     <enumeration value="INVALID_SESSION_ID"/>
                     <enumeration value="INVALID_SETUP_OWNER"/>
                     <enumeration value="INVALID_SIGNUP_COUNTRY"/>
+                    <enumeration value="INVALID_SIGNUP_OPTION"/>
+                    <enumeration value="INVALID_SITE_DELETE_EXCEPTION"/>
+                    <enumeration value="INVALID_SITE_FILE_IMPORTED_EXCEPTION"/>
+                    <enumeration value="INVALID_SITE_FILE_TYPE_EXCEPTION"/>
                     <enumeration value="INVALID_STATUS"/>
                     <enumeration value="INVALID_SUBDOMAIN"/>
                     <enumeration value="INVALID_TYPE"/>
                     <enumeration value="INVALID_TYPE_FOR_OPERATION"/>
                     <enumeration value="INVALID_TYPE_ON_FIELD_IN_RECORD"/>
+                    <enumeration value="INVALID_USERID"/>
                     <enumeration value="IP_RANGE_LIMIT_EXCEEDED"/>
+                    <enumeration value="JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
                     <enumeration value="LICENSE_LIMIT_EXCEEDED"/>
                     <enumeration value="LIGHT_PORTAL_USER_EXCEPTION"/>
                     <enumeration value="LIMIT_EXCEEDED"/>
@@ -4709,14 +8349,32 @@ All Rights Reserved
                     <enumeration value="MANAGER_NOT_DEFINED"/>
                     <enumeration value="MASSMAIL_RETRY_LIMIT_EXCEEDED"/>
                     <enumeration value="MASS_MAIL_LIMIT_EXCEEDED"/>
+                    <enumeration value="MATCH_DEFINITION_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_INVALID_ENGINE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_INVALID_RULE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_ENGINE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_OBJECT_TYPE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_OPTIONS_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_MISSING_RULE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_UNKNOWN_RULE_ERROR"/>
+                    <enumeration value="MATCH_OPERATION_UNSUPPORTED_VERSION_ERROR"/>
+                    <enumeration value="MATCH_PRECONDITION_FAILED"/>
+                    <enumeration value="MATCH_RUNTIME_ERROR"/>
+                    <enumeration value="MATCH_SERVICE_ERROR"/>
+                    <enumeration value="MATCH_SERVICE_TIMED_OUT"/>
+                    <enumeration value="MATCH_SERVICE_UNAVAILABLE_ERROR"/>
                     <enumeration value="MAXIMUM_CCEMAILS_EXCEEDED"/>
                     <enumeration value="MAXIMUM_DASHBOARD_COMPONENTS_EXCEEDED"/>
+                    <enumeration value="MAXIMUM_HIERARCHY_CHILDREN_REACHED"/>
                     <enumeration value="MAXIMUM_HIERARCHY_LEVELS_REACHED"/>
+                    <enumeration value="MAXIMUM_HIERARCHY_TREE_SIZE_REACHED"/>
                     <enumeration value="MAXIMUM_SIZE_OF_ATTACHMENT"/>
                     <enumeration value="MAXIMUM_SIZE_OF_DOCUMENT"/>
                     <enumeration value="MAX_ACTIONS_PER_RULE_EXCEEDED"/>
                     <enumeration value="MAX_ACTIVE_RULES_EXCEEDED"/>
                     <enumeration value="MAX_APPROVAL_STEPS_EXCEEDED"/>
+                    <enumeration value="MAX_DEPTH_IN_FLOW_EXECUTION"/>
                     <enumeration value="MAX_FORMULAS_PER_RULE_EXCEEDED"/>
                     <enumeration value="MAX_RULES_EXCEEDED"/>
                     <enumeration value="MAX_RULE_ENTRIES_EXCEEDED"/>
@@ -4724,13 +8382,16 @@ All Rights Reserved
                     <enumeration value="MAX_TM_RULES_EXCEEDED"/>
                     <enumeration value="MAX_TM_RULE_ITEMS_EXCEEDED"/>
                     <enumeration value="MERGE_FAILED"/>
+                    <enumeration value="METADATA_FIELD_UPDATE_ERROR"/>
                     <enumeration value="MISSING_ARGUMENT"/>
+                    <enumeration value="MISSING_RECORD"/>
                     <enumeration value="MIXED_DML_OPERATION"/>
                     <enumeration value="NONUNIQUE_SHIPPING_ADDRESS"/>
                     <enumeration value="NO_APPLICABLE_PROCESS"/>
                     <enumeration value="NO_ATTACHMENT_PERMISSION"/>
                     <enumeration value="NO_INACTIVE_DIVISION_MEMBERS"/>
                     <enumeration value="NO_MASS_MAIL_PERMISSION"/>
+                    <enumeration value="NO_PARTNER_PERMISSION"/>
                     <enumeration value="NO_SUCH_USER_EXISTS"/>
                     <enumeration value="NUMBER_OUTSIDE_VALID_RANGE"/>
                     <enumeration value="NUM_HISTORY_FIELDS_BY_SOBJECT_EXCEEDED"/>
@@ -4739,18 +8400,51 @@ All Rights Reserved
                     <enumeration value="PACKAGE_LICENSE_REQUIRED"/>
                     <enumeration value="PACKAGING_API_INSTALL_FAILED"/>
                     <enumeration value="PACKAGING_API_UNINSTALL_FAILED"/>
+                    <enumeration value="PALI_INVALID_ACTION_ID"/>
+                    <enumeration value="PALI_INVALID_ACTION_NAME"/>
+                    <enumeration value="PALI_INVALID_ACTION_TYPE"/>
+                    <enumeration value="PAL_INVALID_ASSISTANT_RECOMMENDATION_TYPE_ID"/>
+                    <enumeration value="PAL_INVALID_ENTITY_ID"/>
+                    <enumeration value="PAL_INVALID_FLEXIPAGE_ID"/>
+                    <enumeration value="PAL_INVALID_LAYOUT_ID"/>
+                    <enumeration value="PAL_INVALID_PARAMETERS"/>
+                    <enumeration value="PA_API_EXCEPTION"/>
+                    <enumeration value="PA_AXIS_FAULT"/>
+                    <enumeration value="PA_INVALID_ID_EXCEPTION"/>
+                    <enumeration value="PA_NO_ACCESS_EXCEPTION"/>
+                    <enumeration value="PA_NO_DATA_FOUND_EXCEPTION"/>
+                    <enumeration value="PA_URI_SYNTAX_EXCEPTION"/>
+                    <enumeration value="PA_VISIBLE_ACTIONS_FILTER_ORDERING_EXCEPTION"/>
                     <enumeration value="PORTAL_NO_ACCESS"/>
                     <enumeration value="PORTAL_USER_ALREADY_EXISTS_FOR_CONTACT"/>
+                    <enumeration value="PORTAL_USER_CREATION_RESTRICTED_WITH_ENCRYPTION"/>
                     <enumeration value="PRIVATE_CONTACT_ON_ASSET"/>
+                    <enumeration value="PROCESSING_HALTED"/>
+                    <enumeration value="QA_INVALID_CREATE_FEED_ITEM"/>
+                    <enumeration value="QA_INVALID_SUCCESS_MESSAGE"/>
                     <enumeration value="QUERY_TIMEOUT"/>
+                    <enumeration value="QUICK_ACTION_LIST_ITEM_NOT_ALLOWED"/>
+                    <enumeration value="QUICK_ACTION_LIST_NOT_ALLOWED"/>
                     <enumeration value="RECORD_IN_USE_BY_WORKFLOW"/>
+                    <enumeration value="REL_FIELD_BAD_ACCESSIBILITY"/>
+                    <enumeration value="REPUTATION_MINIMUM_NUMBER_NOT_REACHED"/>
                     <enumeration value="REQUEST_RUNNING_TOO_LONG"/>
                     <enumeration value="REQUIRED_FEATURE_MISSING"/>
                     <enumeration value="REQUIRED_FIELD_MISSING"/>
+                    <enumeration value="RETRIEVE_EXCHANGE_ATTACHMENT_FAILED"/>
+                    <enumeration value="RETRIEVE_EXCHANGE_EMAIL_FAILED"/>
+                    <enumeration value="RETRIEVE_EXCHANGE_EVENT_FAILED"/>
+                    <enumeration value="SALESFORCE_INBOX_TRANSPORT_CONNECTION_ERROR"/>
+                    <enumeration value="SALESFORCE_INBOX_TRANSPORT_TOKEN_ERROR"/>
+                    <enumeration value="SALESFORCE_INBOX_TRANSPORT_UNKNOWN_ERROR"/>
                     <enumeration value="SELF_REFERENCE_FROM_FLOW"/>
                     <enumeration value="SELF_REFERENCE_FROM_TRIGGER"/>
                     <enumeration value="SHARE_NEEDED_FOR_CHILD_OWNER"/>
                     <enumeration value="SINGLE_EMAIL_LIMIT_EXCEEDED"/>
+                    <enumeration value="SOCIAL_ACCOUNT_NOT_FOUND"/>
+                    <enumeration value="SOCIAL_ACTION_INVALID"/>
+                    <enumeration value="SOCIAL_POST_INVALID"/>
+                    <enumeration value="SOCIAL_POST_NOT_FOUND"/>
                     <enumeration value="STANDARD_PRICE_NOT_DEFINED"/>
                     <enumeration value="STORAGE_LIMIT_EXCEEDED"/>
                     <enumeration value="STRING_TOO_LONG"/>
@@ -4766,22 +8460,38 @@ All Rights Reserved
                     <enumeration value="TRANSFER_REQUIRES_READ"/>
                     <enumeration value="UNABLE_TO_LOCK_ROW"/>
                     <enumeration value="UNAVAILABLE_RECORDTYPE_EXCEPTION"/>
+                    <enumeration value="UNAVAILABLE_REF"/>
                     <enumeration value="UNDELETE_FAILED"/>
                     <enumeration value="UNKNOWN_EXCEPTION"/>
+                    <enumeration value="UNSAFE_HTML_CONTENT"/>
                     <enumeration value="UNSPECIFIED_EMAIL_ADDRESS"/>
                     <enumeration value="UNSUPPORTED_APEX_TRIGGER_OPERATON"/>
                     <enumeration value="UNVERIFIED_SENDER_ADDRESS"/>
                     <enumeration value="USER_OWNS_PORTAL_ACCOUNT_EXCEPTION"/>
                     <enumeration value="USER_WITH_APEX_SHARES_EXCEPTION"/>
+                    <enumeration value="VF_COMPILE_ERROR"/>
                     <enumeration value="WEBLINK_SIZE_LIMIT_EXCEEDED"/>
                     <enumeration value="WEBLINK_URL_INVALID"/>
                     <enumeration value="WRONG_CONTROLLER_TYPE"/>
+                    <enumeration value="XCLEAN_UNEXPECTED_ERROR"/>
+                </restriction>
+            </simpleType>
+            <!-- These are the extension code to provide additional error information -->
+            <simpleType name="ExtendedErrorCode">
+                <restriction base="xsd:string">
                 </restriction>
             </simpleType>
 
 
+            <complexType name="ExtendedErrorDetails">
+                <sequence>
+                    <element name="extendedErrorCode" type="tns:ExtendedErrorCode"/>
+                    <any namespace="##targetNamespace" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+                </sequence>
+            </complexType>
             <complexType name="Error">
                 <sequence>
+                    <element name="extendedErrorDetails" type="tns:ExtendedErrorDetails" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="fields"     type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="message"    type="xsd:string"/>
                     <element name="statusCode" type="tns:StatusCode"/>
@@ -4805,6 +8515,15 @@ All Rights Reserved
                 </sequence>
             </complexType>
 
+            <complexType name="RenderEmailTemplateError">
+                <sequence>
+                    <element name="fieldName"  type="xsd:string"/>
+                    <element name="message"    type="xsd:string"/>
+                    <element name="offset"     type="xsd:int"/>
+                    <element name="statusCode" type="tns:StatusCode"/>
+                </sequence>
+            </complexType>
+
             <complexType name="UpsertResult">
                 <sequence>
                     <element name="created"  type="xsd:boolean"/>
@@ -4817,11 +8536,23 @@ All Rights Reserved
 
             <complexType name="PerformQuickActionResult">
                 <sequence>
+                    <element name="contextId" type="tns:ID" minOccurs="0" nillable="true"/>
                     <element name="created"  type="xsd:boolean"/>
                     <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="feedItemIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
                     <element name="ids"       type="tns:ID" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
                     <element name="success"   type="xsd:boolean"/>
+                    <element name="successMessage" type="xsd:string" minOccurs="0" nillable="true"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="QuickActionTemplateResult">
+                <sequence>
+                    <element name="defaultValueFormulas"  type="ens:sObject" nillable="true"/>
+                    <element name="defaultValues"         type="ens:sObject" nillable="true"/>
+                    <element name="errors"                type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"               type="xsd:boolean"/>
                 </sequence>
             </complexType>
 
@@ -4855,6 +8586,9 @@ All Rights Reserved
                     <extension base="tns:ProcessRequest">
                         <sequence>
                             <element name="objectId"     type="tns:ID"/>
+                            <element name="submitterId"    type="tns:ID" nillable="true"/>
+                            <element name="processDefinitionNameOrId" type="xsd:string" nillable="true"/>
+                            <element name="skipEntryCriteria" type="xsd:boolean" nillable="true"/>
                         </sequence>
                     </extension>
                 </complexContent>
@@ -4882,32 +8616,42 @@ All Rights Reserved
 
             <complexType name="DescribeAvailableQuickActionResult">
                 <sequence>
-                    <element name="label"        type="xsd:string"/>
-                    <element name="name"         type="xsd:string"/>
-                    <element name="type"         type="xsd:string"/>
+                    <element name="actionEnumOrId" type="xsd:string"/> 
+                    <element name="label"          type="xsd:string"/>
+                    <element name="name"           type="xsd:string"/>
+                    <element name="type"           type="xsd:string"/>
                 </sequence>
             </complexType>
 
 
             <complexType name="DescribeQuickActionResult">
                 <sequence>
+                    <element name="accessLevelRequired" type="tns:ShareAccessLevel" nillable="true"/> 
+                    <element name="actionEnumOrId" type="xsd:string"/> 
+                    <element name="canvasApplicationId"    type="tns:ID" nillable="true"/>
                     <element name="canvasApplicationName"    type="xsd:string" nillable="true"/>
                     <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/> 
+                    <element name="contextSobjectType"    type="xsd:string" nillable="true"/> 
                     <element name="defaultValues" type="tns:DescribeQuickActionDefaultValue" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="height"        type="xsd:int" nillable="true"/>
                     <element name="iconName"      type="xsd:string" nillable="true"/>
                     <element name="iconUrl"       type="xsd:string" nillable="true"/>
                     <element name="icons"            type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="label"        type="xsd:string"/>
-                    <element name="layout"          type="tns:DescribeLayoutSection" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="layout"          type="tns:DescribeLayoutSection" nillable="true"/>
+                    <element name="lightningComponentBundleId" type="tns:ID" nillable="true"/>
+                    <element name="lightningComponentBundleName" type="xsd:string" nillable="true"/>
+                    <element name="lightningComponentQualifiedName" type="xsd:string" nillable="true"/>
                     <element name="miniIconUrl"      type="xsd:string" nillable="true"/>
                     <element name="name"         type="xsd:string"/>
-                    <element name="sourceSobjectType"    type="xsd:string" nillable="true"/>
-                    <element name="targetParentField"    type="xsd:string" nillable="true"/>
+                    <element name="showQuickActionLcHeader" type="xsd:boolean"/> 
+                    <element name="showQuickActionVfHeader" type="xsd:boolean"/> 
+                                        <element name="targetParentField"    type="xsd:string" nillable="true"/>
                     <element name="targetRecordTypeId"   type="tns:ID" nillable="true"/>
                     <element name="targetSobjectType"    type="xsd:string" nillable="true"/>
                     <element name="type"         type="xsd:string"/>
                     <element name="visualforcePageName"    type="xsd:string" nillable="true"/>
+                    <element name="visualforcePageUrl" type="xsd:string" nillable="true"/> 
                     <element name="width"         type="xsd:int" nillable="true"/>
                 </sequence>
             </complexType>
@@ -4918,6 +8662,23 @@ All Rights Reserved
                     <element name="field" 		type="xsd:string" nillable="false"/>
                 </sequence>
             </complexType>
+
+
+
+        <complexType name="DescribeVisualForceResult">
+            <sequence>
+                <element name="domain" type="xsd:string"/>
+            </sequence>
+        </complexType>
+
+
+            <simpleType name="ShareAccessLevel">
+                <restriction base="xsd:string">
+                    <enumeration value="Read"/>
+                    <enumeration value="Edit"/>
+                    <enumeration value="All"/>
+                </restriction>
+            </simpleType>
 
 
 
@@ -4986,9 +8747,12 @@ All Rights Reserved
                     <element name="success"       type="xsd:boolean"/>
                 </sequence>
             </complexType>
+            
+
 
             <complexType name="DescribeSObjectResult">
                 <sequence>
+                    <element name="actionOverrides"	  type="tns:ActionOverride" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="activateable"        type="xsd:boolean"/>
                     <element name="childRelationships"  type="tns:ChildRelationship" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="compactLayoutable"   type="xsd:boolean"/>
@@ -4999,19 +8763,24 @@ All Rights Reserved
                     <element name="deprecatedAndHidden" type="xsd:boolean"/>
                     <element name="feedEnabled"         type="xsd:boolean"/>
                     <element name="fields"              type="tns:Field" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="hasSubtypes"         type="xsd:boolean"/>
+                    <element name="idEnabled"           type="xsd:boolean"/>
                     <element name="keyPrefix"           type="xsd:string" nillable="true"/>
                     <element name="label"               type="xsd:string"/>
                     <element name="labelPlural"         type="xsd:string"/>
                     <element name="layoutable"          type="xsd:boolean"/>
                     <element name="mergeable"           type="xsd:boolean"/>
+                    <element name="mruEnabled"          type="xsd:boolean"/>
                     <element name="name"                type="xsd:string"/>
+                    <element name="namedLayoutInfos"    type="tns:NamedLayoutInfo" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="networkScopeFieldName"                type="xsd:string" nillable="true"/>
                     <element name="queryable"           type="xsd:boolean"/>
                     <element name="recordTypeInfos"     type="tns:RecordTypeInfo" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="replicateable"       type="xsd:boolean"/>
                     <element name="retrieveable"        type="xsd:boolean"/>
-
-                    <element name="searchLayoutable" type="xsd:boolean" minOccurs="0"/>
+                    <element name="searchLayoutable"    type="xsd:boolean" minOccurs="0"/>
                     <element name="searchable"          type="xsd:boolean" />
+                    <element name="supportedScopes"     type="tns:ScopeInfo" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="triggerable"         type="xsd:boolean" minOccurs="0"/>
                     <element name="undeletable"         type="xsd:boolean"/>
                     <element name="updateable"          type="xsd:boolean"/>
@@ -5020,6 +8789,8 @@ All Rights Reserved
                     <element name="urlNew"              type="xsd:string" nillable="true"/>
                 </sequence>
             </complexType>
+
+
 
             <!-- this is a subset of properties for each SObject that is returned by the describeGlobal call -->
             <complexType name="DescribeGlobalSObjectResult">
@@ -5031,11 +8802,14 @@ All Rights Reserved
                     <element name="deletable"           type="xsd:boolean"/>
                     <element name="deprecatedAndHidden" type="xsd:boolean"/>
                     <element name="feedEnabled"         type="xsd:boolean"/>
+                    <element name="hasSubtypes"         type="xsd:boolean"/>
+                    <element name="idEnabled"           type="xsd:boolean"/>
                     <element name="keyPrefix"           type="xsd:string" nillable="true"/>
                     <element name="label"               type="xsd:string"/>
                     <element name="labelPlural"         type="xsd:string"/>
                     <element name="layoutable"          type="xsd:boolean"/>
                     <element name="mergeable"           type="xsd:boolean"/>
+                    <element name="mruEnabled"           type="xsd:boolean"/>
                     <element name="name"                type="xsd:string"/>
                     <element name="queryable"           type="xsd:boolean"/>
                     <element name="replicateable"       type="xsd:boolean"/>
@@ -5053,6 +8827,8 @@ All Rights Reserved
                     <element name="childSObject"     type="xsd:string"/>
                     <element name="deprecatedAndHidden" type="xsd:boolean"/>
                     <element name="field"            type="xsd:string"/>
+                    <element name="junctionIdListNames" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="junctionReferenceTo" type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="relationshipName" type="xsd:string" minOccurs="0"/>
                     <element name="restrictedDelete" type="xsd:boolean" minOccurs="0"/>
                 </sequence>
@@ -5073,6 +8849,17 @@ All Rights Reserved
                     <element name="theme"       type="tns:DescribeThemeResult"/>
                 </sequence>
             </complexType>
+
+
+
+            <complexType name="ScopeInfo">
+                <sequence>
+                    <element name="label"      type="xsd:string"/>
+                    <element name="name"       type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
 
 
         <simpleType name="fieldType">
@@ -5099,7 +8886,12 @@ All Rights Reserved
                     <enumeration value="encryptedstring"/>
                     <enumeration value="datacategorygroupreference"/>
                     <enumeration value="location"/>
+                    <enumeration value="address"/>
                     <enumeration value="anyType"/> <!-- can be string, picklist, reference, boolean, currency, int, double, percent, id, date, datetime, url, email -->
+
+
+                    <enumeration value="complexvalue"/>
+
                 </restriction>
             </simpleType>
 
@@ -5114,35 +8906,79 @@ All Rights Reserved
                     <enumeration value="xsd:date"/>
                     <enumeration value="xsd:dateTime"/>
                     <enumeration value="xsd:time"/>
+
+                    <enumeration value="tns:location" />
+                    <enumeration value="tns:address" />
+
                     <enumeration value="xsd:anyType"/> <!-- can be id, booolean, double, int, string, date, dateTime -->
+
+
+                    <enumeration value="urn:RelationshipReferenceTo" />
+
+
+                    <enumeration value="urn:JunctionIdListNames" />
+
+
+                    <enumeration value="urn:SearchLayoutFieldsDisplayed" />
+                    <enumeration value="urn:SearchLayoutField" />
+                    <enumeration value="urn:SearchLayoutButtonsDisplayed" />
+                    <enumeration value="urn:SearchLayoutButton" />
+
+
+                    <enumeration value="urn:RecordTypesSupported" />
+
+
+
+
+
                 </restriction>
             </simpleType>
 
+            <complexType name="FilteredLookupInfo">
+                        <sequence>
+                            <element name="controllingFields"             type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                            <element name="dependent"              type="xsd:boolean"/>
+                            <element name="optionalFilter"              type="xsd:boolean"/>
+
+                        </sequence>
+            </complexType>
+
             <complexType name="Field">
                 <sequence>
+                    <element name="aggregatable"               type="xsd:boolean"/>
                     <element name="autoNumber"                 type="xsd:boolean"/>
                     <element name="byteLength"                 type="xsd:int"/>
                     <element name="calculated"                 type="xsd:boolean"/>
                     <element name="calculatedFormula"          type="xsd:string" minOccurs="0"/>
                     <element name="cascadeDelete"              type="xsd:boolean" minOccurs="0"/>
                     <element name="caseSensitive"              type="xsd:boolean"/>
+                    <element name="compoundFieldName"          type="xsd:string" minOccurs="0"/>
                     <element name="controllerName"             type="xsd:string" minOccurs="0"/>
                     <element name="createable"                 type="xsd:boolean"/>
                     <element name="custom"                     type="xsd:boolean"/>
+                    <element name="defaultValue"               type="xsd:anyType" minOccurs="0"/>
                     <element name="defaultValueFormula"        type="xsd:string" minOccurs="0"/>
                     <element name="defaultedOnCreate"          type="xsd:boolean"/>
                     <element name="dependentPicklist"          type="xsd:boolean" minOccurs="0"/>
                     <element name="deprecatedAndHidden"        type="xsd:boolean"/>
                     <element name="digits"                     type="xsd:int"/>
                     <element name="displayLocationInDecimal"   type="xsd:boolean" minOccurs="0"/>
+                    <element name="encrypted"                  type="xsd:boolean" minOccurs="0"/>
                     <element name="externalId"                 type="xsd:boolean" minOccurs="0"/>
+                    <element name="extraTypeInfo"              type="xsd:string"  minOccurs="0"/>
                     <element name="filterable"                 type="xsd:boolean"/>
+
+                    <element name="filteredLookupInfo"			   type="tns:FilteredLookupInfo" nillable="true" minOccurs="0" />
+
                     <element name="groupable"                  type="xsd:boolean"/>
+                    <element name="highScaleNumber"			   type="xsd:boolean" minOccurs="0" />
                     <element name="htmlFormatted"              type="xsd:boolean" minOccurs="0"/>
                     <element name="idLookup"                   type="xsd:boolean"/>
                     <element name="inlineHelpText"             type="xsd:string" minOccurs="0"/>
                     <element name="label"                      type="xsd:string"/>
                     <element name="length"                     type="xsd:int"/>
+                    <element name="mask"                       type="xsd:string"  minOccurs="0"/>
+                    <element name="maskType"                   type="xsd:string"  minOccurs="0"/>
                     <element name="name"                       type="xsd:string"/>
                     <element name="nameField"                  type="xsd:boolean"/>
                     <element name="namePointing"               type="xsd:boolean" minOccurs="0"/>
@@ -5150,6 +8986,8 @@ All Rights Reserved
                     <element name="permissionable"             type="xsd:boolean"/>
                     <element name="picklistValues"             type="tns:PicklistEntry" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="precision"                  type="xsd:int"/>
+                    <element name="queryByDistance"            type="xsd:boolean" />
+                    <element name="referenceTargetField"       type="xsd:string" minOccurs="0"/>
                     <element name="referenceTo"                type="xsd:string" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="relationshipName"           type="xsd:string" minOccurs="0"/>
                     <element name="relationshipOrder"          type="xsd:int" minOccurs="0"/>
@@ -5211,6 +9049,207 @@ All Rights Reserved
             </complexType>
 
 
+            <complexType name="KnowledgeSettings">
+                   <sequence>
+                       <element name="defaultLanguage"  type="xsd:string" minOccurs="0" />
+                       <element name="knowledgeEnabled" type="xsd:boolean"/>
+                       <element name="languages"        type="tns:KnowledgeLanguageItem" minOccurs="0" maxOccurs="unbounded"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="KnowledgeLanguageItem">
+                   <sequence>
+                       <element name="active" type="xsd:boolean"/>
+                       <element name="name" type="xsd:string" />
+                   </sequence>
+            </complexType>
+
+
+            <simpleType name="differenceType">
+                   <restriction base="xsd:string">
+                       <enumeration value="DIFFERENT"/>
+                       <enumeration value="NULL"/>
+                       <enumeration value="SAME"/>
+                       <enumeration value="SIMILAR"/>
+                   </restriction>
+            </simpleType>
+
+            <complexType name="FieldDiff">
+                   <sequence>
+                       <element name="difference" type="tns:differenceType" nillable="false" minOccurs="1" maxOccurs="1"/>
+                       <element name="name" type="xsd:string" />
+                   </sequence>
+            </complexType>
+
+            <complexType name="AdditionalInformationMap">
+                   <sequence>
+                       <element name="name" type="xsd:string" />
+                       <element name="value" type="xsd:string" />
+                   </sequence>
+            </complexType>
+
+            <complexType name="MatchRecord">
+                   <sequence>
+                       <element name="additionalInformation" minOccurs="0" maxOccurs="unbounded" type="tns:AdditionalInformationMap"/>
+                       <element name="fieldDiffs" minOccurs="0" maxOccurs="unbounded" type="tns:FieldDiff"/>
+                       <element name="matchConfidence" type="xsd:double"/>
+                       <element name="record" type="ens:sObject"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="MatchResult">
+                   <sequence>
+                       <element name="entityType" type="xsd:string" />
+                       <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                       <element name="matchEngine" type="xsd:string" />
+                       <element name="matchRecords" minOccurs="0" maxOccurs="unbounded" type="tns:MatchRecord"/>
+                       <element name="rule" type="xsd:string" />
+                       <element name="size" type="xsd:int"/>
+                       <element name="success"   type="xsd:boolean"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="DuplicateResult">
+                   <sequence>
+                       <element name="allowSave" type="xsd:boolean"/>
+                       <element name="duplicateRule" type="xsd:string"/>
+                       <element name="duplicateRuleEntityType" type="xsd:string"/>
+                       <element name="errorMessage" type="xsd:string"/>
+                       <element name="matchResults" minOccurs="0" maxOccurs="unbounded" type="tns:MatchResult"/>
+                   </sequence>
+            </complexType>
+
+            <complexType name="DuplicateError">
+                <complexContent>
+                    <extension base="tns:Error">
+                        <sequence>
+                          <element name="duplicateResult" type="tns:DuplicateResult"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+            <complexType name="DescribeNounResult">
+                <sequence>
+                     <element name="caseValues" minOccurs="0" maxOccurs="unbounded" type="tns:NameCaseValue"/>
+                       <element name="developerName" type="xsd:string"/>
+                    <element name="gender" nillable="true" type="tns:Gender"/>
+                       <element name="name" type="xsd:string"/>
+                       <element name="pluralAlias" type="xsd:string" nillable="true"/>
+                    <element name="startsWith" nillable="true" type="tns:StartsWith"/>
+                </sequence>
+            </complexType>
+
+           <complexType name="NameCaseValue">
+                <sequence>
+                     <element name="article" nillable="true" type="tns:Article"/>
+                     <element name="caseType" nillable="true"  type="tns:CaseType"/>
+                     <element name="number" nillable="true" type="tns:GrammaticalNumber"/>
+                     <element name="possessive" nillable="true"  type="tns:Possessive"/>
+                     <element name="value" type="xsd:string"/>
+                </sequence>
+           </complexType>
+
+            <simpleType name="Article">
+                <restriction base="xsd:string">
+                    <enumeration value="None"/>
+                    <enumeration value="Indefinite"/>
+                    <enumeration value="Definite"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="CaseType">
+                <restriction base="xsd:string">
+                    <enumeration value="Nominative"/>
+                    <enumeration value="Accusative"/>
+                    <enumeration value="Genitive"/>
+                    <enumeration value="Dative"/>
+                    <enumeration value="Inessive"/>
+                    <enumeration value="Elative"/>
+                    <enumeration value="Illative"/>
+                    <enumeration value="Adessive"/>
+                    <enumeration value="Ablative"/>
+                    <enumeration value="Allative"/>
+                    <enumeration value="Essive"/>
+                    <enumeration value="Translative"/>
+                    <enumeration value="Partitive"/>
+                    <enumeration value="Objective"/>
+                    <enumeration value="Subjective"/>
+                    <enumeration value="Instrumental"/>
+                    <enumeration value="Prepositional"/>
+                    <enumeration value="Locative"/>
+                    <enumeration value="Vocative"/>
+                    <enumeration value="Sublative"/>
+                    <enumeration value="Superessive"/>
+                    <enumeration value="Delative"/>
+                    <enumeration value="Causalfinal"/>
+                    <enumeration value="Essiveformal"/>
+                    <enumeration value="Termanative"/>
+                    <enumeration value="Distributive"/>
+                    <enumeration value="Ergative"/>
+                    <enumeration value="Adverbial"/>
+                    <enumeration value="Abessive"/>
+                    <enumeration value="Comitative"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="Gender">
+                <restriction base="xsd:string">
+                    <enumeration value="Neuter"/>
+                    <enumeration value="Masculine"/>
+                    <enumeration value="Feminine"/>
+                    <enumeration value="AnimateMasculine"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="GrammaticalNumber">
+                <restriction base="xsd:string">
+                    <enumeration value="Singular"/>
+                    <enumeration value="Plural"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="Possessive">
+                <restriction base="xsd:string">
+                    <enumeration value="None"/>
+                    <enumeration value="First"/>
+                    <enumeration value="Second"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="StartsWith">
+                <restriction base="xsd:string">
+                    <enumeration value="Consonant"/>
+                    <enumeration value="Vowel"/>
+                    <enumeration value="Special"/>
+                </restriction>
+            </simpleType>
+
+
+
+
+
+            <element name="findDuplicates">
+                <complexType>
+                    <sequence>
+                        <element name="sObjects" type="ens:sObject" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <element name="findDuplicatesResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:FindDuplicatesResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+            <complexType name="FindDuplicatesResult">
+                <sequence>
+                    <element name="duplicateResults" type="tns:DuplicateResult" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="errors"    type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"   type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+
             <complexType name="DescribeFlexiPageResult">
                 <sequence>
                     <element name="id"      		type="tns:ID"/>
@@ -5218,6 +9257,9 @@ All Rights Reserved
                     <element name="name"            type="xsd:string"/>
                     <element name="quickActionList"             type="tns:DescribeQuickActionListResult" minOccurs="0" />
                     <element name="regions"			type="tns:DescribeFlexiPageRegion" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="sobjectType"     type="xsd:string" minOccurs="0" nillable="true"/>
+                    <element name="template"     type="xsd:string" nillable="true"/>
+                    <element name="type"            type="xsd:string"/>
                 </sequence>
             </complexType>
 
@@ -5239,9 +9281,34 @@ All Rights Reserved
             <complexType name="DescribeComponentInstanceProperty">
                 <sequence>
                     <element name="name"   			type="xsd:string"/>
+                    <element name="region"          type="tns:DescribeFlexiPageRegion" nillable="true" minOccurs="0" />
+                    <element name="type"            type="tns:ComponentInstancePropertyTypeEnum"  nillable="true" />
                     <element name="value"   		type="xsd:string" nillable="true" />
                 </sequence>
             </complexType>
+            
+            <simpleType name="ComponentInstancePropertyTypeEnum">
+                <restriction base="xsd:string">
+                    <enumeration value="decorator"/>
+                </restriction>
+            </simpleType>
+            
+     
+            <complexType name="FlexipageContext">
+                <sequence>
+                    <element name="type"            type="tns:FlexipageContextTypeEnum"/>
+                    <element name="value"           type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="FlexipageContextTypeEnum">
+                <restriction base="xsd:string">
+                    <enumeration value="ENTITYNAME"/>
+                </restriction>
+            </simpleType>
+
+     
+
 
 
             <complexType name="DescribeAppMenuResult">
@@ -5328,7 +9395,7 @@ All Rights Reserved
                 <sequence>
                     <element name="compactLayouts" type="tns:DescribeCompactLayout" maxOccurs="unbounded"/>
                     <element name="defaultCompactLayoutId" type="tns:ID"/>
-                    <element name="recordTypeCompactLayoutMappings" type="tns:RecordTypeCompactLayoutMapping" maxOccurs="unbounded"/>
+                    <element name="recordTypeCompactLayoutMappings" type="tns:RecordTypeCompactLayoutMapping" minOccurs="0" maxOccurs="unbounded"/>
                 </sequence>
             </complexType>
 
@@ -5340,6 +9407,7 @@ All Rights Reserved
                     <element name="imageItems" type="tns:DescribeLayoutItem" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="label" type="xsd:string"/>
                     <element name="name" type="xsd:string"/>
+                    <element name="objectType" type="xsd:string"/> 
                 </sequence>
             </complexType>
 
@@ -5350,6 +9418,63 @@ All Rights Reserved
                     <element name="compactLayoutName" type="xsd:string"/>
                     <element name="recordTypeId" type="tns:ID"/>
                     <element name="recordTypeName" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribePathAssistantsResult">
+                <sequence>
+                    <element name="pathAssistants" type="tns:DescribePathAssistant" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribePathAssistant">
+                <sequence>
+                    <element name="active" type="xsd:boolean"/>
+                    <element name="apiName" type="xsd:string"/>
+                    <element name="label" type="xsd:string"/>
+                    <element name="pathPicklistField" type="xsd:string"/>
+                    <element name="picklistsForRecordType" type="tns:PicklistForRecordType" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="recordTypeId" type="tns:ID" nillable="true"/>
+                    <element name="steps" type="tns:DescribePathAssistantStep" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribePathAssistantStep">
+                <sequence>
+                    <element name="closed" type="xsd:boolean"/>
+                    <element name="converted" type="xsd:boolean"/>
+                    <element name="fields" type="tns:DescribePathAssistantField" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="info" type="xsd:string"/>
+                    <element name="layoutSection" type="tns:DescribeLayoutSection"/>
+                    <element name="picklistLabel" type="xsd:string"/>
+                    <element name="picklistValue" type="xsd:string"/>
+                    <element name="won" type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribePathAssistantField">
+                <sequence>
+                    <element name="apiName" type="xsd:string"/>
+                    <element name="label" type="xsd:string"/>
+                    <element name="readOnly" type="xsd:boolean"/>
+                    <element name="required" type="xsd:boolean"/>
+                </sequence>
+            </complexType>
+
+
+            <complexType name="DescribeApprovalLayoutResult">
+                <sequence>
+                    <element name="approvalLayouts" type="tns:DescribeApprovalLayout" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeApprovalLayout">
+                <sequence>
+                    <element name="id" type="tns:ID"/>
+                    <element name="label" type="xsd:string"/>
+                    <element name="layoutItems" type="tns:DescribeLayoutItem" maxOccurs="unbounded"/>
+                    <element name="name" type="xsd:string"/>
                 </sequence>
             </complexType>
 
@@ -5367,6 +9492,9 @@ All Rights Reserved
                     <element name="buttonLayoutSection"  type="tns:DescribeLayoutButtonSection" minOccurs="0"/>
                     <element name="detailLayoutSections" type="tns:DescribeLayoutSection" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="editLayoutSections"   type="tns:DescribeLayoutSection" minOccurs="0" maxOccurs="unbounded"/>
+
+                    <element name="feedView"                    type="tns:DescribeLayoutFeedView" minOccurs="0" />
+
 
                     <element name="highlightsPanelLayoutSection"  type="tns:DescribeLayoutSection" minOccurs="0" />
 
@@ -5392,6 +9520,7 @@ All Rights Reserved
 
             <complexType name="DescribeQuickActionListItemResult">
                 <sequence>
+                    <element name="accessLevelRequired"    type="tns:ShareAccessLevel" nillable="true"/> 
                     <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/> 
                     <element name="iconUrl"       type="xsd:string" nillable="true"/>
                     <element name="icons" type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
@@ -5403,12 +9532,46 @@ All Rights Reserved
                 </sequence>
             </complexType>
 
+
+            <complexType name="DescribeLayoutFeedView">
+                <sequence>
+                    <element name="feedFilters" type="tns:DescribeLayoutFeedFilter" minOccurs="0" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="FeedLayoutFilterType">
+                <restriction base="xsd:string">
+                    <enumeration value="AllUpdates"/>
+                    <enumeration value="FeedItemType"/>
+                    <enumeration value="Custom"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="DescribeLayoutFeedFilter">
+                <sequence>
+                    <element name="label" type="xsd:string"/>
+                    <element name="name"  type="xsd:string"/>
+                    <element name="type"  type="tns:FeedLayoutFilterType"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="TabOrderType">
+                 <restriction base="xsd:string">
+                    <enumeration value="LeftToRight"/>
+                    <enumeration value="TopToBottom"/>
+                 </restriction>
+            </simpleType>
+
             <complexType name="DescribeLayoutSection">
                 <sequence>
+                    <element name="collapsed"  	    	    type="xsd:boolean"/>
                     <element name="columns"                 type="xsd:int"/>
-                    <element name="heading"                 type="xsd:string"/>
+                    <element name="heading"                 type="xsd:string" nillable="true"/>
                     <element name="layoutRows"              type="tns:DescribeLayoutRow" maxOccurs="unbounded"/>
+                    <element name="layoutSectionId"         type="tns:ID"/>
+                    <element name="parentLayoutId"          type="tns:ID"/>
                     <element name="rows"                    type="xsd:int"/>
+                    <element name="tabOrder"                type="tns:TabOrderType"/>
                     <element name="useCollapsibleSection"   type="xsd:boolean"/>
                     <element name="useHeading"              type="xsd:boolean"/>
                 </sequence>
@@ -5419,7 +9582,6 @@ All Rights Reserved
                     <element name="detailButtons"         type="tns:DescribeLayoutButton" maxOccurs="unbounded"/>
                 </sequence>
             </complexType>
-
             <complexType name="DescribeLayoutRow">
                 <sequence>
                     <element name="layoutItems"      type="tns:DescribeLayoutItem" maxOccurs="unbounded"/>
@@ -5429,7 +9591,10 @@ All Rights Reserved
 
             <complexType name="DescribeLayoutItem">
                 <sequence>
-                    <element name="editable"         type="xsd:boolean"/>
+
+                    <element name="editableForNew"         type="xsd:boolean"/>
+                    <element name="editableForUpdate"      type="xsd:boolean"/>
+
                     <element name="label"            type="xsd:string" nillable="true"/>
                     <element name="layoutComponents" type="tns:DescribeLayoutComponent" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="placeholder"      type="xsd:boolean"/>
@@ -5437,12 +9602,70 @@ All Rights Reserved
                 </sequence>
             </complexType>
 
+            <simpleType name="WebLinkWindowType">
+                <restriction base="xsd:string">
+                    <enumeration value="newWindow"/>
+                    <enumeration value="sidebar"/>
+                    <enumeration value="noSidebar"/>
+                    <enumeration value="replace"/>
+                    <enumeration value="onClickJavaScript"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="WebLinkPosition">
+                <restriction base="xsd:string">
+                    <enumeration value="fullScreen"/>
+                    <enumeration value="none"/>
+                    <enumeration value="topLeft"/>
+                </restriction>
+            </simpleType>
+            <simpleType name="WebLinkType">
+                <restriction base="xsd:string">
+                    <enumeration value="url"/>
+                    <enumeration value="sControl"/>
+                    <enumeration value="javascript"/>
+                    <enumeration value="page"/>
+                    <enumeration value="flow"/>
+                </restriction>
+            </simpleType>
+
+
             <complexType name="DescribeLayoutButton">
                 <sequence>
+                 
+                    <element name="behavior"       type="tns:WebLinkWindowType" nillable="true" minOccurs="0"/>
+                    
+                    
+                    <element name="colors"            type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
+                    
+                 
+                    <element name="content"        type="xsd:string" nillable="true" minOccurs="0"/>
+                    <element name="contentSource"        type="tns:WebLinkType" nillable="true" minOccurs="0"/>
+                  
                     <element name="custom"           type="xsd:boolean"/>
+                   
+                    <element name="encoding"        type="xsd:string" nillable="true" minOccurs="0"/>
+                    <element name="height"        type="xsd:int" nillable="true" minOccurs="0"/>
+                   
+                    
                     <element name="icons"            type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    
                     <element name="label"            type="xsd:string" nillable="true"/>
+                    
+                    <element name="menubar"        type="xsd:boolean" nillable="true"/>
+                   
                     <element name="name"             type="xsd:string" nillable="true"/>
+
+                    
+                    <element name="overridden"        type="xsd:boolean"/>
+                    <element name="resizeable"        type="xsd:boolean" nillable="true"/>
+                    <element name="scrollbars"        type="xsd:boolean" nillable="true"/>
+                    <element name="showsLocation"        type="xsd:boolean" nillable="true"/>
+                    <element name="showsStatus"        type="xsd:boolean" nillable="true"/>
+                    <element name="toolbar"        type="xsd:boolean" nillable="true"/>
+                    <element name="url"        type="xsd:string" nillable="true" minOccurs="0"/>
+                    <element name="width"        type="xsd:int" nillable="true" minOccurs="0"/>
+                    <element name="windowPosition"        type="tns:WebLinkPosition" nillable="true" minOccurs="0"/>
+                    
                 </sequence>
             </complexType>
 
@@ -5451,7 +9674,7 @@ All Rights Reserved
                     <element name="displayLines"      type="xsd:int"/>
                     <element name="tabOrder"          type="xsd:int"/>
                     <element name="type"              type="tns:layoutComponentType"/>
-                    <element name="value"             type="xsd:string"/>
+                    <element name="value"             type="xsd:string" nillable="true"/>
                 </sequence>
             </complexType>
 
@@ -5462,12 +9685,87 @@ All Rights Reserved
                     <enumeration value="Separator"/>
                     <enumeration value="SControl"/>
                     <enumeration value="EmptySpace"/>
+
+
                     <enumeration value="VisualforcePage"/>
+
 
                     <enumeration value="ExpandedLookup"/>
 
+
+                    <enumeration value="AuraComponent"/>
+
+
+                    <enumeration value="Canvas"/>
+
+
+                    <enumeration value="CustomLink"/>
+
+
+                    <enumeration value="AnalyticsCloud"/>
+
                 </restriction>
             </simpleType>
+
+
+            <complexType name="FieldComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="field"              type="tns:Field"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+
+            <complexType name="FieldLayoutComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="components"             type="tns:DescribeLayoutComponent" minOccurs="0" maxOccurs="unbounded"/>
+                            <element name="fieldType"              type="tns:fieldType"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+
+            <complexType name="VisualforcePage">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            
+                                <element name="showLabel"              type="xsd:boolean"/>
+                            
+                            <element name="showScrollbars"              type="xsd:boolean"/>
+                            <element name="suggestedHeight"              type="xsd:string"/>
+                            <element name="suggestedWidth"              type="xsd:string"/>
+                            <element name="url"              type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+
+            <complexType name="Canvas">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="displayLocation"              type="xsd:string"/>
+                            <element name="referenceId"              type="xsd:string"/>
+                            <element name="showLabel"              type="xsd:boolean"/>
+                            <element name="showScrollbars"              type="xsd:boolean"/>
+                            <element name="suggestedHeight"              type="xsd:string"/>
+                            <element name="suggestedWidth"              type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
 
             <complexType name="ReportChartComponent">
                 <complexContent>
@@ -5475,6 +9773,7 @@ All Rights Reserved
                         <sequence>
                             <element name="cacheData"              type="xsd:boolean"/>
                             <element name="contextFilterableField" type="xsd:string"/>
+                            <element name="error"                  type="xsd:string"/>
                             <element name="hideOnError"            type="xsd:boolean"/>
                             <element name="includeContext"         type="xsd:boolean"/>
                             <element name="showTitle"              type="xsd:boolean"/>
@@ -5484,6 +9783,35 @@ All Rights Reserved
                 </complexContent>
             </complexType>
 
+            <complexType name="AnalyticsCloudComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="error"                  type="xsd:string"/>
+                            <element name="filter"                 type="xsd:string"/>
+                            <element name="height"                 type="xsd:string"/>
+                            <element name="hideOnError"            type="xsd:boolean"/>
+                            <element name="showSharing"       	   type="xsd:boolean"/>
+                            <element name="showTitle"              type="xsd:boolean"/>
+                            <element name="width"                  type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+
+            <complexType name="CustomLinkComponent">
+                <complexContent>
+                    <extension base="tns:DescribeLayoutComponent">
+                        <sequence>
+                            <element name="customLink"             type="tns:DescribeLayoutButton"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
             <simpleType name="ReportChartSize">
                 <restriction base="xsd:string">
                     <enumeration value="SMALL"/>
@@ -5492,10 +9820,19 @@ All Rights Reserved
                 </restriction>
             </simpleType>
 
+            <complexType name="NamedLayoutInfo">
+                <sequence>
+                    <element name="name" type="xsd:string"/>
+                </sequence>
+            </complexType>
+
             <complexType name="RecordTypeInfo">
                 <sequence>
                     <element name="available"                 type="xsd:boolean"/>
                     <element name="defaultRecordTypeMapping"  type="xsd:boolean"/>
+
+                    <element name="master"                    type="xsd:boolean"/>
+
                     <element name="name"                      type="xsd:string"/>
                     <element name="recordTypeId"              type="tns:ID" nillable="true"/>
                 </sequence>
@@ -5506,6 +9843,9 @@ All Rights Reserved
                     <element name="available"                 type="xsd:boolean"/>
                     <element name="defaultRecordTypeMapping"  type="xsd:boolean"/>
                     <element name="layoutId"                  type="tns:ID"/>
+
+                    <element name="master"                    type="xsd:boolean"/>
+
                     <element name="name"                      type="xsd:string"/>
                     <element name="picklistsForRecordType"    type="tns:PicklistForRecordType" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
                     <element name="recordTypeId"              type="tns:ID" nillable="true"/>
@@ -5535,6 +9875,8 @@ All Rights Reserved
 
             <complexType name="RelatedList">
                 <sequence>
+                    <element name="accessLevelRequiredForCreate"    type="tns:ShareAccessLevel" nillable="true"/> 
+ <element name="buttons"    type="tns:DescribeLayoutButton"  maxOccurs="unbounded" minOccurs="0" nillable="true"/> 
                     <element name="columns"         type="tns:RelatedListColumn" maxOccurs="unbounded"/>
                     <element name="custom"          type="xsd:boolean"/>
                     <element name="field"           type="xsd:string" nillable="true"/>
@@ -5549,6 +9891,7 @@ All Rights Reserved
             <complexType name="RelatedListColumn">
                 <sequence>
                     <element name="field"           type="xsd:string" nillable="true"/>
+                    <element name="fieldApiName"    type="xsd:string"/>
                     <element name="format"          type="xsd:string" nillable="true"/>
                     <element name="label"           type="xsd:string"/>
                     <element name="lookupId"        type="xsd:string"  nillable="true" minOccurs="0"/>
@@ -5583,9 +9926,18 @@ All Rights Reserved
                 </restriction>
             </simpleType>
 
+            <simpleType name="SendEmailOptOutPolicy">
+                <restriction base="xsd:string">
+                    <enumeration value="SEND"/>
+                    <enumeration value="FILTER"/>
+                    <enumeration value="REJECT"/>
+                </restriction>
+            </simpleType>
+
+
             <complexType name="Email">
                 <sequence>
-                    <element name="bccSender"         type="xsd:boolean" nillable="true"/>
+                    <element name="bccSender"          type="xsd:boolean" nillable="true"/>
                     <element name="emailPriority"      type="tns:EmailPriority" nillable="true"/>
                     <element name="replyTo"            type="xsd:string" nillable="true"/>
                     <element name="saveAsActivity"     type="xsd:boolean" nillable="true"/>
@@ -5616,15 +9968,19 @@ All Rights Reserved
                             <element name="ccAddresses"         minOccurs="0" maxOccurs="25" type="xsd:string" nillable="true"/>
                             <element name="charset"             type="xsd:string" nillable="true"/>
                             <element name="documentAttachments" minOccurs="0" maxOccurs="unbounded" type="tns:ID" />
-                            <element name="htmlBody"       type="xsd:string" nillable="true"/>
-                            <element name="inReplyTo"           minOccurs="0" type="xsd:string" nillable="true"/>
+                            <element name="entityAttachments"   minOccurs="0" maxOccurs="unbounded" type="tns:ID" />
                             <element name="fileAttachments"     minOccurs="0" maxOccurs="unbounded" type="tns:EmailFileAttachment"/>
+                            <element name="htmlBody"            type="xsd:string" nillable="true"/>
+                            <element name="inReplyTo"           minOccurs="0" type="xsd:string" nillable="true"/>
+                            <element name="optOutPolicy"        type="tns:SendEmailOptOutPolicy" nillable="true"/>
                             <element name="orgWideEmailAddressId" minOccurs="0" maxOccurs="1" type="tns:ID" nillable="true"/>
                             <element name="plainTextBody"       type="xsd:string" nillable="true"/>
                             <element name="references"          minOccurs="0" type="xsd:string" nillable="true"/>
                             <element name="targetObjectId"      type="tns:ID" nillable="true"/>
                             <element name="templateId"          type="tns:ID" nillable="true"/>
                             <element name="toAddresses"         minOccurs="0" maxOccurs="100" type="xsd:string" nillable="true"/>
+                            <element name="treatBodiesAsTemplate" type="xsd:boolean" nillable="true" />
+                            <element name="treatTargetObjectAsRecipient" type="xsd:boolean" nillable="true" />
                             <element name="whatId"              type="tns:ID" nillable="true"/>
                         </sequence>
                     </extension>
@@ -5640,14 +9996,195 @@ All Rights Reserved
 
 
 
-
-            <complexType name="DescribeSearchLayoutResult">
+            <complexType name="ListViewColumn">
                 <sequence>
-                    <element name="label"           type="xsd:string" />
-                    <element name="limitRows"       type="xsd:int"/>
-                    <element name="searchColumns" type="tns:DescribeColumn" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="ascendingLabel"           type="xsd:string" nillable="true"/>
+                    <element name="descendingLabel"          type="xsd:string" nillable="true"/>
+                    <element name="fieldNameOrPath"          type="xsd:string"/>
+                    <element name="hidden"                   type="xsd:boolean"/>
+                    <element name="label"                    type="xsd:string"/>
+                    <element name="selectListItem"           type="xsd:string"/>
+                    <element name="sortDirection"            type="tns:orderByDirection" nillable="true"/>
+                    <element name="sortIndex"                type="xsd:int" nillable="true"/>
+                    <element name="sortable"                 type="xsd:boolean"/>
+                    <element name="type"                     type="tns:fieldType"/>
                 </sequence>
             </complexType>
+
+            <complexType name="ListViewOrderBy">
+                <sequence>
+                    <element name="fieldNameOrPath"          type="xsd:string"/>
+                    <element name="nullsPosition"            type="tns:orderByNullsPosition" nillable="true"/>
+                    <element name="sortDirection"            type="tns:orderByDirection" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListView">
+                <sequence>
+                    <element name="columns"                  type="tns:ListViewColumn" maxOccurs="unbounded"/>
+                    <element name="id"                       type="tns:ID"/>
+                    <element name="orderBy"                  type="tns:ListViewOrderBy" maxOccurs="unbounded"/>
+                    <element name="query"                    type="xsd:string"/>
+                    <element name="scope"                    type="xsd:string" nillable="true"/>
+                    <element name="sobjectType"              type="xsd:string"/>
+                    <element name="whereCondition"           type="tns:SoqlWhereCondition" minOccurs="0"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListViewsRequest">
+                <sequence>
+                    <element name="listViewParams"      type="tns:DescribeSoqlListViewParams" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListViewParams">
+                <sequence>
+                    <element name="developerNameOrId"        type="xsd:string"/>
+                    <element name="sobjectType"              type="xsd:string" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="DescribeSoqlListViewResult">
+                <sequence>
+                    <element name="describeSoqlListViews"    type="tns:DescribeSoqlListView" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ExecuteListViewRequest">
+                <sequence>
+                    <element name="developerNameOrId"        type="xsd:string"/>
+                    <element name="limit"                    type="xsd:int" nillable="true"/>
+                    <element name="offset"                   type="xsd:int" nillable="true"/>
+                    <element name="orderBy"                  type="tns:ListViewOrderBy" maxOccurs="unbounded"/>
+                    <element name="sobjectType"              type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ExecuteListViewResult">
+                <sequence>
+                    <element name="columns"                  type="tns:ListViewColumn" maxOccurs="unbounded"/>
+                    <element name="developerName"            type="xsd:string"/>
+                    <element name="done"                     type="xsd:boolean"/>
+                    <element name="id"                       type="tns:ID"/>
+                    <element name="label"                    type="xsd:string"/>
+                    <element name="records"                  type="tns:ListViewRecord" maxOccurs="unbounded"/>
+                    <element name="size"                     type="xsd:int"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ListViewRecord">
+                <sequence>
+                    <element name="columns"                  type="tns:ListViewRecordColumn" maxOccurs="unbounded"/>
+                </sequence>
+            </complexType>
+
+            <complexType name="ListViewRecordColumn">
+                <sequence>
+                    <element name="fieldNameOrPath"          type="xsd:string"/>
+                    <element name="value"                    type="xsd:string" nillable="true"/>
+                </sequence>
+            </complexType>
+
+            <simpleType name="orderByDirection">
+                <restriction base="xsd:string">
+                    <enumeration value="ascending"/>
+                    <enumeration value="descending"/>
+                </restriction>
+            </simpleType>
+
+            <simpleType name="orderByNullsPosition">
+                <restriction base="xsd:string">
+                    <enumeration value="first"/>
+                    <enumeration value="last"/>
+                </restriction>
+            </simpleType>
+
+            <simpleType name="soqlOperator">
+                <restriction base="xsd:string">
+                    <enumeration value="equals"/>
+                    <enumeration value="excludes"/>
+                    <enumeration value="greaterThan"/>
+                    <enumeration value="greaterThanOrEqualTo"/>
+                    <enumeration value="in"/>
+                    <enumeration value="includes"/>
+                    <enumeration value="lessThan"/>
+                    <enumeration value="lessThanOrEqualTo"/>
+                    <enumeration value="like"/>
+                    <enumeration value="notEquals"/>
+                    <enumeration value="notIn"/>
+                    <enumeration value="within"/>
+                </restriction>
+            </simpleType>
+
+            <simpleType name="soqlConjunction">
+                <restriction base="xsd:string">
+                    <enumeration value="and"/>
+                    <enumeration value="or"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="SoqlWhereCondition">
+                <sequence/>
+            </complexType>
+
+            <complexType name="SoqlCondition">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="field"                    type="xsd:string"/>
+                            <element name="operator"                 type="tns:soqlOperator"/>
+                            <element name="values"                   type="xsd:string" maxOccurs="unbounded"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SoqlNotCondition">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="condition"                type="tns:SoqlWhereCondition"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SoqlConditionGroup">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="conditions"               type="tns:SoqlWhereCondition" minOccurs="0" maxOccurs="unbounded"/>
+                            <element name="conjunction"              type="tns:soqlConjunction"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+            <complexType name="SoqlSubQueryCondition">
+                <complexContent>
+                    <extension base="tns:SoqlWhereCondition">
+                        <sequence>
+                            <element name="field"                    type="xsd:string"/>
+                            <element name="operator"                 type="tns:soqlOperator"/>
+                            <element name="subQuery"                 type="xsd:string"/>
+                        </sequence>
+                    </extension>
+                </complexContent>
+            </complexType>
+
+
+        
+            <complexType name="DescribeSearchLayoutResult">
+                <sequence>
+                    
+                    <element name="errorMsg" type="xsd:string" nillable="true"/>
+                    <element name="label" type="xsd:string" nillable="true"/>
+                    <element name="limitRows" type="xsd:int" nillable="true"/>
+                    <element name="objectType" type="xsd:string"/>
+                    <element name="searchColumns" type="tns:DescribeColumn" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+                </sequence>
+            </complexType>
+        
 
                 <complexType name="DescribeColumn">
                     <sequence>
@@ -5669,26 +10206,39 @@ All Rights Reserved
             </complexType>
 
 
+
+            <complexType name="DescribeSearchableEntityResult">
+                <sequence>
+                    <element name="label"           type="xsd:string"/>
+                    <element name="name"            type="xsd:string"/>
+                    <element name="pluralLabel"     type="xsd:string"/>
+                </sequence>
+            </complexType>
+
+
             <complexType name="DescribeTabSetResult">
                 <sequence>
+                    <element name="description"     type="xsd:string" />
                     <element name="label"           type="xsd:string" />
                     <element name="logoUrl"         type="xsd:string" />
                     <element name="namespace"       type="xsd:string" minOccurs="0"/>
                     <element name="selected"        type="xsd:boolean" />
+                    <element name="tabSetId"        type="xsd:string" />
                     <element name="tabs"            type="tns:DescribeTab" minOccurs="0" maxOccurs="unbounded"/>
                 </sequence>
             </complexType>
 
             <complexType name="DescribeTab">
                 <sequence>
-                    <element name="colors" type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
-                    <element name="custom"           type="xsd:boolean" />
-                    <element name="iconUrl"          type="xsd:string" />
-                    <element name="icons" type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
-                    <element name="label"            type="xsd:string" />
-                    <element name="miniIconUrl"      type="xsd:string" />
-                    <element name="sobjectName"      type="xsd:string" nillable="true" />
-                    <element name="url"              type="xsd:string" />
+                    <element name="colors"               type="tns:DescribeColor" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="custom"               type="xsd:boolean" />
+                    <element name="iconUrl"              type="xsd:string" />
+                    <element name="icons"                type="tns:DescribeIcon" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="label"                type="xsd:string" />
+                    <element name="miniIconUrl"          type="xsd:string" />
+                    <element name="name"                 type="xsd:string" />
+                    <element name="sobjectName"          type="xsd:string" nillable="true" />
+                    <element name="url"                  type="xsd:string" />
                 </sequence>
             </complexType>
 
@@ -5713,8 +10263,15 @@ All Rights Reserved
             </sequence>
         </complexType>
 
-
-
+        <complexType name="ActionOverride">
+            <sequence>
+                <element name="formFactor" type="xsd:string"/>
+                <element name="isAvailableInTouch" type="xsd:boolean"/>
+                <element name="name" type="xsd:string"/>
+                <element name="pageId" type="tns:ID"/>
+                <element name="url" type="xsd:string"/>
+            </sequence>
+        </complexType>
 
 
 
@@ -5751,6 +10308,8 @@ All Rights Reserved
                     </sequence>
                 </complexType>
             </element>
+
+
 
             <!-- DescibeSObjects Message Types -->
             <element name="describeSObjects">
@@ -5846,10 +10405,31 @@ All Rights Reserved
             </element>
 
 
+            <!-- Describe Knowledge Settings -->
+            <element name="describeKnowledgeSettings">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeKnowledgeSettingsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:KnowledgeSettings"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+
+
+
+
+
             <element name="describeFlexiPages">
                 <complexType>
                     <sequence>
-                        <element name="flexiPages" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+                        <element name="flexiPages" type="xsd:string" minOccurs="1" maxOccurs="unbounded" />
+                        <element name="contexts" type="tns:FlexipageContext" minOccurs="0" maxOccurs="unbounded" />
                     </sequence>
                 </complexType>
             </element>
@@ -5867,6 +10447,7 @@ All Rights Reserved
                 <restriction base="xsd:string">
                     <enumeration value="AppSwitcher"/>
                     <enumeration value="Salesforce1"/>
+                    <enumeration value="NetworkTabs"/>
                 </restriction>
             </simpleType>
 
@@ -5875,6 +10456,8 @@ All Rights Reserved
                 <complexType>
                     <sequence>
                         <element name="appMenuType" type="tns:AppMenuType" />
+
+                        <element name="networkId" type="tns:ID" nillable="true"/>
                     </sequence>
                 </complexType>
             </element>
@@ -5892,6 +10475,7 @@ All Rights Reserved
                 <complexType>
                     <sequence>
                         <element name="sObjectType" type="xsd:string"/>
+                        <element name="layoutName" type="xsd:string" nillable="true"/>
                         <element name="recordTypeIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
                     </sequence>
                 </complexType>
@@ -5921,6 +10505,57 @@ All Rights Reserved
                 </complexType>
             </element>
 
+
+            <element name="describePrimaryCompactLayouts">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectTypes" type="xsd:string" minOccurs="1" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describePrimaryCompactLayoutsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeCompactLayout" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describePathAssistants">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="picklistValue" type="xsd:string" nillable="true"/>
+                        <element name="recordTypeIds" type="tns:ID" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describePathAssistantsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribePathAssistantsResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeApprovalLayout">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="approvalProcessNames" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeApprovalLayoutResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeApprovalLayoutResult" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+
             <element name="describeSoftphoneLayout">
                 <complexType>
                     <sequence/>
@@ -5935,6 +10570,63 @@ All Rights Reserved
             </element>
 
 
+
+            <element name="describeSoqlListViews">
+                <complexType>
+                    <sequence>
+                        <element name="request" type="tns:DescribeSoqlListViewsRequest"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSoqlListViewsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSoqlListViewResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="executeListView">
+                <complexType>
+                    <sequence>
+                        <element name="request" type="tns:ExecuteListViewRequest"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="executeListViewResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:ExecuteListViewResult" minOccurs="0" maxOccurs="1"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <simpleType name="listViewIsSoqlCompatible">
+                <restriction base="xsd:string">
+                    <enumeration value="TRUE"/>
+                    <enumeration value="FALSE"/>
+                    <enumeration value="ALL"/>
+                </restriction>
+            </simpleType>
+
+            <element name="describeSObjectListViews">
+                <complexType>
+                    <sequence>
+                        <element name="sObjectType" type="xsd:string"/>
+                        <element name="recentsOnly" type="xsd:boolean"/>
+                        <element name="isSoqlCompatible" type="tns:listViewIsSoqlCompatible"/>
+                        <element name="limit" type="xsd:int"/>
+                        <element name="offset" type="xsd:int"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSObjectListViewsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSoqlListViewResult"/>
+                    </sequence>
+                </complexType>
+            </element>
 
 
             <element name="describeSearchLayouts">
@@ -5968,11 +10660,29 @@ All Rights Reserved
             </element>
 
 
+
+            <element name="describeSearchableEntities">
+                <complexType>
+                    <sequence>
+                        <element name="includeOnlyEntitiesWithTabs" type="xsd:boolean"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeSearchableEntitiesResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeSearchableEntityResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
             <element name="describeTabs">
                 <complexType>
                     <sequence/>
                 </complexType>
             </element>
+
             <element name="describeTabsResponse">
                 <complexType>
                     <sequence>
@@ -5980,6 +10690,39 @@ All Rights Reserved
                     </sequence>
                 </complexType>
             </element>
+
+
+            <element name="describeAllTabs">
+                <complexType>
+                    <sequence/>
+                </complexType>
+            </element>
+            <element name="describeAllTabsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeTab" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <element name="describeNouns">
+                <complexType>
+                    <sequence>
+                        <element name="nouns" type="xsd:string" minOccurs='0' maxOccurs='100' />
+                        <element name="onlyRenamed" type="xsd:boolean"/>
+                        <element name="includeFields" type="xsd:boolean"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeNounsResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeNounResult" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
 
             <!-- Create Message Types -->
             <element name="create">
@@ -6011,6 +10754,47 @@ All Rights Reserved
                 <complexType>
                     <sequence>
                         <element name="result" minOccurs="0" maxOccurs="10" type="tns:SendEmailResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
+            <!-- Template Merge -->
+            <complexType name="RenderEmailTemplateRequest">
+                    <sequence>
+                        <element name="templateBodies" type="xsd:string" minOccurs="1" maxOccurs="10" nillable="false" />
+                        <element name="whatId"         type="tns:ID" minOccurs="0" maxOccurs="1" />
+                        <element name="whoId"          type="tns:ID" minOccurs="0" maxOccurs="1" />
+                    </sequence>
+            </complexType>
+
+            <complexType name="RenderEmailTemplateBodyResult">
+                <sequence>
+                    <element name="errors"              type="tns:RenderEmailTemplateError" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="mergedBody"          type="xsd:string" nillable="true" />
+                    <element name="success"             type="xsd:boolean" />
+                </sequence>
+            </complexType>
+
+            <complexType name="RenderEmailTemplateResult">
+                <sequence>
+                    <element name="bodyResults"         type="tns:RenderEmailTemplateBodyResult" minOccurs="0" maxOccurs="10"/>
+                    <element name="errors"    			type="tns:Error" minOccurs="0" maxOccurs="unbounded"/>
+                    <element name="success"             type="xsd:boolean" />
+                </sequence>
+            </complexType>
+
+            <element name="renderEmailTemplate">
+                <complexType>
+                    <sequence>
+                        <element name="renderRequests" type="tns:RenderEmailTemplateRequest" minOccurs="0" maxOccurs="10"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="renderEmailTemplateResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" minOccurs="0" maxOccurs="10" type="tns:RenderEmailTemplateResult"/>
                     </sequence>
                 </complexType>
             </element>
@@ -6162,6 +10946,23 @@ All Rights Reserved
                 </complexType>
             </element>
 
+
+            <element name="retrieveQuickActionTemplates">
+                <complexType>
+                    <sequence>
+                        <element name="quickActionNames" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+                        <element name="contextId" type="tns:ID" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="retrieveQuickActionTemplatesResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:QuickActionTemplateResult" minOccurs="0" maxOccurs="unbounded"/>
+                    </sequence>
+                </complexType>
+            </element>
+
             <element name="describeQuickActions">
                 <complexType>
                     <sequence>
@@ -6193,6 +10994,23 @@ All Rights Reserved
             </element>
 
 
+            <element name="describeVisualForce">
+                <complexType>
+                    <sequence>
+                        <element name="includeAllDetails" type="xsd:boolean"/>
+                        <element name="namespacePrefix" type="xsd:string" nillable="true"/>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="describeVisualForceResponse">
+                <complexType>
+                    <sequence>
+                        <element name="result" type="tns:DescribeVisualForceResult"/>
+                    </sequence>
+                </complexType>
+            </element>
+
+
 
             <!-- Retrieve (ID List) Message Types -->
             <element name="retrieve">
@@ -6211,6 +11029,8 @@ All Rights Reserved
                     </sequence>
                 </complexType>
             </element>
+
+      
 
             <!-- Convert Lead Message Types -->
             <element name="convertLead">
@@ -6455,15 +11275,61 @@ All Rights Reserved
                     <enumeration value="None"/>
                     <enumeration value="DebugOnly"/>
                     <enumeration value="Db"/>
+
+                    <enumeration value="Profiling"/>
+                    <enumeration value="Callout"/>
+                    <enumeration value="Detail"/>
+
                 </restriction>
             </simpleType>
+
+
+
+
             <element name="DebuggingHeader">
                 <complexType>
                     <sequence>
+
+                        <xsd:element name="categories" minOccurs="0" maxOccurs="unbounded" type="tns:LogInfo"/>
+
                         <element name="debugLevel" type="tns:DebugLevel"/>
                     </sequence>
                 </complexType>
-            </element>
+           </element>
+
+           <xsd:complexType name="LogInfo">
+               <xsd:sequence>
+                   <xsd:element name="category" type="tns:LogCategory"/>
+                   <xsd:element name="level" type="tns:LogCategoryLevel"/>
+               </xsd:sequence>
+           </xsd:complexType>
+           <xsd:simpleType name="LogCategory">
+              <xsd:restriction base="xsd:string">
+                  <xsd:enumeration value="Db"/>
+                  <xsd:enumeration value="Workflow"/>
+                  <xsd:enumeration value="Validation"/>
+                  <xsd:enumeration value="Callout"/>
+                  <xsd:enumeration value="Apex_code"/>
+                  <xsd:enumeration value="Apex_profiling"/>
+                  <xsd:enumeration value="Visualforce"/>
+                  <xsd:enumeration value="System"/>
+                  <xsd:enumeration value="All"/>
+              </xsd:restriction>
+           </xsd:simpleType>
+           <xsd:simpleType name="LogCategoryLevel">
+                   <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="None"/>
+                    <xsd:enumeration value="Finest"/>
+                    <xsd:enumeration value="Finer"/>
+                    <xsd:enumeration value="Fine"/>
+                    <xsd:enumeration value="Debug"/>
+                    <xsd:enumeration value="Info"/>
+                    <xsd:enumeration value="Warn"/>
+                     <xsd:enumeration value="Error"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+
+
             <element name="DebuggingInfo">
                 <complexType>
                     <sequence>
@@ -6526,6 +11392,18 @@ All Rights Reserved
 
 
 
+        <element name="DuplicateRuleHeader">
+            <complexType>
+                <sequence>
+                    <element name="allowSave" type="xsd:boolean" />
+                    <element name="includeRecordDetails" type="xsd:boolean" />
+                    <element name="runAsCurrentUser" type="xsd:boolean" />
+                </sequence>
+            </complexType>
+        </element>
+
+
+
         <complexType name="LimitInfo">
             <sequence>
                 <element name="current" type="xsd:int"/>
@@ -6543,17 +11421,22 @@ All Rights Reserved
         </element>
 
 
+
+
+
+
+
             <!-- ideally this could of just been elem name="..." type="xsd:boolean"
                  but is required to be nested within a complexType for .NET 1.1 compatibility -->
-            <element name="MruHeader">
+    <element name="MruHeader">
                 <complexType>
                     <sequence>
                         <element name="updateMru" type="xsd:boolean" />
                     </sequence>
                 </complexType>
-            </element>
+    </element>
 
-            <element name="EmailHeader">
+    <element name="EmailHeader">
                 <complexType>
                     <sequence>
                         <element name="triggerAutoResponseEmail"    type="xsd:boolean"/>
@@ -6561,16 +11444,16 @@ All Rights Reserved
                         <element name="triggerUserEmail"            type="xsd:boolean"/>
                     </sequence>
                 </complexType>
-            </element>
+    </element>
 
-            <element name="AssignmentRuleHeader">
+    <element name="AssignmentRuleHeader">
                 <complexType>
                     <sequence>
                         <element name="assignmentRuleId"    type="tns:ID"  nillable="true" />
                         <element name="useDefaultRule"      type="xsd:boolean" nillable="true" />
                     </sequence>
                 </complexType>
-            </element>
+    </element>
 
             <element name="UserTerritoryDeleteHeader">
                 <complexType>
@@ -6586,41 +11469,84 @@ All Rights Reserved
                 <complexType>
                     <sequence>
                         <element name="language"  type="xsd:string" minOccurs="0"/>
+
+                        <element name="localizeErrors" type="xsd:boolean" minOccurs="0"/>
+
                     </sequence>
                 </complexType>
             </element>
 
-        <element name="OwnerChangeOptions">
-            <complexType>
+            <simpleType name="OwnerChangeOptionType">
+                <restriction base="xsd:string">
+                    <enumeration value="EnforceNewOwnerHasReadAccess"/>
+                    <enumeration value="TransferOpenActivities"/>
+                    <enumeration value="TransferNotesAndAttachments"/>
+                    <enumeration value="TransferOthersOpenOpportunities"/>
+                    <enumeration value="TransferOwnedOpenOpportunities"/>
+                    <enumeration value="TransferContracts"/>
+                    <enumeration value="TransferOrders"/>
+                    <enumeration value="TransferContacts"/>
+                </restriction>
+            </simpleType>
+
+            <complexType name="OwnerChangeOption">
                 <sequence>
-                    <element name="transferAttachments" type="xsd:boolean"/>
-                    <element name="transferOpenActivities" type="xsd:boolean"/>
+                      <element name="type" type="tns:OwnerChangeOptionType"/>
+                      <element name="execute" type="xsd:boolean"/>
                 </sequence>
             </complexType>
-        </element>
+
+            <element name="OwnerChangeOptions">
+                <complexType>
+                     <sequence>
+
+                         <element name="options" type="tns:OwnerChangeOption" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+
+                   </sequence>
+                </complexType>
+            </element>
 
         </schema>
 
         <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:fault.enterprise.soap.sforce.com" xmlns:fns="urn:fault.enterprise.soap.sforce.com">
 
+            <import namespace="urn:enterprise.soap.sforce.com"/>
             <simpleType name="ExceptionCode">
                 <restriction base="xsd:string">
                     <enumeration value="APEX_TRIGGER_COUPLING_LIMIT"/>
                     <enumeration value="API_CURRENTLY_DISABLED"/>
                     <enumeration value="API_DISABLED_FOR_ORG"/>
                     <enumeration value="ARGUMENT_OBJECT_PARSE_ERROR"/>
+                    <enumeration value="ASYNC_OPERATION_LOCATOR"/>
+                    <enumeration value="ASYNC_QUERY_UNSUPPORTED_QUERY"/>
                     <enumeration value="BATCH_PROCESSING_HALTED"/>
+                    <enumeration value="BIG_OBJECT_UNSUPPORTED_OPERATION"/>
+                    <enumeration value="CANNOT_DELETE_ENTITY"/>
                     <enumeration value="CANNOT_DELETE_OWNER"/>
                     <enumeration value="CANT_ADD_STANDADRD_PORTAL_USER_TO_TERRITORY"/>
                     <enumeration value="CANT_ADD_STANDARD_PORTAL_USER_TO_TERRITORY"/>
                     <enumeration value="CIRCULAR_OBJECT_GRAPH"/>
                     <enumeration value="CLIENT_NOT_ACCESSIBLE_FOR_USER"/>
                     <enumeration value="CLIENT_REQUIRE_UPDATE_FOR_USER"/>
+                    <enumeration value="CONTENT_CUSTOM_DOWNLOAD_EXCEPTION"/>
                     <enumeration value="CONTENT_HUB_AUTHENTICATION_EXCEPTION"/>
                     <enumeration value="CONTENT_HUB_FILE_DOWNLOAD_EXCEPTION"/>
                     <enumeration value="CONTENT_HUB_FILE_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_INVALID_OBJECT_TYPE_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_INVALID_PAGE_NUMBER_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_INVALID_PAYLOAD"/>
+                    <enumeration value="CONTENT_HUB_INVALID_RENDITION_PAGE_NUMBER_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_ITEM_TYPE_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_OBJECT_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_OPERATION_NOT_SUPPORTED_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_SECURITY_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_TIMEOUT_EXCEPTION"/>
+                    <enumeration value="CONTENT_HUB_UNEXPECTED_EXCEPTION"/>
                     <enumeration value="CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+                    <enumeration value="CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
                     <enumeration value="DATACLOUD_API_CLIENT_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_DISABLED_EXCEPTION"/>
+                    <enumeration value="DATACLOUD_API_INVALID_QUERY_EXCEPTION"/>
                     <enumeration value="DATACLOUD_API_SERVER_BUSY_EXCEPTION"/>
                     <enumeration value="DATACLOUD_API_SERVER_EXCEPTION"/>
                     <enumeration value="DATACLOUD_API_TIMEOUT_EXCEPTION"/>
@@ -6631,10 +11557,12 @@ All Rights Reserved
                     <enumeration value="EMAIL_TO_CASE_INVALID_ROUTING"/>
                     <enumeration value="EMAIL_TO_CASE_LIMIT_EXCEEDED"/>
                     <enumeration value="EMAIL_TO_CASE_NOT_ENABLED"/>
+                    <enumeration value="ENTITY_NOT_QUERYABLE"/>
                     <enumeration value="ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
                     <enumeration value="EXCEEDED_ID_LIMIT"/>
                     <enumeration value="EXCEEDED_LEAD_CONVERT_LIMIT"/>
                     <enumeration value="EXCEEDED_MAX_SIZE_REQUEST"/>
+                    <enumeration value="EXCEEDED_MAX_SOBJECTS"/>
                     <enumeration value="EXCEEDED_MAX_TYPES_LIMIT"/>
                     <enumeration value="EXCEEDED_QUOTA"/>
                     <enumeration value="EXTERNAL_OBJECT_AUTHENTICATION_EXCEPTION"/>
@@ -6648,6 +11576,7 @@ All Rights Reserved
                     <enumeration value="ILLEGAL_QUERY_PARAMETER_VALUE"/>
                     <enumeration value="INACTIVE_OWNER_OR_USER"/>
                     <enumeration value="INACTIVE_PORTAL"/>
+                    <enumeration value="INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE"/>
                     <enumeration value="INSUFFICIENT_ACCESS"/>
                     <enumeration value="INTERNAL_CANVAS_ERROR"/>
                     <enumeration value="INVALID_ASSIGNMENT_RULE"/>
@@ -6686,6 +11615,8 @@ All Rights Reserved
                     <enumeration value="JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
                     <enumeration value="JIGSAW_REQUEST_NOT_SUPPORTED"/>
                     <enumeration value="JSON_PARSER_ERROR"/>
+                    <enumeration value="KEY_HAS_BEEN_DESTROYED"/>
+                    <enumeration value="LICENSING_DATA_ERROR"/>
                     <enumeration value="LICENSING_UNKNOWN_ERROR"/>
                     <enumeration value="LIMIT_EXCEEDED"/>
                     <enumeration value="LOGIN_CHALLENGE_ISSUED"/>
@@ -6698,8 +11629,11 @@ All Rights Reserved
                     <enumeration value="MALFORMED_SEARCH"/>
                     <enumeration value="MISSING_ARGUMENT"/>
                     <enumeration value="MISSING_RECORD"/>
+                    <enumeration value="MODIFIED"/>
                     <enumeration value="MUTUAL_AUTHENTICATION_FAILED"/>
+                    <enumeration value="NOT_ACCEPTABLE"/>
                     <enumeration value="NOT_MODIFIED"/>
+                    <enumeration value="NO_ACTIVE_DUPLICATE_RULE"/>
                     <enumeration value="NO_SOFTPHONE_LAYOUT"/>
                     <enumeration value="NUMBER_OUTSIDE_VALID_RANGE"/>
                     <enumeration value="OPERATION_TOO_LARGE"/>
@@ -6716,17 +11650,23 @@ All Rights Reserved
                     <enumeration value="REQUEST_LIMIT_EXCEEDED"/>
                     <enumeration value="REQUEST_RUNNING_TOO_LONG"/>
                     <enumeration value="SERVER_UNAVAILABLE"/>
+                    <enumeration value="SERVICE_DESK_NOT_ENABLED"/>
                     <enumeration value="SOCIALCRM_FEEDSERVICE_API_CLIENT_EXCEPTION"/>
                     <enumeration value="SOCIALCRM_FEEDSERVICE_API_SERVER_EXCEPTION"/>
                     <enumeration value="SOCIALCRM_FEEDSERVICE_API_UNAVAILABLE"/>
                     <enumeration value="SSO_SERVICE_DOWN"/>
+                    <enumeration value="SST_ADMIN_FILE_DOWNLOAD_EXCEPTION"/>
                     <enumeration value="TOO_MANY_APEX_REQUESTS"/>
                     <enumeration value="TOO_MANY_RECIPIENTS"/>
                     <enumeration value="TOO_MANY_RECORDS"/>
                     <enumeration value="TRIAL_EXPIRED"/>
+                    <enumeration value="TXN_SECURITY_END_A_SESSION"/>
+                    <enumeration value="TXN_SECURITY_NO_ACCESS"/>
+                    <enumeration value="TXN_SECURITY_TWO_FA_REQUIRED"/>
                     <enumeration value="UNABLE_TO_LOCK_ROW"/>
                     <enumeration value="UNKNOWN_ATTACHMENT_EXCEPTION"/>
                     <enumeration value="UNKNOWN_EXCEPTION"/>
+                    <enumeration value="UNKNOWN_ORG_SETTING"/>
                     <enumeration value="UNSUPPORTED_API_VERSION"/>
                     <enumeration value="UNSUPPORTED_ATTACHMENT_ENCODING"/>
                     <enumeration value="UNSUPPORTED_CLIENT"/>
@@ -6741,18 +11681,36 @@ All Rights Reserved
                     <enumeration value="fns:API_CURRENTLY_DISABLED"/>
                     <enumeration value="fns:API_DISABLED_FOR_ORG"/>
                     <enumeration value="fns:ARGUMENT_OBJECT_PARSE_ERROR"/>
+                    <enumeration value="fns:ASYNC_OPERATION_LOCATOR"/>
+                    <enumeration value="fns:ASYNC_QUERY_UNSUPPORTED_QUERY"/>
                     <enumeration value="fns:BATCH_PROCESSING_HALTED"/>
+                    <enumeration value="fns:BIG_OBJECT_UNSUPPORTED_OPERATION"/>
+                    <enumeration value="fns:CANNOT_DELETE_ENTITY"/>
                     <enumeration value="fns:CANNOT_DELETE_OWNER"/>
                     <enumeration value="fns:CANT_ADD_STANDADRD_PORTAL_USER_TO_TERRITORY"/>
                     <enumeration value="fns:CANT_ADD_STANDARD_PORTAL_USER_TO_TERRITORY"/>
                     <enumeration value="fns:CIRCULAR_OBJECT_GRAPH"/>
                     <enumeration value="fns:CLIENT_NOT_ACCESSIBLE_FOR_USER"/>
                     <enumeration value="fns:CLIENT_REQUIRE_UPDATE_FOR_USER"/>
+                    <enumeration value="fns:CONTENT_CUSTOM_DOWNLOAD_EXCEPTION"/>
                     <enumeration value="fns:CONTENT_HUB_AUTHENTICATION_EXCEPTION"/>
                     <enumeration value="fns:CONTENT_HUB_FILE_DOWNLOAD_EXCEPTION"/>
                     <enumeration value="fns:CONTENT_HUB_FILE_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_INVALID_OBJECT_TYPE_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_INVALID_PAGE_NUMBER_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_INVALID_PAYLOAD"/>
+                    <enumeration value="fns:CONTENT_HUB_INVALID_RENDITION_PAGE_NUMBER_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_ITEM_TYPE_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_OBJECT_NOT_FOUND_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_OPERATION_NOT_SUPPORTED_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_SECURITY_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_TIMEOUT_EXCEPTION"/>
+                    <enumeration value="fns:CONTENT_HUB_UNEXPECTED_EXCEPTION"/>
                     <enumeration value="fns:CUSTOM_METADATA_LIMIT_EXCEEDED"/>
+                    <enumeration value="fns:CUSTOM_SETTINGS_LIMIT_EXCEEDED"/>
                     <enumeration value="fns:DATACLOUD_API_CLIENT_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_DISABLED_EXCEPTION"/>
+                    <enumeration value="fns:DATACLOUD_API_INVALID_QUERY_EXCEPTION"/>
                     <enumeration value="fns:DATACLOUD_API_SERVER_BUSY_EXCEPTION"/>
                     <enumeration value="fns:DATACLOUD_API_SERVER_EXCEPTION"/>
                     <enumeration value="fns:DATACLOUD_API_TIMEOUT_EXCEPTION"/>
@@ -6763,10 +11721,12 @@ All Rights Reserved
                     <enumeration value="fns:EMAIL_TO_CASE_INVALID_ROUTING"/>
                     <enumeration value="fns:EMAIL_TO_CASE_LIMIT_EXCEEDED"/>
                     <enumeration value="fns:EMAIL_TO_CASE_NOT_ENABLED"/>
+                    <enumeration value="fns:ENTITY_NOT_QUERYABLE"/>
                     <enumeration value="fns:ENVIRONMENT_HUB_MEMBERSHIP_CONFLICT"/>
                     <enumeration value="fns:EXCEEDED_ID_LIMIT"/>
                     <enumeration value="fns:EXCEEDED_LEAD_CONVERT_LIMIT"/>
                     <enumeration value="fns:EXCEEDED_MAX_SIZE_REQUEST"/>
+                    <enumeration value="fns:EXCEEDED_MAX_SOBJECTS"/>
                     <enumeration value="fns:EXCEEDED_MAX_TYPES_LIMIT"/>
                     <enumeration value="fns:EXCEEDED_QUOTA"/>
                     <enumeration value="fns:EXTERNAL_OBJECT_AUTHENTICATION_EXCEPTION"/>
@@ -6780,6 +11740,7 @@ All Rights Reserved
                     <enumeration value="fns:ILLEGAL_QUERY_PARAMETER_VALUE"/>
                     <enumeration value="fns:INACTIVE_OWNER_OR_USER"/>
                     <enumeration value="fns:INACTIVE_PORTAL"/>
+                    <enumeration value="fns:INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE"/>
                     <enumeration value="fns:INSUFFICIENT_ACCESS"/>
                     <enumeration value="fns:INTERNAL_CANVAS_ERROR"/>
                     <enumeration value="fns:INVALID_ASSIGNMENT_RULE"/>
@@ -6818,6 +11779,8 @@ All Rights Reserved
                     <enumeration value="fns:JIGSAW_IMPORT_LIMIT_EXCEEDED"/>
                     <enumeration value="fns:JIGSAW_REQUEST_NOT_SUPPORTED"/>
                     <enumeration value="fns:JSON_PARSER_ERROR"/>
+                    <enumeration value="fns:KEY_HAS_BEEN_DESTROYED"/>
+                    <enumeration value="fns:LICENSING_DATA_ERROR"/>
                     <enumeration value="fns:LICENSING_UNKNOWN_ERROR"/>
                     <enumeration value="fns:LIMIT_EXCEEDED"/>
                     <enumeration value="fns:LOGIN_CHALLENGE_ISSUED"/>
@@ -6830,8 +11793,11 @@ All Rights Reserved
                     <enumeration value="fns:MALFORMED_SEARCH"/>
                     <enumeration value="fns:MISSING_ARGUMENT"/>
                     <enumeration value="fns:MISSING_RECORD"/>
+                    <enumeration value="fns:MODIFIED"/>
                     <enumeration value="fns:MUTUAL_AUTHENTICATION_FAILED"/>
+                    <enumeration value="fns:NOT_ACCEPTABLE"/>
                     <enumeration value="fns:NOT_MODIFIED"/>
+                    <enumeration value="fns:NO_ACTIVE_DUPLICATE_RULE"/>
                     <enumeration value="fns:NO_SOFTPHONE_LAYOUT"/>
                     <enumeration value="fns:NUMBER_OUTSIDE_VALID_RANGE"/>
                     <enumeration value="fns:OPERATION_TOO_LARGE"/>
@@ -6848,17 +11814,23 @@ All Rights Reserved
                     <enumeration value="fns:REQUEST_LIMIT_EXCEEDED"/>
                     <enumeration value="fns:REQUEST_RUNNING_TOO_LONG"/>
                     <enumeration value="fns:SERVER_UNAVAILABLE"/>
+                    <enumeration value="fns:SERVICE_DESK_NOT_ENABLED"/>
                     <enumeration value="fns:SOCIALCRM_FEEDSERVICE_API_CLIENT_EXCEPTION"/>
                     <enumeration value="fns:SOCIALCRM_FEEDSERVICE_API_SERVER_EXCEPTION"/>
                     <enumeration value="fns:SOCIALCRM_FEEDSERVICE_API_UNAVAILABLE"/>
                     <enumeration value="fns:SSO_SERVICE_DOWN"/>
+                    <enumeration value="fns:SST_ADMIN_FILE_DOWNLOAD_EXCEPTION"/>
                     <enumeration value="fns:TOO_MANY_APEX_REQUESTS"/>
                     <enumeration value="fns:TOO_MANY_RECIPIENTS"/>
                     <enumeration value="fns:TOO_MANY_RECORDS"/>
                     <enumeration value="fns:TRIAL_EXPIRED"/>
+                    <enumeration value="fns:TXN_SECURITY_END_A_SESSION"/>
+                    <enumeration value="fns:TXN_SECURITY_NO_ACCESS"/>
+                    <enumeration value="fns:TXN_SECURITY_TWO_FA_REQUIRED"/>
                     <enumeration value="fns:UNABLE_TO_LOCK_ROW"/>
                     <enumeration value="fns:UNKNOWN_ATTACHMENT_EXCEPTION"/>
                     <enumeration value="fns:UNKNOWN_EXCEPTION"/>
+                    <enumeration value="fns:UNKNOWN_ORG_SETTING"/>
                     <enumeration value="fns:UNSUPPORTED_API_VERSION"/>
                     <enumeration value="fns:UNSUPPORTED_ATTACHMENT_ENCODING"/>
                     <enumeration value="fns:UNSUPPORTED_CLIENT"/>
@@ -6873,6 +11845,9 @@ All Rights Reserved
                 <sequence>
                     <element name="exceptionCode"    type="fns:ExceptionCode"/>
                     <element name="exceptionMessage" type="xsd:string"/>
+
+                    <element name="extendedErrorDetails" type="tns:ExtendedErrorDetails" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
+
 
                 </sequence>
             </complexType>
@@ -6962,11 +11937,18 @@ All Rights Reserved
         <part element="tns:LoginScopeHeader"             name="LoginScopeHeader"/>
         <part element="tns:SessionHeader"                name="SessionHeader"/>
 
+
         <part element="tns:QueryOptions"                 name="QueryOptions"/>
         <part element="tns:AssignmentRuleHeader"         name="AssignmentRuleHeader"/>
         <part element="tns:AllowFieldTruncationHeader"   name="AllowFieldTruncationHeader"/>
 
         <part element="tns:AllOrNoneHeader"              name="AllOrNoneHeader"/>
+
+
+
+
+        <part element="tns:DuplicateRuleHeader"          name="DuplicateRuleHeader"/>
+
 
 
         <part element="tns:DisableFeedTrackingHeader"    name="DisableFeedTrackingHeader"/>
@@ -6981,6 +11963,8 @@ All Rights Reserved
 
         <part element="tns:DebuggingHeader"              name="DebuggingHeader"/>
         <part element="tns:PackageVersionHeader"         name="PackageVersionHeader"/>
+
+
         <part element="tns:DebuggingInfo"                name="DebuggingInfo"/>
 
         <part element="tns:LimitInfoHeader"              name="LimitInfoHeader"/>
@@ -7069,6 +12053,13 @@ All Rights Reserved
         <part element="tns:describeDataCategoryGroupStructuresResponse" name="parameters"/>
     </message>
 
+    <message name="describeKnowledgeSettingsRequest">
+        <part element="tns:describeKnowledgeSettings" name="parameters"/>
+    </message>
+    <message name="describeKnowledgeSettingsResponse">
+        <part element="tns:describeKnowledgeSettingsResponse" name="parameters"/>
+    </message>
+
     <message name="describeFlexiPagesRequest">
         <part element="tns:describeFlexiPages" name="parameters"/>
     </message>
@@ -7118,6 +12109,13 @@ All Rights Reserved
         <part element="tns:describeSearchLayoutsResponse" name="parameters"/>
     </message>
 
+    <message name="describeSearchableEntitiesRequest">
+        <part element="tns:describeSearchableEntities" name="parameters"/>
+    </message>
+    <message name="describeSearchableEntitiesResponse">
+        <part element="tns:describeSearchableEntitiesResponse" name="parameters"/>
+    </message>
+
     <message name="describeSearchScopeOrderRequest">
         <part element="tns:describeSearchScopeOrder" name="parameters"/>
     </message>
@@ -7132,11 +12130,60 @@ All Rights Reserved
         <part element="tns:describeCompactLayoutsResponse" name="parameters"/>
     </message>
 
+    <message name="describePathAssistantsRequest">
+        <part element="tns:describePathAssistants" name="parameters"/>
+    </message>
+    <message name="describePathAssistantsResponse">
+        <part element="tns:describePathAssistantsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeApprovalLayoutRequest">
+        <part element="tns:describeApprovalLayout" name="parameters"/>
+    </message>
+    <message name="describeApprovalLayoutResponse">
+        <part element="tns:describeApprovalLayoutResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSoqlListViewsRequest">
+        <part element="tns:describeSoqlListViews" name="parameters"/>
+    </message>
+    <message name="describeSoqlListViewsResponse">
+        <part element="tns:describeSoqlListViewsResponse" name="parameters"/>
+    </message>
+
+    <message name="executeListViewRequest">
+        <part element="tns:executeListView" name="parameters"/>
+    </message>
+    <message name="executeListViewResponse">
+        <part element="tns:executeListViewResponse" name="parameters"/>
+    </message>
+
+    <message name="describeSObjectListViewsRequest">
+        <part element="tns:describeSObjectListViews" name="parameters"/>
+    </message>
+    <message name="describeSObjectListViewsResponse">
+        <part element="tns:describeSObjectListViewsResponse" name="parameters"/>
+    </message>
+
     <message name="describeTabsRequest">
         <part element="tns:describeTabs" name="parameters"/>
     </message>
     <message name="describeTabsResponse">
         <part element="tns:describeTabsResponse" name="parameters"/>
+    </message>
+
+    <message name="describeAllTabsRequest">
+        <part element="tns:describeAllTabs" name="parameters"/>
+    </message>
+    <message name="describeAllTabsResponse">
+        <part element="tns:describeAllTabsResponse" name="parameters"/>
+    </message>
+
+    <message name="describePrimaryCompactLayoutsRequest">
+        <part element="tns:describePrimaryCompactLayouts" name="parameters"/>
+    </message>
+    <message name="describePrimaryCompactLayoutsResponse">
+        <part element="tns:describePrimaryCompactLayoutsResponse" name="parameters"/>
     </message>
 
     <message name="createRequest">
@@ -7307,6 +12354,13 @@ All Rights Reserved
         <part element="tns:sendEmailResponse" name="parameters"/>
     </message>
 
+    <message name="renderEmailTemplateRequest">
+        <part element="tns:renderEmailTemplate" name="parameters"/>
+    </message>
+    <message name="renderEmailTemplateResponse">
+        <part element="tns:renderEmailTemplateResponse" name="parameters"/>
+    </message>
+
     <message name="performQuickActionsRequest">
         <part element="tns:performQuickActions" name="parameters"/>
     </message>
@@ -7326,6 +12380,34 @@ All Rights Reserved
     </message>
     <message name="describeAvailableQuickActionsResponse">
         <part element="tns:describeAvailableQuickActionsResponse" name="parameters"/>
+    </message>
+
+    <message name="retrieveQuickActionTemplatesRequest">
+        <part element="tns:retrieveQuickActionTemplates" name="parameters"/>
+    </message>
+    <message name="retrieveQuickActionTemplatesResponse">
+        <part element="tns:retrieveQuickActionTemplatesResponse" name="parameters"/>
+    </message>
+
+    <message name="describeVisualForceRequest">
+        <part element="tns:describeVisualForce" name="parameters"/>
+    </message>
+    <message name="describeVisualForceResponse">
+        <part element="tns:describeVisualForceResponse" name="parameters"/>
+    </message>
+
+    <message name="findDuplicatesRequest">
+        <part element="tns:findDuplicates" name="parameters"/>
+    </message>
+    <message name="findDuplicatesResponse">
+        <part element="tns:findDuplicatesResponse" name="parameters"/>
+    </message>
+
+    <message name="describeNounsRequest">
+        <part element="tns:describeNouns" name="parameters"/>
+    </message>
+    <message name="describeNounsResponse">
+        <part element="tns:describeNounsResponse" name="parameters"/>
     </message>
 
 
@@ -7350,7 +12432,7 @@ All Rights Reserved
         </operation>
 
         <operation name="describeSObjects">
-            <documentation>Describe a number sObjects</documentation>
+            <documentation>Describe multiple sObjects (upto 100)</documentation>
             <input  message="tns:describeSObjectsRequest"/>
             <output message="tns:describeSObjectsResponse"/>
             <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
@@ -7377,6 +12459,13 @@ All Rights Reserved
             <input  message="tns:describeDataCategoryGroupStructuresRequest"/>
             <output message="tns:describeDataCategoryGroupStructuresResponse"/>
             <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeKnowledgeSettings">
+            <documentation>Describes your Knowledge settings, such as if knowledgeEnabled is on or off, its default language and supported languages</documentation>
+            <input  message="tns:describeKnowledgeSettingsRequest"/>
+            <output message="tns:describeKnowledgeSettingsResponse"/>
             <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
         </operation>
 
@@ -7433,6 +12522,12 @@ All Rights Reserved
             <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
         </operation>
 
+        <operation name="describeSearchableEntities">
+            <documentation>Describe a list of entity names that reflects the current user's searchable entities</documentation>
+            <input  message="tns:describeSearchableEntitiesRequest"/>
+            <output message="tns:describeSearchableEntitiesResponse"/>
+        </operation>
+
         <operation name="describeSearchScopeOrder">
             <documentation>Describe a list of objects representing the order and scope of objects on a users search result page</documentation>
             <input  message="tns:describeSearchScopeOrderRequest"/>
@@ -7445,11 +12540,58 @@ All Rights Reserved
             <output message="tns:describeCompactLayoutsResponse"/>
         </operation>
 
+        <operation name="describePathAssistants">
+            <documentation>Describe the Path Assistants for the given sObject and optionally RecordTypes</documentation>
+            <input  message="tns:describePathAssistantsRequest"/>
+            <output message="tns:describePathAssistantsResponse"/>
+        </operation>
+
+        <operation name="describeApprovalLayout">
+            <documentation>Describe the approval layouts of the given sObject</documentation>
+            <input  message="tns:describeApprovalLayoutRequest"/>
+            <output message="tns:describeApprovalLayoutResponse"/>
+        </operation>
+
+        <operation name="describeSoqlListViews">
+            <documentation>Describe the ListViews as SOQL metadata for the generation of SOQL.</documentation>
+            <input  message="tns:describeSoqlListViewsRequest"/>
+            <output message="tns:describeSoqlListViewsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="executeListView">
+            <documentation>Execute the specified list view and return the presentation-ready results.</documentation>
+            <input  message="tns:executeListViewRequest"/>
+            <output message="tns:executeListViewResponse"/>
+        </operation>
+
+        <operation name="describeSObjectListViews">
+            <documentation>Describe the ListViews of a SObject as SOQL metadata for the generation of SOQL.</documentation>
+            <input  message="tns:describeSObjectListViewsRequest"/>
+            <output message="tns:describeSObjectListViewsResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
         <operation name="describeTabs">
             <documentation>Describe the tabs that appear on a users page</documentation>
             <input  message="tns:describeTabsRequest"/>
             <output message="tns:describeTabsResponse"/>
             <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describeAllTabs">
+            <documentation>Describe all tabs available to a user</documentation>
+            <input  message="tns:describeAllTabsRequest"/>
+            <output message="tns:describeAllTabsResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
+        <operation name="describePrimaryCompactLayouts">
+            <documentation>Describe the primary compact layouts for the sObjects requested</documentation>
+            <input  message="tns:describePrimaryCompactLayoutsRequest"/>
+            <output message="tns:describePrimaryCompactLayoutsResponse"/>
         </operation>
 
         <operation name="create">
@@ -7658,6 +12800,13 @@ All Rights Reserved
             <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
         </operation>
 
+        <operation name="renderEmailTemplate">
+            <documentation>Perform a template merge on one or more blocks of text.</documentation>
+            <input  message="tns:renderEmailTemplateRequest"/>
+            <output message="tns:renderEmailTemplateResponse"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+        </operation>
+
         <operation name="performQuickActions">
             <documentation>Perform a series of predefined actions such as quick create or log a task</documentation>
             <input  message="tns:performQuickActionsRequest"/>
@@ -7674,6 +12823,33 @@ All Rights Reserved
             <documentation>Describe the details of a series of quick actions available for the given contextType</documentation>
             <input  message="tns:describeAvailableQuickActionsRequest"/>
             <output message="tns:describeAvailableQuickActionsResponse"/>
+        </operation>
+
+        <operation name="retrieveQuickActionTemplates">
+            <documentation>Retreive the template sobjects, if appropriate, for the given quick action names in a given context</documentation>
+            <input  message="tns:retrieveQuickActionTemplatesRequest"/>
+            <output message="tns:retrieveQuickActionTemplatesResponse"/>
+        </operation>
+
+        <operation name="describeVisualForce">
+            <documentation>Describe visualforce for an org</documentation>
+            <input  message="tns:describeVisualForceRequest"/>
+            <output message="tns:describeVisualForceResponse"/>
+        </operation>
+
+        <operation name="findDuplicates">
+            <documentation>Find duplicates for a set of sObjects</documentation>
+            <input  message="tns:findDuplicatesRequest"/>
+            <output message="tns:findDuplicatesResponse"/>
+            <fault  message="tns:InvalidSObjectFault" name="InvalidSObjectFault"/>
+            <fault  message="tns:UnexpectedErrorFault" name="UnexpectedErrorFault"/>
+            <fault  message="tns:InvalidFieldFault" name="InvalidFieldFault"/>
+        </operation>
+
+        <operation name="describeNouns">
+            <documentation>Return the renameable nouns from the server for use in presentation using the salesforce grammar engine</documentation>
+            <input  message="tns:describeNounsRequest"/>
+            <output message="tns:describeNounsResponse"/>
         </operation>
 
     </portType>
@@ -7787,6 +12963,22 @@ All Rights Reserved
             <fault name="InvalidSObjectFault">
                 <soap:fault name="InvalidSObjectFault" use="literal"/>
             </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeKnowledgeSettings">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
             <fault name="UnexpectedErrorFault">
                 <soap:fault name="UnexpectedErrorFault" use="literal"/>
             </fault>
@@ -7908,6 +13100,18 @@ All Rights Reserved
                 <soap:fault name="UnexpectedErrorFault" use="literal"/>
             </fault>
         </operation>
+        <operation name="describeSearchableEntities">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
         <operation name="describeSearchScopeOrder">
             <soap:operation soapAction=""/>
             <input>
@@ -7932,6 +13136,78 @@ All Rights Reserved
                 <soap:body use="literal"/>
             </output>
         </operation>
+        <operation name="describePathAssistants">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeApprovalLayout">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeSoqlListViews">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="executeListView">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="MruHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeSObjectListViews">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
         <operation name="describeTabs">
             <soap:operation soapAction=""/>
             <input>
@@ -7947,6 +13223,33 @@ All Rights Reserved
                 <soap:fault name="UnexpectedErrorFault" use="literal"/>
             </fault>
         </operation>
+        <operation name="describeAllTabs">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describePrimaryCompactLayouts">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
         <operation name="create">
             <soap:operation soapAction=""/>
             <input>
@@ -7957,6 +13260,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
                 <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
@@ -7990,6 +13295,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
                 <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
@@ -8024,6 +13331,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
                 <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
@@ -8057,6 +13366,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
@@ -8091,6 +13402,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
                 <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:body parts="parameters" use="literal"/>
             </input>
@@ -8111,6 +13424,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
                 <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:body parts="parameters" use="literal"/>
@@ -8174,6 +13489,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:body parts="parameters" use="literal"/>
@@ -8197,6 +13514,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="AllowFieldTruncationHeader"/>
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:body parts="parameters" use="literal"/>
@@ -8476,6 +13795,20 @@ All Rights Reserved
                 <soap:fault name="UnexpectedErrorFault" use="literal"/>
             </fault>
         </operation>
+        <operation name="renderEmailTemplate">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+        </operation>
         <operation name="performQuickActions">
             <soap:operation soapAction=""/>
             <input>
@@ -8486,6 +13819,8 @@ All Rights Reserved
                 <soap:header use="literal" message="tns:Header" part="DisableFeedTrackingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="StreamingEnabledHeader"/>
                 <soap:header use="literal" message="tns:Header" part="AllOrNoneHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
                 <soap:header use="literal" message="tns:Header" part="DebuggingHeader"/>
                 <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
                 <soap:header use="literal" message="tns:Header" part="EmailHeader"/>
@@ -8523,6 +13858,66 @@ All Rights Reserved
                 <soap:body use="literal"/>
             </output>
         </operation>
+        <operation name="retrieveQuickActionTemplates">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="describeVisualForce">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="findDuplicates">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="DuplicateRuleHeader"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+            <fault name="InvalidSObjectFault">
+                <soap:fault name="InvalidSObjectFault" use="literal"/>
+            </fault>
+            <fault name="UnexpectedErrorFault">
+                <soap:fault name="UnexpectedErrorFault" use="literal"/>
+            </fault>
+            <fault name="InvalidFieldFault">
+                <soap:fault name="InvalidFieldFault" use="literal"/>
+            </fault>
+        </operation>
+        <operation name="describeNouns">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:header use="literal" message="tns:Header" part="SessionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="PackageVersionHeader"/>
+                <soap:header use="literal" message="tns:Header" part="LocaleOptions"/>
+                <soap:body parts="parameters" use="literal"/>
+            </input>
+            <output>
+                <soap:header use="literal" message="tns:Header" part="LimitInfoHeader"/>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
 
     </binding>
 
@@ -8530,7 +13925,7 @@ All Rights Reserved
     <service name="SforceService">
         <documentation>Sforce SOAP API</documentation>
         <port binding="tns:SoapBinding" name="Soap">
-            <soap:address location="https://login.salesforce.com/services/Soap/c/29.0"/>
+            <soap:address location="https://login.salesforce.com/services/Soap/c/38.0"/>
         </port>
     </service>
 </definitions>

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -461,6 +461,7 @@ class SoapTest inherits QUnit::Test {
         h = op.serializeRequest(UrlReplVal1, NOTHING);
         assertEq("get?country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
+        assertFalse(exists h.hdr."Content-Type");
         assertThrows("SOAP-DESERIALIZATION-ERROR", \parseMessage(), (h, op, True));
 
         op = ws.getOperation("pt2", "urlEncoded2");

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -356,7 +356,7 @@ class SoapTest inherits QUnit::Test {
             "issue985": (
                 "i985_e1": "test", "i985_e2": "test",
             ),
-            );
+        );
 
         assertEq(req_r, h, "attr-deser-our");
 
@@ -536,7 +536,7 @@ class SoapTest inherits QUnit::Test {
 
         h = op.serializeResponse(h);
         assertTrue(h.hdr."Content-Type".regex("^text/xml"), "Content type");
-        assertTrue(h.body.regex("^\\<\\?xml version"), "serialize mimexml");
+        assertTrue(h.body.regex("^\\<\\?xml version.*string.*xxx"), "serialize mimexml");
 
 
     }

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -272,7 +272,11 @@ class SoapTest inherits QUnit::Test {
                 ),
             ),
         );
-
+        const UrlReplVal1 = (
+            "country": "CZ",
+            "city": "Prague 2",
+            "zip": "12000",
+        );
     }
 
     constructor() : QUnit::Test("SoapTest", "1.0") {
@@ -419,6 +423,33 @@ class SoapTest inherits QUnit::Test {
         h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
+
+        op = ws.getOperation("pt2", "urlRepl");
+        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        assertEq("get/CZ/12000-Prague%202", h.path);
+        assertEq("GET", h.method);
+
+        op = ws.getOperation("pt2", "urlEncoded1");
+        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        assertEq("get?country=CZ&city=Prague%202&zip=12000", h.path);
+        assertEq("GET", h.method);
+
+        op = ws.getOperation("pt2", "urlEncoded2");
+        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        assertEq("get?test&country=CZ&city=Prague%202&zip=12000", h.path);
+        assertEq("GET", h.method);
+
+        op = ws.getOperation("pt2", "postForm");
+        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        assertEq("country=CZ&city=Prague%202&zip=12000", h.body);
+        assertEq("POST", h.method);
+
+        op = ws.getOperation("pt2", "postText");
+        h = op.serializeRequest(("info": "important info &"), NOTHING);
+        assertEq("important info &", h.body);
+        assertTrue(regexpMatches(h.hdr."Content-Type", "^text\/"));
+        assertEq("POST", h.method);
+
     }
 
     test1() {

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -423,7 +423,7 @@ class SoapTest inherits QUnit::Test {
         assertEq(NOTHING, eh);
 
         op = ws.getOperation("noInput");
-        h = op.serializeRequest(NOTHING, NOTHING, ForcedHeaderValues);
+        h = op.serializeRequest(NOTHING, ForcedHeaderValues);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-input-no-binding", ForcedHeaderReq, xh);
 
@@ -435,7 +435,7 @@ class SoapTest inherits QUnit::Test {
         assertEq(NOTHING, eh);
 
         op = ws.getOperation("headerVal");
-        h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
+        h = op.serializeRequest(NOTHING, HeaderVal1);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 
@@ -445,7 +445,7 @@ class SoapTest inherits QUnit::Test {
         assertEq(headerDeser, h2."^header^");
 
         op = ws.getOperation("headerVal-doc");
-        h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
+        h = op.serializeRequest(NOTHING, HeaderVal1);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 
@@ -453,24 +453,24 @@ class SoapTest inherits QUnit::Test {
         assertEq(headerDeser, h2."^header^");
 
         op = ws.getOperation("pt2", "urlRepl");
-        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        h = op.serializeRequest(UrlReplVal1);
         assertEq("get/CZ/12000-Prague%202", h.path);
         assertEq("GET", h.method);
 
         op = ws.getOperation("pt2", "urlEncoded1");
-        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        h = op.serializeRequest(UrlReplVal1);
         assertEq("get?country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
         assertFalse(exists h.hdr."Content-Type");
         assertThrows("SOAP-DESERIALIZATION-ERROR", \parseMessage(), (h, op, True));
 
         op = ws.getOperation("pt2", "urlEncoded2");
-        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        h = op.serializeRequest(UrlReplVal1);
         assertEq("get?test&country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
 
         op = ws.getOperation("pt2", "postForm");
-        h = op.serializeRequest(UrlReplVal1, NOTHING);
+        h = op.serializeRequest(UrlReplVal1);
         assertEq("country=CZ&city=Prague%202&zip=12000", h.body);
         assertEq("POST", h.method);
 
@@ -478,7 +478,7 @@ class SoapTest inherits QUnit::Test {
         assertEq(UrlReplVal1, h2, h.path);
 
         op = ws.getOperation("pt2", "postText");
-        h = op.serializeRequest(("info": "important info &"), NOTHING);
+        h = op.serializeRequest(("info": "important info &"));
         assertEq("important info &", h.body);
         assertTrue(h.hdr."Content-Type".regex("^text/"), "Content type");
         assertEq("POST", h.method);
@@ -488,7 +488,7 @@ class SoapTest inherits QUnit::Test {
         assertEq("text/plain", h2.info."^attributes^"."^content-type^");
 
         op = ws.getOperation("pt2", "postImg");
-        h = op.serializeRequest(("img": <ABCDEF>), NOTHING);
+        h = op.serializeRequest(("img": <ABCDEF>));
         assertEq(h.hdr."Content-Type", "image/png");
         assertEq(<ABCDEF>, h.body);
         assertEq("POST", h.method);
@@ -504,12 +504,12 @@ class SoapTest inherits QUnit::Test {
         assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("img": <ABCDEF>), "post img no content type");
 
         op = ws.getOperation("pt2", "postImg2");
-        h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))), NOTHING);
+        h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))));
         assertEq("image/jpeg", h.hdr."Content-Type");
         assertEq(<ABCDEF>, h.body);
 
         op = ws.getOperation("pt2", "postImg3");
-        h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))), NOTHING);
+        h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))));
         assertEq("image/jpeg", h.hdr."Content-Type");
         assertEq(<ABCDEF>, h.body);
 
@@ -524,7 +524,7 @@ class SoapTest inherits QUnit::Test {
         assertThrows("SOAP-MESSAGE-ERROR", \op.serializeRequest(), ("img": ("^value^": "xxx", "^attributes^": ("^content-type^": "text/plain"))), "post img wrong content type");
 
         op = ws.getOperation("pt2", "postData");
-        h = op.serializeRequest(("payload": ("^value^": "012", "^attributes^": ("^content-type^": "application/x-data"))), NOTHING);
+        h = op.serializeRequest(("payload": ("^value^": "012", "^attributes^": ("^content-type^": "application/x-data"))));
         assertTrue(h.hdr."Content-Type".regex("^application/x-data"), "Content type");
         assertEq(<303132>, h.body);
 

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -466,6 +466,37 @@ class SoapTest inherits QUnit::Test {
         assertEq(<ABCDEF>, h.body);
         assertEq("POST", h.method);
 
+        op = ws.getOperation("pt2", "postImg");
+        assertThrows("SOAP-MESSAGE-ERROR", \op.serializeRequest(), ("img": ("^value^": "xxx", "^attributes^": ("^content-type^": "text/plain"))), "post img wrong content type");
+
+        op = ws.getOperation("pt2", "postImg2");
+        assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("img": <ABCDEF>), "post img no content type");
+
+        op = ws.getOperation("pt2", "postImg2");
+        h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))), NOTHING);
+        assertEq(h.hdr."Content-Type", "image/jpeg");
+        assertEq(<ABCDEF>, h.body);
+
+        op = ws.getOperation("pt2", "postImg3");
+        h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))), NOTHING);
+        assertEq(h.hdr."Content-Type", "image/jpeg");
+        assertEq(<ABCDEF>, h.body);
+
+        op = ws.getOperation("pt2", "postImg3");
+        assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("img": <ABCDEF>), "post img no content type");
+
+        op = ws.getOperation("pt2", "postImg3");
+        assertThrows("SOAP-MESSAGE-ERROR", \op.serializeRequest(), ("img": ("^value^": "xxx", "^attributes^": ("^content-type^": "text/plain"))), "post img wrong content type");
+
+        op = ws.getOperation("pt2", "postData");
+        h = op.serializeRequest(("payload": ("^value^": "012", "^attributes^": ("^content-type^": "application/x-data"))), NOTHING);
+        assertTrue(h.hdr."Content-Type".regex("^application/x-data"), "Content type");
+        assertEq(<303132>, h.body);
+
+        op = ws.getOperation("pt2", "postData");
+        assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("payload": "xxx"), "post img no content type");
+
+
     }
 
     test1() {

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -266,7 +266,12 @@ class SoapTest inherits QUnit::Test {
             "soap:Envelope": SoapEnvAttr + (
                 "soap:Header": (
                     "st:GetInfo": ("st:tickerSymbol": "EET1"),
-                    "st:docs": HeaderVal1.docs,
+                    "st:docs": (
+                        "^attributes^": (
+                            "xsi:type" : "xsd:string",
+                        ),
+                        "^value^": HeaderVal1.docs,
+                    ),
                     "st:SetInfo": ("st:name": "NAME-M3", "st:id": "457", "^attributes^": ("infoType": "ATW", "code": "58" )),
                     "unknown": "??",
                 ),
@@ -421,6 +426,13 @@ class SoapTest inherits QUnit::Test {
 
         op = ws.getOperation("headerVal");
         h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
+printf("HEADERVAL:%N\n", h.body);
+        xh = parse_xml(h.body);
+        compareSoapMsgs("header-val", HeaderValReq1, xh);
+
+        op = ws.getOperation("headerVal-doc");
+        h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
+printf("HEADERVAL_DOC:%N\n", h.body);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -280,7 +280,7 @@ class SoapTest inherits QUnit::Test {
         const UrlReplVal1 = (
             "country": "CZ",
             "city": "Prague 2",
-            "zip": "12000",
+            "zip": 12000,
         );
     }
 
@@ -289,6 +289,16 @@ class SoapTest inherits QUnit::Test {
         addTestCase("Test1", \test1());
         addTestCase("globalweather", \globalWeather());
         set_return_value(main());
+    }
+
+    *hash parseMessage(hash msg, WSOperation op, bool request) {
+        msg."content-type" = msg.hdr."Content-Type";
+        *hash pdata = WSDLLib::parseSOAPMessage(msg);
+        if (request) {
+            return op.deserializeRequest(pdata);
+        } else {
+            return op.deserializeResponse(pdata);
+        }
     }
 
     soapTestCase() {
@@ -429,10 +439,18 @@ class SoapTest inherits QUnit::Test {
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 
+        *hash h2 = op.deserializeRequest(xh);
+
+        hash headerDeser = ("m1": ("body": ("tickerSymbol" : "EET1")), "m2": ("docs": "DOCS-M2"), "m3": ("body": ("name": "NAME-M3", "id": 457, "^attributes^": ("infoType": "ATW", "code": 58))));
+        assertEq(headerDeser, h2."^header^");
+
         op = ws.getOperation("headerVal-doc");
         h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
+
+        h2 = op.deserializeRequest(xh);
+        assertEq(headerDeser, h2."^header^");
 
         op = ws.getOperation("pt2", "urlRepl");
         h = op.serializeRequest(UrlReplVal1, NOTHING);
@@ -443,6 +461,7 @@ class SoapTest inherits QUnit::Test {
         h = op.serializeRequest(UrlReplVal1, NOTHING);
         assertEq("get?country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
+        assertThrows("SOAP-DESERIALIZATION-ERROR", \parseMessage(), (h, op, True));
 
         op = ws.getOperation("pt2", "urlEncoded2");
         h = op.serializeRequest(UrlReplVal1, NOTHING);
@@ -454,17 +473,28 @@ class SoapTest inherits QUnit::Test {
         assertEq("country=CZ&city=Prague%202&zip=12000", h.body);
         assertEq("POST", h.method);
 
+        h2 = parseMessage(h, op, True);
+        assertEq(UrlReplVal1, h2, h.path);
+
         op = ws.getOperation("pt2", "postText");
         h = op.serializeRequest(("info": "important info &"), NOTHING);
         assertEq("important info &", h.body);
         assertTrue(h.hdr."Content-Type".regex("^text/"), "Content type");
         assertEq("POST", h.method);
 
+        h2 = parseMessage(h, op, True);
+        assertEq("important info &", get_xml_value(h2.info));
+        assertEq("text/plain", h2.info."^attributes^"."^content-type^");
+
         op = ws.getOperation("pt2", "postImg");
         h = op.serializeRequest(("img": <ABCDEF>), NOTHING);
         assertEq(h.hdr."Content-Type", "image/png");
         assertEq(<ABCDEF>, h.body);
         assertEq("POST", h.method);
+
+        h2 = parseMessage(h, op, True);
+        assertEq(<ABCDEF>, get_xml_value(h2.img));
+        assertEq(h2.img."^attributes^"."^content-type^", "image/png");
 
         op = ws.getOperation("pt2", "postImg");
         assertThrows("SOAP-MESSAGE-ERROR", \op.serializeRequest(), ("img": ("^value^": "xxx", "^attributes^": ("^content-type^": "text/plain"))), "post img wrong content type");
@@ -474,13 +504,17 @@ class SoapTest inherits QUnit::Test {
 
         op = ws.getOperation("pt2", "postImg2");
         h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))), NOTHING);
-        assertEq(h.hdr."Content-Type", "image/jpeg");
+        assertEq("image/jpeg", h.hdr."Content-Type");
         assertEq(<ABCDEF>, h.body);
 
         op = ws.getOperation("pt2", "postImg3");
         h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))), NOTHING);
-        assertEq(h.hdr."Content-Type", "image/jpeg");
+        assertEq("image/jpeg", h.hdr."Content-Type");
         assertEq(<ABCDEF>, h.body);
+
+        h2 = parseMessage(h, op, True);
+        assertEq(<ABCDEF>, get_xml_value(h2.img));
+        assertEq("image/jpeg", h2.img."^attributes^"."^content-type^");
 
         op = ws.getOperation("pt2", "postImg3");
         assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("img": <ABCDEF>), "post img no content type");

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -249,15 +249,8 @@ class SoapTest inherits QUnit::Test {
             ),
         );
 
-        const ForcedHeaderValues = ("h1": "1", "h2": "a");
-        const ForcedHeaderReq = (
-            "soap:Envelope": SoapEnvAttr + (
-                "soap:Header": ForcedHeaderValues
-            ),
-        );
-
         const HeaderVal1 = (
-            "body": ("tickerSymbol": "EET1"),
+            "tickerSymbol": "EET1",
             "docs": "DOCS-M2",
             "m3": ("SetInfo": ("name": "NAME-M3", "id": 457, "^attributes^": ("infoType": "ATW", "code": 58 ) )),
         );
@@ -272,6 +265,27 @@ class SoapTest inherits QUnit::Test {
                         "^value^": HeaderVal1.docs,
                     ),
                     "st:SetInfo": ("st:name": "NAME-M3", "st:id": "457", "^attributes^": ("infoType": "ATW", "code": "58" )),
+                ),
+            ),
+        );
+        const HeaderValBody = (
+            "tickerSymbol": "EET1",
+            "docs": "DOCS-M2",
+        );
+        const HeaderValBodyReq = (
+            "soap:Envelope": SoapEnvAttr + (
+                "soap:Header": (
+                    "st:docs": (
+                        "^attributes^": (
+                            "xsi:type" : "xsd:string",
+                        ),
+                        "^value^": HeaderValBody.docs,
+                    ),
+                ),
+                "soap:Body": (
+                    "st:headerValBody": (
+                        "st:GetInfo": ("st:tickerSymbol": "EET1"),
+                    )
                 ),
             ),
         );
@@ -419,13 +433,6 @@ class SoapTest inherits QUnit::Test {
         eh = op.deserializeRequest(h);
         assertEq(NOTHING, eh);
 
-/*        op = ws.getOperation("noInput");
-        h = op.serializeRequest(NOTHING, ForcedHeaderValues);
-        xh = parse_xml(h.body);
-        compareSoapMsgs("header-input-no-binding", ForcedHeaderReq, xh);  */
-
-#TODO: header vals via normal vals, remaining header exception, ^header^ deserialize change
-
         op = ws.getOperation("noOutput");
         h = op.serializeResponse();
         xh = parse_xml(h.body);
@@ -441,15 +448,32 @@ class SoapTest inherits QUnit::Test {
         *hash h2 = op.deserializeRequest(xh);
 
         hash headerDeser = ("m1": ("body": ("tickerSymbol" : "EET1")), "m2": ("docs": "DOCS-M2"), "m3": ("body": ("name": "NAME-M3", "id": 457, "^attributes^": ("infoType": "ATW", "code": 58))));
-        assertEq(headerDeser, h2."^header^");
+        assertEq(headerDeser, h2);
 
         op = ws.getOperation("headerVal-doc");
         h = op.serializeRequest(NOTHING, HeaderVal1);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 
+        op = ws.getOperation("headerVal-doc");
+        h = op.serializeRequest(HeaderVal1);
+        xh = parse_xml(h.body);
+        compareSoapMsgs("header-val", HeaderValReq1, xh);
+
+        assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), (HeaderVal1, ("unknown": "dummy") ) );
+        assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), (HeaderVal1 + ("unknown": "dummy") ) );
+
         h2 = op.deserializeRequest(xh);
-        assertEq(headerDeser, h2."^header^");
+        assertEq(headerDeser, h2);
+
+        op = ws.getOperation("headerValBody");
+        h = op.serializeRequest(HeaderValBody);
+        xh = parse_xml(h.body);
+        compareSoapMsgs("header-valBody", HeaderValBodyReq, xh);
+
+        h2 = op.deserializeRequest(xh);
+        headerDeser = ("body": ("tickerSymbol": "EET1"), "m2": ("docs": "DOCS-M2"));
+        assertEq(headerDeser, h2);
 
         op = ws.getPortTypeOperation("pt2", "urlRepl");
         h = op.serializeRequest(UrlReplVal1);

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -426,13 +426,11 @@ class SoapTest inherits QUnit::Test {
 
         op = ws.getOperation("headerVal");
         h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
-printf("HEADERVAL:%N\n", h.body);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 
         op = ws.getOperation("headerVal-doc");
         h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
-printf("HEADERVAL_DOC:%N\n", h.body);
         xh = parse_xml(h.body);
         compareSoapMsgs("header-val", HeaderValReq1, xh);
 
@@ -459,7 +457,13 @@ printf("HEADERVAL_DOC:%N\n", h.body);
         op = ws.getOperation("pt2", "postText");
         h = op.serializeRequest(("info": "important info &"), NOTHING);
         assertEq("important info &", h.body);
-        assertTrue(regexpMatches(h.hdr."Content-Type", "^text\/"));
+        assertTrue(h.hdr."Content-Type".regex("^text/"), "Content type");
+        assertEq("POST", h.method);
+
+        op = ws.getOperation("pt2", "postImg");
+        h = op.serializeRequest(("img": <ABCDEF>), NOTHING);
+        assertEq(h.hdr."Content-Type", "image/png");
+        assertEq(<ABCDEF>, h.body);
         assertEq("POST", h.method);
 
     }

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -491,6 +491,8 @@ class SoapTest inherits QUnit::Test {
         h = op.serializeRequest(UrlReplVal1);
         assertEq("get?test&country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
+        h = op.deserializePath(h.path, "b2");
+        assertEq(UrlReplVal1, h);
 
         op = ws.getBindingOperation("b2", "postForm");
         h = op.serializeRequest(UrlReplVal1);

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -472,7 +472,7 @@ class SoapTest inherits QUnit::Test {
         compareSoapMsgs("header-valBody", HeaderValBodyReq, xh);
 
         h2 = op.deserializeRequest(xh);
-        headerDeser = ("body": ("tickerSymbol": "EET1"), "m2": ("docs": "DOCS-M2"));
+        headerDeser = ("tickerSymbol": "EET1", "m2": ("docs": "DOCS-M2"));
         assertEq(headerDeser, h2);
 
         op = ws.getPortTypeOperation("pt2", "urlRepl");

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -260,7 +260,6 @@ class SoapTest inherits QUnit::Test {
             "body": ("tickerSymbol": "EET1"),
             "docs": "DOCS-M2",
             "m3": ("SetInfo": ("name": "NAME-M3", "id": 457, "^attributes^": ("infoType": "ATW", "code": 58 ) )),
-            "unknown": "??",
         );
         const HeaderValReq1 = (
             "soap:Envelope": SoapEnvAttr + (
@@ -273,7 +272,6 @@ class SoapTest inherits QUnit::Test {
                         "^value^": HeaderVal1.docs,
                     ),
                     "st:SetInfo": ("st:name": "NAME-M3", "st:id": "457", "^attributes^": ("infoType": "ATW", "code": "58" )),
-                    "unknown": "??",
                 ),
             ),
         );
@@ -421,10 +419,12 @@ class SoapTest inherits QUnit::Test {
         eh = op.deserializeRequest(h);
         assertEq(NOTHING, eh);
 
-        op = ws.getOperation("noInput");
+/*        op = ws.getOperation("noInput");
         h = op.serializeRequest(NOTHING, ForcedHeaderValues);
         xh = parse_xml(h.body);
-        compareSoapMsgs("header-input-no-binding", ForcedHeaderReq, xh);
+        compareSoapMsgs("header-input-no-binding", ForcedHeaderReq, xh);  */
+
+#TODO: header vals via normal vals, remaining header exception, ^header^ deserialize change
 
         op = ws.getOperation("noOutput");
         h = op.serializeResponse();

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -287,7 +287,6 @@ class SoapTest inherits QUnit::Test {
     constructor() : QUnit::Test("SoapTest", "1.0") {
         addTestCase("SoapTestCase", \soapTestCase());
         addTestCase("Test1", \test1());
-        addTestCase("globalweather", \globalWeather());
         set_return_value(main());
     }
 
@@ -452,24 +451,24 @@ class SoapTest inherits QUnit::Test {
         h2 = op.deserializeRequest(xh);
         assertEq(headerDeser, h2."^header^");
 
-        op = ws.getOperation("pt2", "urlRepl");
+        op = ws.getPortTypeOperation("pt2", "urlRepl");
         h = op.serializeRequest(UrlReplVal1);
         assertEq("get/CZ/12000-Prague%202", h.path);
         assertEq("GET", h.method);
 
-        op = ws.getOperation("pt2", "urlEncoded1");
+        op = ws.getPortTypeOperation("pt2", "urlEncoded1");
         h = op.serializeRequest(UrlReplVal1);
         assertEq("get?country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
         assertFalse(exists h.hdr."Content-Type");
         assertThrows("SOAP-DESERIALIZATION-ERROR", \parseMessage(), (h, op, True));
 
-        op = ws.getOperation("pt2", "urlEncoded2");
+        op = ws.getBindingOperation("b2", "urlEncoded2");
         h = op.serializeRequest(UrlReplVal1);
         assertEq("get?test&country=CZ&city=Prague%202&zip=12000", h.path);
         assertEq("GET", h.method);
 
-        op = ws.getOperation("pt2", "postForm");
+        op = ws.getBindingOperation("b2", "postForm");
         h = op.serializeRequest(UrlReplVal1);
         assertEq("country=CZ&city=Prague%202&zip=12000", h.body);
         assertEq("POST", h.method);
@@ -477,7 +476,7 @@ class SoapTest inherits QUnit::Test {
         h2 = parseMessage(h, op, True);
         assertEq(UrlReplVal1, h2, h.path);
 
-        op = ws.getOperation("pt2", "postText");
+        op = ws.getPortTypeOperation("pt2", "postText");
         h = op.serializeRequest(("info": "important info &"));
         assertEq("important info &", h.body);
         assertTrue(h.hdr."Content-Type".regex("^text/"), "Content type");
@@ -487,7 +486,7 @@ class SoapTest inherits QUnit::Test {
         assertEq("important info &", get_xml_value(h2.info));
         assertEq("text/plain", h2.info."^attributes^"."^content-type^");
 
-        op = ws.getOperation("pt2", "postImg");
+        op = ws.getPortTypeOperation("pt2", "postImg");
         h = op.serializeRequest(("img": <ABCDEF>));
         assertEq(h.hdr."Content-Type", "image/png");
         assertEq(<ABCDEF>, h.body);
@@ -497,18 +496,18 @@ class SoapTest inherits QUnit::Test {
         assertEq(<ABCDEF>, get_xml_value(h2.img));
         assertEq(h2.img."^attributes^"."^content-type^", "image/png");
 
-        op = ws.getOperation("pt2", "postImg");
+        op = ws.getPortTypeOperation("pt2", "postImg");
         assertThrows("SOAP-MESSAGE-ERROR", \op.serializeRequest(), ("img": ("^value^": "xxx", "^attributes^": ("^content-type^": "text/plain"))), "post img wrong content type");
 
-        op = ws.getOperation("pt2", "postImg2");
+        op = ws.getPortTypeOperation("pt2", "postImg2");
         assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("img": <ABCDEF>), "post img no content type");
 
-        op = ws.getOperation("pt2", "postImg2");
+        op = ws.getPortTypeOperation("pt2", "postImg2");
         h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))));
         assertEq("image/jpeg", h.hdr."Content-Type");
         assertEq(<ABCDEF>, h.body);
 
-        op = ws.getOperation("pt2", "postImg3");
+        op = ws.getPortTypeOperation("pt2", "postImg3");
         h = op.serializeRequest(("img": ("^value^": <ABCDEF>, "^attributes^": ("^content-type^": "image/jpeg"))));
         assertEq("image/jpeg", h.hdr."Content-Type");
         assertEq(<ABCDEF>, h.body);
@@ -517,19 +516,27 @@ class SoapTest inherits QUnit::Test {
         assertEq(<ABCDEF>, get_xml_value(h2.img));
         assertEq("image/jpeg", h2.img."^attributes^"."^content-type^");
 
-        op = ws.getOperation("pt2", "postImg3");
+        op = ws.getPortTypeOperation("pt2", "postImg3");
         assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("img": <ABCDEF>), "post img no content type");
 
-        op = ws.getOperation("pt2", "postImg3");
+        op = ws.getPortTypeOperation("pt2", "postImg3");
         assertThrows("SOAP-MESSAGE-ERROR", \op.serializeRequest(), ("img": ("^value^": "xxx", "^attributes^": ("^content-type^": "text/plain"))), "post img wrong content type");
 
-        op = ws.getOperation("pt2", "postData");
+        op = ws.getPortTypeOperation("pt2", "postData");
         h = op.serializeRequest(("payload": ("^value^": "012", "^attributes^": ("^content-type^": "application/x-data"))));
         assertTrue(h.hdr."Content-Type".regex("^application/x-data"), "Content type");
         assertEq(<303132>, h.body);
 
-        op = ws.getOperation("pt2", "postData");
+        op = ws.getPortTypeOperation("pt2", "postData");
         assertThrows("SOAP-SERIALIZATION-ERROR", \op.serializeRequest(), ("payload": "xxx"), "post img no content type");
+
+        op = ws.getPortTypeOperation("pt2", "getMimeXml");
+        h = op.deserializeResponse(("string": "xxx"));
+        assertEq("xxx", h.STR, "deserialize mimeXml");
+
+        h = op.serializeResponse(h);
+        assertTrue(h.hdr."Content-Type".regex("^text/xml"), "Content type");
+        assertTrue(h.body.regex("^\\<\\?xml version"), "serialize mimexml");
 
 
     }
@@ -555,10 +562,6 @@ class SoapTest inherits QUnit::Test {
         compareSoapMsgs("output", Test1Res, xh);
         *hash eh = op.deserializeResponse(xh);
         assertEq(Res1_1, eh, "deserialize response");
-    }
-
-    globalWeather() {
-        assertThrows("WSDL-ERROR", sub () { WebService ws(ReadOnlyFile::readTextFile(get_script_dir() + "/globalweather.wsdl")); }, NOTHING, "http binding");
     }
 
     compareSoapMsgs(string assert, hash h1, hash h2) {

--- a/test/soap.qtest
+++ b/test/soap.qtest
@@ -55,7 +55,7 @@ class SoapTest inherits QUnit::Test {
                 "xmlns:st": "http://qore.org/simpletest",
                 "xmlns:st1": "http://qore.org/simpletest1",
             ),
-            );
+        );
 
         # all values are strings here because we do raw XML parsing and not SOAP deserialization for the comparison
         # to avoid comparing values generated and parsed with the same code which would result in an identity test
@@ -194,7 +194,7 @@ class SoapTest inherits QUnit::Test {
                 "xmlns:soap": SOAP_11_ENV,
                 "xmlns:tes": "http://example.com/test1/test1_ws",
             ),
-            );
+        );
 
         # all values are strings here because we do raw XML parsing and not SOAP deserialization for the comparison
         # to avoid comparing values generated and parsed with the same code which would result in an identity test
@@ -207,7 +207,7 @@ class SoapTest inherits QUnit::Test {
                     ),
                 ),
             ),
-            );
+        );
 
         const SoapEnvAttr1Res = (
             "^attributes^": (
@@ -215,7 +215,7 @@ class SoapTest inherits QUnit::Test {
                 "xmlns:tes": "http://example.com/test1/test1_ws",
                 "xmlns:oth": "http://example.com/test1/other",
             ),
-            );
+        );
 
         const Test1Res = (
             "soap:Envelope": SoapEnvAttr1Res + (
@@ -247,7 +247,32 @@ class SoapTest inherits QUnit::Test {
                 "res1": "a",
                 "res2": "b",
             ),
-            );
+        );
+
+        const ForcedHeaderValues = ("h1": "1", "h2": "a");
+        const ForcedHeaderReq = (
+            "soap:Envelope": SoapEnvAttr + (
+                "soap:Header": ForcedHeaderValues
+            ),
+        );
+
+        const HeaderVal1 = (
+            "body": ("tickerSymbol": "EET1"),
+            "docs": "DOCS-M2",
+            "m3": ("SetInfo": ("name": "NAME-M3", "id": 457, "^attributes^": ("infoType": "ATW", "code": 58 ) )),
+            "unknown": "??",
+        );
+        const HeaderValReq1 = (
+            "soap:Envelope": SoapEnvAttr + (
+                "soap:Header": (
+                    "st:GetInfo": ("st:tickerSymbol": "EET1"),
+                    "st:docs": HeaderVal1.docs,
+                    "st:SetInfo": ("st:name": "NAME-M3", "st:id": "457", "^attributes^": ("infoType": "ATW", "code": "58" )),
+                    "unknown": "??",
+                ),
+            ),
+        );
+
     }
 
     constructor() : QUnit::Test("SoapTest", "1.0") {
@@ -378,12 +403,22 @@ class SoapTest inherits QUnit::Test {
         eh = op.deserializeRequest(h);
         assertEq(NOTHING, eh);
 
+        op = ws.getOperation("noInput");
+        h = op.serializeRequest(NOTHING, NOTHING, ForcedHeaderValues);
+        xh = parse_xml(h.body);
+        compareSoapMsgs("header-input-no-binding", ForcedHeaderReq, xh);
+
         op = ws.getOperation("noOutput");
         h = op.serializeResponse();
         xh = parse_xml(h.body);
         compareSoapMsgs("no-output", EmptyRes, xh);
         eh = op.deserializeResponse(h);
         assertEq(NOTHING, eh);
+
+        op = ws.getOperation("headerVal");
+        h = op.serializeRequest(NOTHING, NOTHING, HeaderVal1);
+        xh = parse_xml(h.body);
+        compareSoapMsgs("header-val", HeaderValReq1, xh);
     }
 
     test1() {
@@ -420,6 +455,11 @@ class SoapTest inherits QUnit::Test {
 
         # compare soap version in envelope
         assertEq(nh1.getSoapUri(), nh2.getSoapUri());
+
+        *hash hdr1 = SoapTest::getValue(h1, nh1.se, "Envelope", "Header");
+        *hash hdr2 = SoapTest::getValue(h2, nh2.se, "Envelope", "Header");
+        #printf("COMPARE\n%N\n%N\n%N\n%N\n\n", h1, h2, hdr1, hdr2);
+        compareSoapValue(assert, "Envelope.Header", hdr1, hdr2, nh1, nh2);
 
         *hash b1 = SoapTest::getValue(h1, nh1.se, "Envelope", "Body");
         *hash b2 = SoapTest::getValue(h2, nh2.se, "Envelope", "Body");

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -239,6 +239,9 @@
     </wsdl:operation>
     <wsdl:operation name="headerVal" />
     <wsdl:operation name="headerVal-doc" />
+    <wsdl:operation name="headerValBody" >
+      <wsdl:input message="tns:m1" />
+    </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="b1" type="tns:pt1">
     <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc" />
@@ -286,6 +289,13 @@
         <soap12:header message="m1" part="body" use="literal" />
         <soap12:header message="m2" part="docs" use="encoded" />
         <soap12:header message="m3" part="body" use="literal" />
+      </wsdl:input>
+    </wsdl:operation>
+    <wsdl:operation name="headerValBody">
+      <soap12:operation soapAction="http://qore.org/headerValBody" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+        <soap12:header message="m2" part="docs" use="encoded" />
       </wsdl:input>
     </wsdl:operation>
   </wsdl:binding>

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -220,6 +220,10 @@
     <wsdl:part name="info" type="s:string"/>
   </wsdl:message>
 
+  <wsdl:message name="m7">
+    <wsdl:part name="img" type="s:base64Binary"/>
+  </wsdl:message>
+
   <wsdl:portType name="pt1">
     <wsdl:operation name="getInfo">
       <wsdl:input message="tns:m1"/>
@@ -307,6 +311,9 @@
     <wsdl:operation name="postText">
 	  <wsdl:input message="tns:m6"/>
 	</wsdl:operation>
+    <wsdl:operation name="postImg">
+	  <wsdl:input message="tns:m7"/>
+	</wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="b2" type="tns:pt2">
@@ -343,6 +350,12 @@
 	  <http:operation location="posttext"/>
 	  <input>
 	    <mime:content type="text/plain"/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="postImg">
+	  <http:operation location="postimg"/>
+	  <input>
+	    <mime:content type="image/png"/>
 	  </input>
 	</wsdl:operation>
   </wsdl:binding>

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -210,6 +210,16 @@
     <wsdl:part name="issue663" element="tns:issue663"/>
   </wsdl:message>
 
+  <wsdl:message name="m5">
+    <wsdl:part name="country" type="s:string"/>
+    <wsdl:part name="city" type="s:string"/>
+    <wsdl:part name="zip" type="s:integer"/>
+  </wsdl:message>
+
+  <wsdl:message name="m6">
+    <wsdl:part name="info" type="s:string"/>
+  </wsdl:message>
+
   <wsdl:portType name="pt1">
     <wsdl:operation name="getInfo">
       <wsdl:input message="tns:m1"/>
@@ -269,6 +279,62 @@
         <soap12:header message="m3" part="body" use="literal"/>
       </wsdl:input>
     </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:portType name="pt2">
+    <wsdl:operation name="urlRepl">
+	  <wsdl:input message="tns:m5"/>
+	</wsdl:operation>
+    <wsdl:operation name="urlEncoded1">
+	  <wsdl:input message="tns:m5"/>
+	</wsdl:operation>
+    <wsdl:operation name="urlEncoded2">
+	  <wsdl:input message="tns:m5"/>
+	</wsdl:operation>
+    <wsdl:operation name="postForm">
+	  <wsdl:input message="tns:m5"/>
+	</wsdl:operation>
+    <wsdl:operation name="postText">
+	  <wsdl:input message="tns:m6"/>
+	</wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="b2" type="tns:pt2">
+    <http:binding verb="GET"/>
+    <wsdl:operation name="urlRepl">
+	  <http:operation location="get/(country)/(zip)-(city)"/>
+	  <input>
+	    <http:urlReplacement/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="urlEncoded1">
+	  <http:operation location="get"/>
+	  <input>
+	    <http:urlEncoded/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="urlEncoded2">
+	  <http:operation location="get?test"/>
+	  <input>
+	    <http:urlEncoded/>
+	  </input>
+	</wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:binding name="b3" type="tns:pt2">
+    <http:binding verb="POST"/>
+    <wsdl:operation name="postForm">
+	  <http:operation location="postform"/>
+	  <input>
+		<mime:content type="application/x-www-form-urlencoded"/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="postText">
+	  <http:operation location="posttext"/>
+	  <input>
+	    <mime:content type="text/plain"/>
+	  </input>
+	</wsdl:operation>
   </wsdl:binding>
 
   <wsdl:service name="InfoService">

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -237,6 +237,8 @@
     </wsdl:operation>
     <wsdl:operation name="headerVal">
     </wsdl:operation>
+    <wsdl:operation name="headerVal-doc">
+    </wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="b1" type="tns:pt1">
@@ -275,7 +277,15 @@
       <soap12:operation soapAction="http://qore.org/headerVal"/>
       <wsdl:input>
         <soap12:header message="m1" part="body" use="literal"/>
-        <soap12:header message="m2" part="docs" use="literal"/>
+        <soap12:header message="m2" part="docs" use="encoded"/>
+        <soap12:header message="m3" part="body" use="literal"/>
+      </wsdl:input>
+    </wsdl:operation>
+    <wsdl:operation name="headerVal-doc">
+      <soap12:operation soapAction="http://qore.org/headerVal" style="document"/>
+      <wsdl:input>
+        <soap12:header message="m1" part="body" use="literal"/>
+        <soap12:header message="m2" part="docs" use="encoded"/>
         <soap12:header message="m3" part="body" use="literal"/>
       </wsdl:input>
     </wsdl:operation>

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -389,7 +389,13 @@
     </wsdl:operation>
   </wsdl:binding>
   <wsdl:service name="InfoService">
-    <wsdl:port name="InfoPort" binding="tns:b1">
+    <wsdl:port name="SoapPort" binding="tns:b1">
+      <soap12:address location="http://localhost:8001/SOAP/simple" />
+    </wsdl:port>
+    <wsdl:port name="HttpGetPort" binding="tns:b2">
+      <soap12:address location="http://localhost:8001/SOAP/simple" />
+    </wsdl:port>
+    <wsdl:port name="HttpPostPort" binding="tns:b3">
       <soap12:address location="http://localhost:8001/SOAP/simple" />
     </wsdl:port>
   </wsdl:service>

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -225,6 +225,8 @@
     <wsdl:operation name="noOutput">
       <wsdl:input message="tns:m3"/>
     </wsdl:operation>
+    <wsdl:operation name="headerVal">
+    </wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="b1" type="tns:pt1">
@@ -257,6 +259,14 @@
       <soap12:operation soapAction="http://qore.org/noOutput"/>
       <wsdl:input>
 	<soap12:body use="literal"/>
+      </wsdl:input>
+    </wsdl:operation>
+    <wsdl:operation name="headerVal">
+      <soap12:operation soapAction="http://qore.org/headerVal"/>
+      <wsdl:input>
+        <soap12:header message="m1" part="body" use="literal"/>
+        <soap12:header message="m2" part="docs" use="literal"/>
+        <soap12:header message="m3" part="body" use="literal"/>
       </wsdl:input>
     </wsdl:operation>
   </wsdl:binding>

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -224,6 +224,10 @@
     <wsdl:part name="img" type="s:base64Binary"/>
   </wsdl:message>
 
+  <wsdl:message name="m8">
+    <wsdl:part name="payload" type="s:base64Binary"/>
+  </wsdl:message>
+
   <wsdl:portType name="pt1">
     <wsdl:operation name="getInfo">
       <wsdl:input message="tns:m1"/>
@@ -314,6 +318,15 @@
     <wsdl:operation name="postImg">
 	  <wsdl:input message="tns:m7"/>
 	</wsdl:operation>
+    <wsdl:operation name="postImg2">
+	  <wsdl:input message="tns:m7"/>
+	</wsdl:operation>
+    <wsdl:operation name="postImg3">
+	  <wsdl:input message="tns:m7"/>
+	</wsdl:operation>
+    <wsdl:operation name="postData">
+	  <wsdl:input message="tns:m8"/>
+	</wsdl:operation>
   </wsdl:portType>
 
   <wsdl:binding name="b2" type="tns:pt2">
@@ -356,6 +369,25 @@
 	  <http:operation location="postimg"/>
 	  <input>
 	    <mime:content type="image/png"/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="postImg2">
+	  <http:operation location="postimg2"/>
+	  <input>
+	    <mime:content type="image/jpeg"/>
+	    <mime:content type="image/png"/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="postImg3">
+	  <http:operation location="postimg3"/>
+	  <input>
+	    <mime:content type="image/*"/>
+	  </input>
+	</wsdl:operation>
+    <wsdl:operation name="postData">
+	  <http:operation location="postdata"/>
+	  <input>
+	    <mime:content type="*/*"/>
 	  </input>
 	</wsdl:operation>
   </wsdl:binding>

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -214,10 +214,10 @@
     <wsdl:part name="info" type="s:string" />
   </wsdl:message>
   <wsdl:message name="m7">
-    <wsdl:part name="img" type="s:base64Binary" />
+    <wsdl:part name="img" type="s:binary" />
   </wsdl:message>
   <wsdl:message name="m8">
-    <wsdl:part name="payload" type="s:base64Binary" />
+    <wsdl:part name="payload" type="s:binary" />
   </wsdl:message>
   <wsdl:message name="m9">
     <wsdl:part name="STR" element="tns:string" />
@@ -330,6 +330,9 @@
     <wsdl:operation name="getMimeXml">
       <wsdl:output message="tns:m9" />
     </wsdl:operation>
+    <wsdl:operation name="getBinary">
+      <wsdl:output message="tns:m8" />
+    </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="b2" type="tns:pt2">
     <http:binding verb="GET" />
@@ -356,6 +359,15 @@
       <wsdl:output>
         <mime:mimeXml part="STR" />
       </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getBinary">
+      <http:operation location="getbinary" />
+      <output>
+        <mime:content type="image/*" />
+        <mime:content type="application/*" />
+        <mime:content type="text/plain" />
+        <mime:content type="text/html" />
+      </output>
     </wsdl:operation>
   </wsdl:binding>
   <wsdl:binding name="b3" type="tns:pt2">

--- a/test/test.wsdl
+++ b/test/test.wsdl
@@ -1,401 +1,397 @@
-<?xml version="1.0" encoding="utf-8"?>
-<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://qore.org/simpletest" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:test="http://initial-value" targetNamespace="http://qore.org/simpletest" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:test="http://initial-value" xmlns:tns="http://qore.org/simpletest" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://qore.org/simpletest">
   <wsdl:types>
-    <s:schema xmlns:tns1="http://qore.org/simpletest1" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:test="http://other-value" elementFormDefault="qualified" targetNamespace="http://qore.org/simpletest" xmlns="http://www.w3.org/2001/XMLSchema">
-      <s:import namespace="http://qore.org/simpletest1"/>
+    <s:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:test="http://other-value" xmlns:tns1="http://qore.org/simpletest1" elementFormDefault="qualified" targetNamespace="http://qore.org/simpletest">
+      <s:import namespace="http://qore.org/simpletest1" />
       <s:element name="SetInfo">
-	<s:complexType>
-	  <s:all>
-	    <s:element name="name" type="string"/>
-	    <s:element name="id" type="s:int"/>
-	  </s:all>
-	  <s:attribute name="infoType" type="xsd:string" use="required"/>
-	  <s:attribute name="code" type="s:int" use="required"/>
-	</s:complexType>
+        <s:complexType>
+          <s:all>
+            <s:element name="name" type="string" />
+            <s:element name="id" type="s:int" />
+          </s:all>
+          <s:attribute name="infoType" type="xsd:string" use="required" />
+          <s:attribute name="code" type="s:int" use="required" />
+        </s:complexType>
       </s:element>
       <s:element name="Test">
-	<s:complexType>
-	  <s:simpleContent>
+        <s:complexType>
+          <s:simpleContent>
             <s:extension base="tns:testEnum">
-              <s:attribute name="info" type="s:string" use="required"/>
+              <s:attribute name="info" type="s:string" use="required" />
             </s:extension>
           </s:simpleContent>
-	</s:complexType>
+        </s:complexType>
       </s:element>
       <s:simpleType name="testEnum">
-	<restriction base="xsd:string">
-	  <enumeration value="test"/>
-	  <enumeration value="other"/>
+        <restriction base="xsd:string">
+          <enumeration value="test" />
+          <enumeration value="other" />
         </restriction>
       </s:simpleType>
       <s:complexType name="issue86">
-	<s:sequence>
-	  <s:element maxOccurs="1" minOccurs="1" ref="tns:issue86"/>
-	  <!-- add data element here in interface specific wsdl, can be any type -->
-	</s:sequence>
+        <s:sequence>
+          <s:element maxOccurs="1" minOccurs="1" ref="tns:issue86" />
+          <!-- add data element here in interface specific wsdl, can be any type -->
+        </s:sequence>
       </s:complexType>
-      <s:element name="issue86" type="tns:issue86_2"/>
+      <s:element name="issue86" type="tns:issue86_2" />
       <s:complexType name="issue86_2">
-	<s:complexContent>
-	  <s:extension base="tns1:issue86_1">
-	    <s:sequence>
-	      <s:element name="issue86_1_2" nillable="false" type="s:string"/>
-	    </s:sequence>
-	  </s:extension>
-	</s:complexContent>
+        <s:complexContent>
+          <s:extension base="tns1:issue86_1">
+            <s:sequence>
+              <s:element name="issue86_1_2" nillable="false" type="s:string" />
+            </s:sequence>
+          </s:extension>
+        </s:complexContent>
       </s:complexType>
       <s:element name="issue87">
-	<s:complexType>
-	  <s:sequence>
-	    <s:element name="issue87e1" type="s:string"/>
-	    <s:choice minOccurs="1">
-	      <s:element name="choice11" type="s:string"/>
-	      <s:element name="choice12" type="s:string"/>
-	    </s:choice>
-	    <s:choice minOccurs="0">
-	      <s:element name="choice21" type="s:int"/>
-	      <s:element name="choice22" type="s:int"/>
-	    </s:choice>
-	  </s:sequence>
-	</s:complexType>
+        <s:complexType>
+          <s:sequence>
+            <s:element name="issue87e1" type="s:string" />
+            <s:choice minOccurs="1">
+              <s:element name="choice11" type="s:string" />
+              <s:element name="choice12" type="s:string" />
+            </s:choice>
+            <s:choice minOccurs="0">
+              <s:element name="choice21" type="s:int" />
+              <s:element name="choice22" type="s:int" />
+            </s:choice>
+          </s:sequence>
+        </s:complexType>
       </s:element>
-      <s:element name="issue97" type="tns:issue97"/>
+      <s:element name="issue97" type="tns:issue97" />
       <s:complexType name="issue97">
         <s:sequence>
-          <s:element name="i97list" type="tns:i97list"/>
+          <s:element name="i97list" type="tns:i97list" />
         </s:sequence>
       </s:complexType>
       <s:complexType name="i97list">
         <s:sequence>
-          <s:element maxOccurs="unbounded" minOccurs="0" name="i97element" type="s:string"/>
+          <s:element maxOccurs="unbounded" minOccurs="0" name="i97element" type="s:string" />
         </s:sequence>
       </s:complexType>
-      <s:element name="SetInfoResult" type="s:string"/>
+      <s:element name="SetInfoResult" type="s:string" />
       <s:element name="GetInfo">
-	<s:complexType>
-	  <s:all>
-	    <s:element name="tickerSymbol" type="s:string"/>
-	  </s:all>
-	</s:complexType>
+        <s:complexType>
+          <s:all>
+            <s:element name="tickerSymbol" type="s:string" />
+          </s:all>
+        </s:complexType>
       </s:element>
       <s:element name="GetInfoResult">
-	<s:complexType>
-	  <s:all>
-	    <s:element name="result" type="s:decimal"/>
-	  </s:all>
-	</s:complexType>
+        <s:complexType>
+          <s:all>
+            <s:element name="result" type="s:decimal" />
+          </s:all>
+        </s:complexType>
       </s:element>
       <s:element name="issue468">
-	<s:complexType>
-	  <s:sequence>
-	    <s:element name="issue468_1" nillable="true" type="s:string"/>
-	  </s:sequence>
-	</s:complexType>
+        <s:complexType>
+          <s:sequence>
+            <s:element name="issue468_1" nillable="true" type="s:string" />
+          </s:sequence>
+        </s:complexType>
       </s:element>
       <s:complexType name="issue560_1">
-	<s:complexContent>
-	  <s:extension base="tns:issue560_2">
-	    <s:sequence>
-	      <s:element name="issue560_1" nillable="false" type="s:string"/>
-	    </s:sequence>
-	  </s:extension>
-	</s:complexContent>
+        <s:complexContent>
+          <s:extension base="tns:issue560_2">
+            <s:sequence>
+              <s:element name="issue560_1" nillable="false" type="s:string" />
+            </s:sequence>
+          </s:extension>
+        </s:complexContent>
       </s:complexType>
       <s:complexType name="issue560_2">
-	<s:complexContent>
-	  <s:extension base="tns:issue560_3">
-	    <s:sequence>
-	      <s:element name="issue560_2" nillable="false" type="s:string"/>
-	    </s:sequence>
-	  </s:extension>
-	</s:complexContent>
+        <s:complexContent>
+          <s:extension base="tns:issue560_3">
+            <s:sequence>
+              <s:element name="issue560_2" nillable="false" type="s:string" />
+            </s:sequence>
+          </s:extension>
+        </s:complexContent>
       </s:complexType>
       <s:complexType name="issue560_3">
-	<s:sequence>
-	  <s:element name="issue560_3" nillable="false" type="s:string"/>
-	</s:sequence>
+        <s:sequence>
+          <s:element name="issue560_3" nillable="false" type="s:string" />
+        </s:sequence>
       </s:complexType>
-      <s:element name="issue560" type="tns:issue560_1"/>
-      <s:element name="issue663" type="tns:issue663"/>
+      <s:element name="issue560" type="tns:issue560_1" />
+      <s:element name="issue663" type="tns:issue663" />
       <s:complexType name="issue663">
         <s:sequence>
-          <s:element name="i663list" type="tns:i663list" maxOccurs="1" minOccurs="1"/>
+          <s:element name="i663list" type="tns:i663list" maxOccurs="1" minOccurs="1" />
         </s:sequence>
       </s:complexType>
       <s:complexType name="i663list">
         <s:sequence>
-          <s:element maxOccurs="unbounded" minOccurs="0" name="i663element" type="tns:i663element"/>
+          <s:element maxOccurs="unbounded" minOccurs="0" name="i663element" type="tns:i663element" />
         </s:sequence>
       </s:complexType>
       <s:complexType name="i663element">
         <s:sequence>
-          <s:element maxOccurs="1" minOccurs="1" name="i663element_2" type="s:string"/>
-          <s:element maxOccurs="1" minOccurs="1" name="i663element_3" type="s:string"/>
+          <s:element maxOccurs="1" minOccurs="1" name="i663element_2" type="s:string" />
+          <s:element maxOccurs="1" minOccurs="1" name="i663element_3" type="s:string" />
         </s:sequence>
       </s:complexType>
       <s:complexType name="i975">
-	<s:simpleContent>
+        <s:simpleContent>
           <s:extension base="tns:i975_1">
-            <s:attribute name="info" type="s:string" use="required"/>
+            <s:attribute name="info" type="s:string" use="required" />
           </s:extension>
         </s:simpleContent>
       </s:complexType>
       <s:simpleType name="i975_1">
-	<restriction base="xsd:string">
-	  <!-- "length" and "pattern" restrictions not yet supported -->
-          <length value="18"/>
-          <pattern value='[a-zA-Z0-9]{18}'/>
+        <restriction base="xsd:string">
+          <!-- "length" and "pattern" restrictions not yet supported -->
+          <length value="18" />
+          <pattern value="[a-zA-Z0-9]{18}" />
         </restriction>
       </s:simpleType>
       <s:complexType name="i984">
         <s:sequence>
           <s:element name="i984_empty">
-	    <s:complexType>
-	    </s:complexType>
-	  </s:element>
+            <s:complexType />
+          </s:element>
         </s:sequence>
       </s:complexType>
-      <s:element name="issue984" type="tns:i984"/>
+      <s:element name="issue984" type="tns:i984" />
       <s:complexType name="i985_2">
-	<s:complexContent>
+        <s:complexContent>
           <s:extension base="tns:i985_1">
             <s:sequence>
-              <s:element maxOccurs="1" minOccurs="1" name="i985_e2" type="s:string"/>
+              <s:element maxOccurs="1" minOccurs="1" name="i985_e2" type="s:string" />
             </s:sequence>
-	  </s:extension>
-	</s:complexContent>
+          </s:extension>
+        </s:complexContent>
       </s:complexType>
       <s:complexType name="i985_1">
-	<s:sequence>
-	  <s:element name="i985_e1" nillable="true" type="s:string"/>
-	</s:sequence>
+        <s:sequence>
+          <s:element name="i985_e1" nillable="true" type="s:string" />
+        </s:sequence>
       </s:complexType>
-      <s:element name="issue985" type="tns:i985_1"/>
+      <s:element name="issue985" type="tns:i985_1" />
+      <s:element name="string" nillable="true" type="s:string" />
     </s:schema>
     <s:schema xmlns:tns1="http://qore.org/simpletest1" elementFormDefault="qualified" targetNamespace="http://qore.org/simpletest1">
-      <s:element name="issue86" type="tns1:issue86_1"/>
+      <s:element name="issue86" type="tns1:issue86_1" />
       <s:complexType name="issue86_1">
-	<s:sequence>
-	  <s:element name="issue86_1_1" nillable="false" type="s:string"/>
-	</s:sequence>
+        <s:sequence>
+          <s:element name="issue86_1_1" nillable="false" type="s:string" />
+        </s:sequence>
       </s:complexType>
     </s:schema>
   </wsdl:types>
-
   <wsdl:message name="m1">
-    <wsdl:part name="body" element="tns:GetInfo"/>
+    <wsdl:part name="body" element="tns:GetInfo" />
   </wsdl:message>
-
   <wsdl:message name="m2">
-    <wsdl:part name="body" element="tns:GetInfoResult"/>
-    <wsdl:part name="docs" type="s:string"/>
-    <wsdl:part name="logo" type="s:base64Binary"/>
+    <wsdl:part name="body" element="tns:GetInfoResult" />
+    <wsdl:part name="docs" type="s:string" />
+    <wsdl:part name="logo" type="s:base64Binary" />
   </wsdl:message>
-
   <wsdl:message name="m3">
-    <wsdl:part name="body" element="tns:SetInfo"/>
-    <wsdl:part name="test" element="tns:Test"/>
-    <wsdl:part name="issue86" element="tns:issue86"/>
-    <wsdl:part name="issue87" element="tns:issue87"/>
-    <wsdl:part name="issue97" element="tns:issue97"/>
-    <wsdl:part name="issue468" element="tns:issue468"/>
-    <wsdl:part name="issue560" element="tns:issue560"/>
-    <wsdl:part name="issue984" element="tns:issue984"/>
-    <wsdl:part name="issue985" element="tns:issue985"/>
-    <wsdl:part name="logo" type="s:base64Binary"/>
+    <wsdl:part name="body" element="tns:SetInfo" />
+    <wsdl:part name="test" element="tns:Test" />
+    <wsdl:part name="issue86" element="tns:issue86" />
+    <wsdl:part name="issue87" element="tns:issue87" />
+    <wsdl:part name="issue97" element="tns:issue97" />
+    <wsdl:part name="issue468" element="tns:issue468" />
+    <wsdl:part name="issue560" element="tns:issue560" />
+    <wsdl:part name="issue984" element="tns:issue984" />
+    <wsdl:part name="issue985" element="tns:issue985" />
+    <wsdl:part name="logo" type="s:base64Binary" />
   </wsdl:message>
-
   <wsdl:message name="m4">
-    <wsdl:part name="body" element="tns:SetInfoResult"/>
-    <wsdl:part name="issue663" element="tns:issue663"/>
+    <wsdl:part name="body" element="tns:SetInfoResult" />
+    <wsdl:part name="issue663" element="tns:issue663" />
   </wsdl:message>
-
   <wsdl:message name="m5">
-    <wsdl:part name="country" type="s:string"/>
-    <wsdl:part name="city" type="s:string"/>
-    <wsdl:part name="zip" type="s:integer"/>
+    <wsdl:part name="country" type="s:string" />
+    <wsdl:part name="city" type="s:string" />
+    <wsdl:part name="zip" type="s:integer" />
   </wsdl:message>
-
   <wsdl:message name="m6">
-    <wsdl:part name="info" type="s:string"/>
+    <wsdl:part name="info" type="s:string" />
   </wsdl:message>
-
   <wsdl:message name="m7">
-    <wsdl:part name="img" type="s:base64Binary"/>
+    <wsdl:part name="img" type="s:base64Binary" />
   </wsdl:message>
-
   <wsdl:message name="m8">
-    <wsdl:part name="payload" type="s:base64Binary"/>
+    <wsdl:part name="payload" type="s:base64Binary" />
   </wsdl:message>
-
+  <wsdl:message name="m9">
+    <wsdl:part name="STR" element="tns:string" />
+  </wsdl:message>
   <wsdl:portType name="pt1">
     <wsdl:operation name="getInfo">
-      <wsdl:input message="tns:m1"/>
-      <wsdl:output message="tns:m2"/>
+      <wsdl:input message="tns:m1" />
+      <wsdl:output message="tns:m2" />
     </wsdl:operation>
     <wsdl:operation name="setInfo">
-      <wsdl:input message="tns:m3"/>
-      <wsdl:output message="tns:m4"/>
+      <wsdl:input message="tns:m3" />
+      <wsdl:output message="tns:m4" />
     </wsdl:operation>
     <wsdl:operation name="noInput">
-      <wsdl:output message="tns:m4"/>
+      <wsdl:output message="tns:m4" />
     </wsdl:operation>
     <wsdl:operation name="noOutput">
-      <wsdl:input message="tns:m3"/>
+      <wsdl:input message="tns:m3" />
     </wsdl:operation>
-    <wsdl:operation name="headerVal">
-    </wsdl:operation>
-    <wsdl:operation name="headerVal-doc">
-    </wsdl:operation>
+    <wsdl:operation name="headerVal" />
+    <wsdl:operation name="headerVal-doc" />
   </wsdl:portType>
-
   <wsdl:binding name="b1" type="tns:pt1">
-    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc" />
     <wsdl:operation name="getInfo">
-      <soap12:operation soapAction="http://qore.org/getInfo"/>
+      <soap12:operation soapAction="http://qore.org/getInfo" />
       <wsdl:input>
-	<soap12:body use="literal"/>
+        <soap12:body use="literal" />
       </wsdl:input>
       <wsdl:output>
-	<soap12:body use="literal"/>
+        <soap12:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
     <wsdl:operation name="setInfo">
-      <soap12:operation soapAction="http://qore.org/setInfo"/>
+      <soap12:operation soapAction="http://qore.org/setInfo" />
       <wsdl:input>
-	<soap12:body use="literal"/>
+        <soap12:body use="literal" />
       </wsdl:input>
       <wsdl:output>
-	<soap12:body use="literal"/>
+        <soap12:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
     <wsdl:operation name="noInput">
-      <soap12:operation soapAction="http://qore.org/noInput"/>
+      <soap12:operation soapAction="http://qore.org/noInput" />
       <wsdl:output>
-	<soap12:body use="literal"/>
+        <soap12:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
     <wsdl:operation name="noOutput">
-      <soap12:operation soapAction="http://qore.org/noOutput"/>
+      <soap12:operation soapAction="http://qore.org/noOutput" />
       <wsdl:input>
-	<soap12:body use="literal"/>
+        <soap12:body use="literal" />
       </wsdl:input>
     </wsdl:operation>
     <wsdl:operation name="headerVal">
-      <soap12:operation soapAction="http://qore.org/headerVal"/>
+      <soap12:operation soapAction="http://qore.org/headerVal" />
       <wsdl:input>
-        <soap12:header message="m1" part="body" use="literal"/>
-        <soap12:header message="m2" part="docs" use="encoded"/>
-        <soap12:header message="m3" part="body" use="literal"/>
+        <soap12:header message="m1" part="body" use="literal" />
+        <soap12:header message="m2" part="docs" use="encoded" />
+        <soap12:header message="m3" part="body" use="literal" />
       </wsdl:input>
     </wsdl:operation>
     <wsdl:operation name="headerVal-doc">
-      <soap12:operation soapAction="http://qore.org/headerVal" style="document"/>
+      <soap12:operation soapAction="http://qore.org/headerVal" style="document" />
       <wsdl:input>
-        <soap12:header message="m1" part="body" use="literal"/>
-        <soap12:header message="m2" part="docs" use="encoded"/>
-        <soap12:header message="m3" part="body" use="literal"/>
+        <soap12:header message="m1" part="body" use="literal" />
+        <soap12:header message="m2" part="docs" use="encoded" />
+        <soap12:header message="m3" part="body" use="literal" />
       </wsdl:input>
     </wsdl:operation>
   </wsdl:binding>
-
   <wsdl:portType name="pt2">
     <wsdl:operation name="urlRepl">
-	  <wsdl:input message="tns:m5"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m5" />
+    </wsdl:operation>
     <wsdl:operation name="urlEncoded1">
-	  <wsdl:input message="tns:m5"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m5" />
+    </wsdl:operation>
     <wsdl:operation name="urlEncoded2">
-	  <wsdl:input message="tns:m5"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m5" />
+    </wsdl:operation>
     <wsdl:operation name="postForm">
-	  <wsdl:input message="tns:m5"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m5" />
+    </wsdl:operation>
     <wsdl:operation name="postText">
-	  <wsdl:input message="tns:m6"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m6" />
+    </wsdl:operation>
     <wsdl:operation name="postImg">
-	  <wsdl:input message="tns:m7"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m7" />
+    </wsdl:operation>
     <wsdl:operation name="postImg2">
-	  <wsdl:input message="tns:m7"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m7" />
+    </wsdl:operation>
     <wsdl:operation name="postImg3">
-	  <wsdl:input message="tns:m7"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m7" />
+    </wsdl:operation>
     <wsdl:operation name="postData">
-	  <wsdl:input message="tns:m8"/>
-	</wsdl:operation>
+      <wsdl:input message="tns:m8" />
+    </wsdl:operation>
+    <wsdl:operation name="getMimeXml">
+      <wsdl:output message="tns:m9" />
+    </wsdl:operation>
   </wsdl:portType>
-
   <wsdl:binding name="b2" type="tns:pt2">
-    <http:binding verb="GET"/>
+    <http:binding verb="GET" />
     <wsdl:operation name="urlRepl">
-	  <http:operation location="get/(country)/(zip)-(city)"/>
-	  <input>
-	    <http:urlReplacement/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="get/(country)/(zip)-(city)" />
+      <input>
+        <http:urlReplacement />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="urlEncoded1">
-	  <http:operation location="get"/>
-	  <input>
-	    <http:urlEncoded/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="get" />
+      <input>
+        <http:urlEncoded />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="urlEncoded2">
-	  <http:operation location="get?test"/>
-	  <input>
-	    <http:urlEncoded/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="get?test" />
+      <input>
+        <http:urlEncoded />
+      </input>
+    </wsdl:operation>
+    <wsdl:operation name="getMimeXml">
+      <http:operation location="/getMimeXml" />
+      <wsdl:output>
+        <mime:mimeXml part="STR" />
+      </wsdl:output>
+    </wsdl:operation>
   </wsdl:binding>
-
   <wsdl:binding name="b3" type="tns:pt2">
-    <http:binding verb="POST"/>
+    <http:binding verb="POST" />
     <wsdl:operation name="postForm">
-	  <http:operation location="postform"/>
-	  <input>
-		<mime:content type="application/x-www-form-urlencoded"/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="postform" />
+      <input>
+        <mime:content type="application/x-www-form-urlencoded" />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="postText">
-	  <http:operation location="posttext"/>
-	  <input>
-	    <mime:content type="text/plain"/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="posttext" />
+      <input>
+        <mime:content type="text/plain" />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="postImg">
-	  <http:operation location="postimg"/>
-	  <input>
-	    <mime:content type="image/png"/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="postimg" />
+      <input>
+        <mime:content type="image/png" />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="postImg2">
-	  <http:operation location="postimg2"/>
-	  <input>
-	    <mime:content type="image/jpeg"/>
-	    <mime:content type="image/png"/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="postimg2" />
+      <input>
+        <mime:content type="image/jpeg" />
+        <mime:content type="image/png" />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="postImg3">
-	  <http:operation location="postimg3"/>
-	  <input>
-	    <mime:content type="image/*"/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="postimg3" />
+      <input>
+        <mime:content type="image/*" />
+      </input>
+    </wsdl:operation>
     <wsdl:operation name="postData">
-	  <http:operation location="postdata"/>
-	  <input>
-	    <mime:content type="*/*"/>
-	  </input>
-	</wsdl:operation>
+      <http:operation location="postdata" />
+      <input>
+        <mime:content type="*/*" />
+      </input>
+    </wsdl:operation>
   </wsdl:binding>
-
   <wsdl:service name="InfoService">
     <wsdl:port name="InfoPort" binding="tns:b1">
-      <soap12:address location="http://localhost:8001/SOAP/simple"/>
+      <soap12:address location="http://localhost:8001/SOAP/simple" />
     </wsdl:port>
   </wsdl:service>
-
 </wsdl:definitions>
+


### PR DESCRIPTION
HTTP binding for SOAP is somehow implemented. There is also support for multibinding, urlEncoded, form encoded, binary types, SOAP data in headers etc. HTTP binding has sense for SOAP client only now. SOAP server is probably not responsible for general HTTP messages, because Content-type is not application/soap+xml etc. then SoapHandler won't capture messages. It would require rewriting handlers as well. As SOAP is overcomplicated, there are "hundreds" combinations, weak SOAP doc and lack of real examples we should adjust it when we have real use case.