### PR TITLE
refs #3696 implemented support for connection serialization and remov…

### DIFF
--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -332,6 +332,11 @@ printf("%s\n", make_xml(h, XGF_ADD_FORMATTING));
 
     @subsection xml15 xml Module Version 1.5
     <b>Changes and Bug Fixes in This Release</b>
+    - fixed a bug where the <a href="../../SoapClient/html/index.html">SoapClient</a> class would force the receipt of
+      a message body even if there was no output message defined for the operation
+      (<a href="https://github.com/qorelanguage/qore/issues/3706">issue 3706</a>)
+    - implemented support for serializing connection objects
+      (<a href="https://github.com/qorelanguage/qore/issues/3696">issue 3696</a>)
     - fixed a bug where serialization errors were not thrown wtih unserializable data types
       (<a href="https://github.com/qorelanguage/qore/issues/3588">issue 3588</a>)
     - added support for the data provider API
@@ -343,7 +348,8 @@ printf("%s\n", make_xml(h, XGF_ADD_FORMATTING));
     - updated the <a href="../../SoapClient/html/index.html">SoapClient</a> and
       <a href="../../SalesforceSoapClient/html/index.html">SalesforceSoapClient</a> modules to support the updated
       abstract connection API (<a href="https://github.com/qorelanguage/qore/issues/2628">issue 2628</a>)
-    - updated the <a href="../../WSDL/html/index.html">WSDL</a> module with serialization support for the \c WebService class
+    - updated the <a href="../../WSDL/html/index.html">WSDL</a> module with serialization support for the
+      \c WebService class
       (<a href="https://github.com/qorelanguage/qore/issues/2793">issue 2793</a>)
 
     @subsection xml142 xml Module Version 1.4.2

--- a/qlib/SalesforceSoapClient.qm
+++ b/qlib/SalesforceSoapClient.qm
@@ -36,7 +36,7 @@
 %enable-all-warnings
 
 module SalesforceSoapClient {
-    version = "1.2";
+    version = "1.3";
     desc = "Salesforce SOAP Client Definition module";
     author = "Qore Technologies, s.r.o.";
     url = "http://qoretechnologies.com";
@@ -81,11 +81,16 @@ hash opts = (
 
 SalesforceSoapClient sc(opts);
 string ss = sprintf("select id, name, description, accountnumber from account where accountnumber = '%s'", AcctNo1);
-hash rh = sc.query(("queryString": ss));
+hash<auto> rh = sc.query({"queryString": ss});
 printf("%N\n", rh);
     @endcode
 
     @section salesforcesoapclientrelnotes SalesforceSoapClient Release Notes
+
+    @subsection salesfocesoapclient_1_3 SalesforceSoapClient v1.3
+    - removed the obsolete \c SalesforceSoapConnection::getConstructorInfo() method as connection serialization is a
+      much more elegant and maintainable solution
+      (<a href="https://github.com/qorelanguage/qore/issues/3696">issue 3696</a>)
 
     @subsection salesfocesoapclient_1_2 SalesforceSoapClient v1.2
     - added the @ref SalesforceSoapClient::SalesforceSoapConnection::getConstructorInfo() "SalesforceSoapConnection::getConstructorInfo()"
@@ -160,7 +165,7 @@ public namespace SalesforceSoapClient {
             - \c token: (required) Salesforce.com user API token
             - \c force_logout (optional) forces a logout when the SalesforceSoapClient object is destroyed; this should normally be @ref Qore::False "False" to allow for the session to remain valid
          */
-        constructor(hash opts) : SoapClient(opts) {
+        constructor(hash<auto> opts) : SoapClient(opts) {
             processOpts(opts);
         }
 
@@ -173,7 +178,7 @@ public namespace SalesforceSoapClient {
         }
 
         #! processes options given in the constructor()
-        private processOpts(hash opts) {
+        private processOpts(hash<auto> opts) {
             foreach string opt in (AuthorizationOpts) {
                 if (!opts{opt})
                     throw "SALESFORCE-SOAP-ERROR", sprintf("missing required option %y", opt);
@@ -243,7 +248,7 @@ public namespace SalesforceSoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
          */
-        auto callOperation(string operation, auto args, *hash opts, *reference info) {
+        auto callOperation(string operation, auto args, *hash<auto> opts, *reference<auto> info) {
             lck.lock();
             on_exit lck.unlock();
 
@@ -282,7 +287,7 @@ public namespace SalesforceSoapClient {
 
             @note this method can throw any exception that @ref Qore::HTTPClient::send() "HTTPClient::send()" can throw as well as any XML parsing errors thrown by @ref Qore::XML::parse_xml() "parse_xml()"
          */
-        private auto callIntern(string operation, auto args, *hash opts, *reference info) {
+        private auto callIntern(string operation, auto args, *hash<auto> opts, *reference<auto> info) {
             # add session ID to SOAP call header
             if (sessionid)
                 opts.soap_header.sessionId = sessionid;
@@ -298,7 +303,7 @@ public namespace SalesforceSoapClient {
 
             @return the deserialized result of the SOAP call to the SOAP server
         */
-        auto call(string operation, auto args, *hash header) {
+        auto call(string operation, auto args, *hash<auto> header) {
             return callOperation(operation, args, ("soap_header": header));
         }
 
@@ -319,7 +324,7 @@ public namespace SalesforceSoapClient {
 
             @return the deserialized result of the SOAP call to the SOAP server
         */
-        auto call(string operation, auto args, reference info) {
+        auto call(string operation, auto args, reference<auto> info) {
             return callOperation(operation, args, NOTHING, \info);
         }
 
@@ -341,7 +346,7 @@ public namespace SalesforceSoapClient {
 
             @return the deserialized result of the SOAP call to the SOAP server
         */
-        auto call(reference info, string operation, auto args, *hash header) {
+        auto call(reference<auto> info, string operation, auto args, *hash<auto> header) {
             return callOperation(operation, args, ("soap_header": header), \info);
         }
 
@@ -464,7 +469,7 @@ public namespace SalesforceSoapClient {
 
             @throw SALESFORCE-SOAP-ERROR missing one or more of the required options: \c "username", \c "password", or \c "token"
          */
-        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+        constructor(string name, string description, string url, hash<auto> attributes = {}, hash<auto> options = {})
             : SoapConnection(name, description, url, attributes, options) {
             constructorInit();
         }
@@ -489,7 +494,7 @@ public namespace SalesforceSoapClient {
 
             @return a @ref SalesforceSoapClient object
         */
-        private SalesforceSoapClient getImpl(bool connect = True, *hash rtopts) {
+        private SalesforceSoapClient getImpl(bool connect = True, *hash<auto> rtopts) {
             hash callopts = real_opts + rtopts.("log", "dbglog");
             if (callopts.wsdl.typeCode() == NT_STRING)
                 callopts.wsdl = getWsdl(callopts.wsdl);
@@ -499,22 +504,6 @@ public namespace SalesforceSoapClient {
             if (connect)
                 sc.login();
             return sc;
-        }
-
-        #! returns a hash that can be used to contruct the object dynamically
-        /** @since %SalesforceSoapClient 1.1
-        */
-        private hash<ConnectionConstructorInfo> getConstructorInfoImpl() {
-            string my_pre_code = "*string def_path; string wsdl = WSDLLib::getWSDL(args[0].url, NOTHING, NOTHING, \def_path); args[0] += {\"wsdl\": new WebService(wsdl, {\"def_path\": def_path})} + rtopts.(\"log\", \"dbglog\");";
-            string my_post_code = "if (connect) {obj.login();}";
-
-            return new hash<ConnectionConstructorInfo>({
-                "module": "SalesforceSoapClient",
-                "class_name": "SalesforceSoapClient::SalesforceSoapClient",
-                "args": real_opts,
-                "pre_processing": my_pre_code,
-                "post_processing": my_post_code,
-            });
         }
 
         #! returns a WSDL::WebService object for the given URL using a cache for local files
@@ -562,7 +551,7 @@ public namespace SalesforceSoapClient {
         }
 
         #! gets options
-        hash getOptions() {
+        hash<auto> getOptions() {
             return Options;
         }
 
@@ -571,7 +560,7 @@ public namespace SalesforceSoapClient {
             - \c "log": a closure accepting a single string for logging
             - \c "dbglog": a closure taking a single string for detailed technical connection logging
         */
-        *hash getRuntimeOptions() {
+        *hash<auto> getRuntimeOptions() {
             return {
                 "log": True,
                 "dbglog": True,

--- a/qlib/SoapClient.qm
+++ b/qlib/SoapClient.qm
@@ -43,7 +43,7 @@
 %enable-all-warnings
 
 module SoapClient {
-    version = "0.3";
+    version = "0.4";
     desc = "SoapClient module";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -74,7 +74,7 @@ module SoapClient {
     Here is an example of how to use this module:
     @code{.py}
 %requires SoapClient
-SoapClient sc = new SoapClient(("wsdl" : "http://soap.server.org:8080/my-service?wsdl"));
+SoapClient sc = new SoapClient({"wsdl": "http://soap.server.org:8080/my-service?wsdl"});
 hash<auto> msg = getMessage();
 auto result = sc.call("SubmitDocument", msg);
     @endcode
@@ -99,6 +99,11 @@ auto result = sc.call("SubmitDocument", msg);
     - \c "timeout"
 
     @section soapclientrelnotes SoapClient Release Notes
+
+    @subsection soapclient_0_4 SoapClient v0.4
+    - removed the obsolete \c SoapConnection::getConstructorInfo() method as connection serialization is a
+      much more elegant and maintainable solution
+      (<a href="https://github.com/qorelanguage/qore/issues/3696">issue 3696</a>)
 
     @subsection soapclient_0_3 SoapClient v0.3
     - added the @ref SoapClient::SoapConnection::getConstructorInfo() "SoapConnection::getConstructorInfo()"
@@ -464,7 +469,15 @@ public namespace SoapClient {
             if (url_path) {
                 msg.path = rtrim(url_path, "/") + msg.path;
             }
-            msglog(('reason': 'request', 'method': msg.method, 'path': msg.path, 'header': hdr, 'content-type': msg."content-type" ?? msg.hdr."Content-Type" ?? msg.header."Content-Type", 'accept': msg.accept ?? msg.hdr.Accept ?? msg.header.Accept, 'body': msg.body));
+            msglog({
+                'reason': 'request',
+                'method': msg.method,
+                'path': msg.path,
+                'header': hdr,
+                'content-type': msg."content-type" ?? msg.hdr."Content-Type" ?? msg.header."Content-Type",
+                'accept': msg.accept ?? msg.hdr.Accept ?? msg.header.Accept,
+                'body': msg.body
+            });
             # apply content encoding here
             data body = msg.body ?? "";
             if (seh.ce && body.size() > CompressionThreshold) {
@@ -476,7 +489,8 @@ public namespace SoapClient {
             hash<auto> rh;
             try {
                 #printf("SoapClient::makeCallIntern: msg: %y\n", msg);
-                rh = send(body, msg.method, msg.path, hdr, True, \info);
+                # only try to read a message body in the response if the operation has an output message
+                rh = send(body, msg.method, msg.path, hdr, exists op.output, \info);
                 info."response-body" = rh.body;
                 http_status_code = rh.status_code;
             } catch (hash<ExceptionInfo> ex) {
@@ -808,22 +822,6 @@ private nothing msglog(hash<auto> msg) {
             if (connect)
                 sc.connect();
             return sc;
-        }
-
-        #! returns a hash that can be used to contruct the object dynamically
-        /** @since %SoapClient 0.3
-        */
-        private hash<ConnectionConstructorInfo> getConstructorInfoImpl() {
-            string my_pre_code = "args[0] += rtopts.(\"log\", \"dbglog\");";
-            string my_post_code = "if (connect) {obj.connect();}";
-
-            return new hash<ConnectionConstructorInfo>({
-                "module": "SoapClient",
-                "class_name": "SoapClient::SoapClient",
-                "args": real_opts,
-                "pre_processing": my_pre_code,
-                "post_processing": my_post_code,
-            });
         }
 
         #! gets options

--- a/qlib/XmlRpcConnection.qm
+++ b/qlib/XmlRpcConnection.qm
@@ -40,7 +40,7 @@
 %new-style
 
 module XmlRpcConnection {
-    version = "1.2";
+    version = "1.3";
     desc = "user module for providing XML-RPC client connections";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -67,6 +67,11 @@ module XmlRpcConnection {
     - @ref XmlRpcConnection::XmlRpcConnection "XmlRpcConnection"
 
     @section xmlrpcconnection_relnotes XmlRpcConnection Module Release History
+
+    @subsection xmlrpcconnection_v1_3 XmlRpcConnection v1.3
+    - removed the obsolete \c XmlRpcConnection::getConstructorInfo() method as connection serialization is a
+      much more elegant and maintainable solution
+      (<a href="https://github.com/qorelanguage/qore/issues/3696">issue 3696</a>)
 
     @subsection xmlrpcconnection_v1_2 XmlRpcConnection v1.2
     - new AbstractConnection infrastructure
@@ -98,7 +103,7 @@ public namespace XmlRpcConnection {
     */
     public class XmlRpcConnection inherits ConnectionProvider::HttpBasedConnection {
         public {
-            hash real_opts;
+            hash<auto> real_opts;
         }
 
         #! DEPRECATED: creates the XmlRpcConnection object
@@ -114,7 +119,7 @@ public namespace XmlRpcConnection {
         deprecated
         constructor(string name, string desc, string url, bool monitor, *hash opts, hash urlh)
             : HttpBasedConnection(name, desc, url, {"monitor": monitor}, opts ?? {}) {
-            real_opts = ("url": real_url) + self.opts;
+            real_opts = {"url": real_url} + self.opts;
         }
 
         #! creates the XmlRpcConnection object
@@ -126,9 +131,9 @@ public namespace XmlRpcConnection {
 
             See @ref AbstractConnection::constructor() for \c attributes and \c options reference.
          */
-        constructor(string name, string description, string url, hash attributes = {}, hash options = {})
+        constructor(string name, string description, string url, hash<auto> attributes = {}, hash<auto> options = {})
             : HttpBasedConnection(name, description, url, attributes, options) {
-            real_opts = ("url": real_url) + opts;
+            real_opts = {"url": real_url} + opts;
         }
 
         #! returns a @ref Qore::Xml::XmlRpcClient object
@@ -137,20 +142,8 @@ public namespace XmlRpcConnection {
 
             @return a @ref Qore::Xml::XmlRpcClient object
         */
-        private Qore::Xml::XmlRpcClient getImpl(bool connect = True, *hash rtopts) {
+        private Qore::Xml::XmlRpcClient getImpl(bool connect = True, *hash<auto> rtopts) {
             return new Qore::Xml::XmlRpcClient(real_opts, !connect);
-        }
-
-        #! returns a hash that can be used to contruct the object dynamically
-        /** @since %XmlRpcConnection 1.1
-        */
-        private hash<ConnectionConstructorInfo> getConstructorInfoImpl() {
-            return new hash<ConnectionConstructorInfo>((
-                "module": "xml",
-                "class_name": "Qore::Xml::XmlRpcClient",
-                "args": real_opts,
-                "pre_processing": "args[1] = !connect;",
-            ));
         }
 
         #! gets options
@@ -163,12 +156,12 @@ public namespace XmlRpcConnection {
 
             @see @ref Qore::Xml::XmlRpcClient::constructor() "XmlRpcClient::constructor()" for more information on the above options
         */
-        hash getOptions() {
+        hash<auto> getOptions() {
             return HttpConnection::Options;
         }
 
         #! returns default options
-        *hash getDefaultOptions() {
+        *hash<auto> getDefaultOptions() {
             return HttpConnection::DefaultOptions;
         }
 

--- a/test/Salesforce.com.qtest
+++ b/test/Salesforce.com.qtest
@@ -51,8 +51,7 @@ class SalesforceTest inherits QUnit::Test {
 
         try {
             setupConnection();
-        }
-        catch (hash ex) {
+        } catch (hash<ExceptionInfo> ex) {
             if (m_options.verbose)
                 printf("%s: %s\n", ex.err, ex.desc);
         }
@@ -97,8 +96,7 @@ class SalesforceTest inherits QUnit::Test {
         sc = new SalesforceSoapClient(opts);
         try {
             sc.login();
-        }
-        catch (hash<ExceptionInfo> ex) {
+        } catch (hash<ExceptionInfo> ex) {
             if ((ex.err == "SOAP-SERVER-FAULT-RESPONSE" && ex.arg.faultcode == "INVALID_LOGIN")
                 || (ex.err == "HTTP-CLIENT-RECEIVE-ERROR" && ex.desc =~ /Service Unavailable/)) {
                 delete sc;
@@ -112,8 +110,7 @@ class SalesforceTest inherits QUnit::Test {
             *list ids = getAccountIds(AcctNo1);
             if (ids)
                 sc.delete(("ids": ids));
-        }
-        catch (hash ex) {
+        } catch (hash<ExceptionInfo> ex) {
             printf("%s\n", get_exception_string(ex));
         }
     }
@@ -143,7 +140,7 @@ class SalesforceTest inherits QUnit::Test {
     string createAccount() {
         #hash del_note = get_qr(sc, "Note", ("Title": "Delete Me", "Body": del_text));
 
-        hash acct1 = {
+        hash<auto> acct1 = {
             "Name": AcctName1,
             "AccountNumber": AcctNo1,
             "Description": "test account",
@@ -154,8 +151,7 @@ class SalesforceTest inherits QUnit::Test {
         hash rh;
         try {
             rh = sc.create(("sObjects": sc.getType("Account", l)));
-        }
-        catch (hash<ExceptionInfo> ex) {
+        } catch (hash<ExceptionInfo> ex) {
             if (ex.err == "HTTP-CLIENT-RECEIVE-ERROR" && ex.arg.body =~ /INVALID_LOGIN/) {
                 delete sc;
                 testSkip("login failed");
@@ -250,54 +246,28 @@ class SalesforceTest inherits QUnit::Test {
             "done": True,
             "records": sc.getType(type, recs),
             "size": recs.size(),
-            );
+        );
     }
     */
 
     salesforceSoapConnectionTest() {
         # allow this test to run even if there is no Salesforce.com config in place
-        hash fake_opts = (
+        hash<auto> fake_opts = {
             "wsdl": get_script_dir() + "/test.wsdl",
             "username": "user",
             "password": "pass",
             "token": "token",
-        );
+        };
 
         string conn_url = "sfsoap://ignored";
         SalesforceSoapConnection conn("test", "test", conn_url, {"monitor": False}, fake_opts);
         SalesforceSoapClient sc = conn.get(False, opts.("log", "dbglog"));
+        # issue #3696: test connection serialization
+        SalesforceSoapConnection conn2 = Serializable::deserialize(conn.serialize());
+        assertEq(conn.url, conn2.url);
 
         string url = sc.getURL();
-        hash uh = parse_url(url);
+        hash<UrlInfo> uh = parse_url(url);
         assertEq("http", uh.protocol);
-
-        hash<ConnectionConstructorInfo> conn_info = conn.getConstructorInfo();
-        assertEq("SalesforceSoapClient", conn_info.module);
-        assertEq("SalesforceSoapClient::SalesforceSoapClient", conn_info.class_name);
-        assertEq(fake_opts, conn_info.args[0].(keys fake_opts));
-        assertEq(45s, conn_info.args[0].connect_timeout);
-        assertEq(45s, conn_info.args[0].timeout);
-        checkPreAndPostProcessing(conn_info);
-    }
-
-    private checkPreAndPostProcessing(hash<ConnectionConstructorInfo> info) {
-        if (info.pre_processing) {
-            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
-            if (info.module)
-                p.loadModule(info.module);
-            string pre_processing = sprintf("sub pre_processing(reference<*softlist<auto>> args, bool connect, *hash rtopts) { %s }", info.pre_processing);
-            # ensure that the pre processing code can be parsed
-            p.parse(pre_processing, "pre processing");
-            assertTrue(True, "pre processing: " + info.class_name);
-        }
-        if (info.post_processing) {
-            Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
-            if (info.module)
-                p.loadModule(info.module);
-            string post_processing = sprintf("sub post_processing(%s obj, bool connect, *hash rtopts) { %s }", info.class_name, info.post_processing);
-            # ensure that the post processing code can be parsed
-            p.parse(post_processing, "post processing");
-            assertTrue(True, "post processing: " + info.class_name);
-        }
     }
 }

--- a/test/SoapClient.qtest
+++ b/test/SoapClient.qtest
@@ -32,11 +32,23 @@ const ResponseBody = ("result": 99.9);
 
 class TestSoapHandler inherits SoapHandler {
     public {
-        list msglogs;
+        list<hash<auto>> msglogs;
+        *Queue queue;
     }
-    constructor(HttpServer::AbstractAuthenticator auth, *code n_getLogMessage, bool dbg = False): SoapHandler(auth, n_getLogMessage, dbg) {}
 
-    nothing msglog(hash cx, hash msg) {
+    constructor(HttpServer::AbstractAuthenticator auth, *code n_getLogMessage, bool dbg = False, *Queue queue)
+        : SoapHandler(auth, n_getLogMessage, dbg) {
+        self.queue = queue;
+    }
+
+    hash<HttpResponseInfo> handleRequest(HttpListenerInterface listener, Socket s, hash<auto> cx, hash<auto> hdr, *data body) {
+        if (queue) {
+            s.setEventQueue(queue, "server connection", True);
+        }
+        return SoapHandler::handleRequest(listener, s, cx, hdr, body);
+    }
+
+    nothing msglog(hash<auto> cx, hash<auto> msg) {
         push msglogs, msg;
     }
 }
@@ -45,19 +57,19 @@ class TestSoapServer inherits HttpServer {
     public {
         TestSoapHandler soap;
         string opname;
-        any mdata;
-        any rdata;
+        auto mdata;
+        auto rdata;
     }
 
     private {
         int verbose;
     }
 
-    constructor(WebService ws, int port, int verbose = 0) : HttpServer(\self.log(), \self.errlog(), verbose > 2) {
+    constructor(WebService ws, int port, int verbose = 0, *Queue queue) : HttpServer(\self.log(), \self.errlog(), verbose > 2) {
         self.verbose = verbose;
 
         # setup SOAP handler
-        soap = new TestSoapHandler(new PermissiveAuthenticator(), NOTHING, verbose > 2);
+        soap = new TestSoapHandler(new PermissiveAuthenticator(), NOTHING, verbose > 2, queue);
         setHandler("soap_prefix", "SOAP", MimeTypeSoapXml, soap, "soapaction", False);
         setDefaultHandler("soap", soap);
 
@@ -65,20 +77,22 @@ class TestSoapServer inherits HttpServer {
         soap.addMethod(ws, ws.getOperation("getInfo"), \getInfo(), NOTHING, NOTHING, NOTHING, "InfoService");
 
         # not yet supported
-        soap.addMethod(ws, ws.getOperation("urlRepl"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
-        soap.addMethod(ws, ws.getOperation("urlEncoded1"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
-#        soap.addMethod(ws, ws.getOperation("urlEncoded2"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
-        soap.addMethod(ws, ws.getOperation("getMimeXml"), \generalOutputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
-        soap.addMethod(ws, ws.getOperation("getBinary"), \generalOutputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("urlRepl"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("urlEncoded1"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("getMimeXml"), \generalOutputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b2");
+        soap.addMethod(ws, ws.getOperation("getBinary"), \generalOutputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b2");
 
-        soap.addMethod(ws, ws.getOperation("postForm"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
-        soap.addMethod(ws, ws.getOperation("postText"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
-        soap.addMethod(ws, ws.getOperation("postImg"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
-        soap.addMethod(ws, ws.getOperation("postImg2"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
-        soap.addMethod(ws, ws.getOperation("postImg3"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
-        soap.addMethod(ws, ws.getOperation("postData"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, /*path*/NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postForm"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postText"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postImg"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postImg2"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postImg3"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b3");
+        soap.addMethod(ws, ws.getOperation("postData"), \generalInputOnly(), NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, NOTHING, "b3");
 
         addListener(port);
+        if (queue) {
+            listeners.firstValue().setEventQueue(queue, "server", True);
+        }
     }
 
     hash getInfo(hash cx, hash h) {
@@ -136,18 +150,23 @@ class SoapClientTest inherits QUnit::Test {
             "port": "p,port=i",
             #"verbose": "verbose=i",  # already in Opts
             "host": "host=s",
+            "events": "e,show-events",
         );
 
-        const OptionColumn = 25;
         string url;
         int serverPort;
+
+        # event queue
+        Queue queue();
+
+        const OptionColumn = 25;
     }
 
     constructor() : QUnit::Test("SoapClientTest", "1.0", \ARGV, MyOpts) {
         WebService ws(WSDLLib::getFileFromURL(WsdlUrl));
 
         # start SOAP server server
-        server = new TestSoapServer(ws, m_options.port ?? DefaultPort, m_options.verbose);
+        server = new TestSoapServer(ws, m_options.port ?? DefaultPort, m_options.verbose, m_options.events ? queue : NOTHING);
         on_exit server.stop();
         serverPort = server.getListenerInfo(0).port;
         # when dual IPv4/IPv6 stack then may resolve gethostname() with unsupposed IP address where server is not listening
@@ -159,6 +178,11 @@ class SoapClientTest inherits QUnit::Test {
         addTestCase("HttpGetClientTest", \httpGetClientTest());
         addTestCase("HttpPostClientTest", \httpPostClientTest());
         addTestCase("SoapConnectionTest", \soapConnectionTest());
+
+        if (m_options.events) {
+            background eventThread();
+        }
+        on_exit if (m_options.events) queue.push();
 
         # execute tests
         set_return_value(main()); exit();
@@ -177,6 +201,10 @@ class SoapClientTest inherits QUnit::Test {
     soapClientTest() {
         #printf("url: %y\n", url);
         sc = new TestSoapClient(("wsdl": WsdlUrl, "port": "SoapPort", "url": url));
+
+        if (m_options.events) {
+            sc.setEventQueue(queue, "client", True);
+        }
 
         cleanMsgLog();
 
@@ -226,15 +254,19 @@ class SoapClientTest inherits QUnit::Test {
         #printf("url: %y\n", url);
         sc = new TestSoapClient(("wsdl": WsdlUrl, "port": "HttpGetPort", "url": url));
 
+        if (m_options.events) {
+            sc.setEventQueue(queue, "GET client", True);
+        }
+
         cleanMsgLog();
-        *hash h;
+        *hash<auto> h;
         assertThrows("HTTP-CLIENT-RECEIVE-ERROR", \sc.callOperation(), ("urlRepl", ("country": "CZ", "city": "Prague 2", "zip": 12000)));
         assertEq("/get/CZ/12000-Prague%202", sc.msglogs[0].path);
         assertEq(sc.msglogs[0].method, "GET");
 
         try {
             cleanMsgLog();
-            hash hi = ("country": "CZ", "city": "Prague_2", "zip": 12000);
+            hash<auto> hi = ("country": "CZ", "city": "Prague_2", "zip": 12000);
             h = sc.callOperation("urlEncoded1", hi);
             assertEq(server.opname, "urlEncoded1");
             assertEq(server.mdata, hi);
@@ -269,7 +301,12 @@ class SoapClientTest inherits QUnit::Test {
     httpPostClientTest() {
         #printf("url: %y\n", url);
         sc = new TestSoapClient(("wsdl": WsdlUrl, "port": "HttpPostPort", "url": url));
-        *hash h;
+
+        if (m_options.events) {
+            sc.setEventQueue(queue, "POST client", True);
+        }
+
+        *hash<auto> h;
         try {
             cleanMsgLog();
             hash hi = ("country": "CZ", "city": "Prague_2", "zip": 12000);
@@ -316,7 +353,6 @@ class SoapClientTest inherits QUnit::Test {
             assertEq(server.opname, "postData");
             assertEq(hi.payload."^attributes^"."^content-type^", sc.msglogs[0].header."Content-Type");
             assertEq(hi, server.mdata);
-
         } catch (hash<ExceptionInfo> ex) {
             printf("Exception: %s\n", get_exception_string(ex));
             rethrow;
@@ -332,45 +368,46 @@ class SoapClientTest inherits QUnit::Test {
 
         SoapConnection conn("test", "test", conn_url, False, ("target_url": url, "port": "SoapPort"), parse_url(conn_url));
         SoapClient sc2 = conn.get();
-        hash h = sc2.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
+        hash<auto> h = sc2.callOperation("getInfo", ("GetInfo": ("tickerSymbol": "ABC")), ("soapaction": ""));
         assertEq(99.9, h.body.result);
         assertEq("ABC", h.docs);
         assertEq(binary(), h.logo);
 
-        hash<ConnectionConstructorInfo> conn_info = conn.getConstructorInfo();
-        assertEq("SoapClient", conn_info.module);
-        assertEq("SoapClient::SoapClient", conn_info.class_name);
-        assertEq(url, conn_info.args[0].target_url);
-        assertEq(url, conn_info.args[0].url);
-        assertEq(45s, conn_info.args[0].connect_timeout);
-        assertEq(45s, conn_info.args[0].timeout);
-        checkPreAndPostProcessing(conn_info);
+        # issue #3696: test connection serialization
+        SoapConnection conn2 = Serializable::deserialize(conn.serialize());
+        assertEq(conn.url, conn2.url);
     }
 
-    private checkPreAndPostProcessing(hash<ConnectionConstructorInfo> info) {
-        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
-        if (info.module) {
-            p.loadModule(info.module);
-        }
-        if (info.pre_processing) {
-            string pre_processing = sprintf("sub pre_processing(reference<*softlist<auto>> args, bool connect, *hash rtopts) { %s }", info.pre_processing);
-            # ensure that the pre processing code can be parsed
-            p.parsePending(pre_processing, "pre processing");
-        }
-        if (info.post_processing) {
-            string post_processing = sprintf("sub post_processing(%s obj, bool connect, *hash rtopts) { %s }", info.class_name, info.post_processing);
-            # ensure that the post processing code can be parsed
-            p.parsePending(post_processing, "post processing");
-        }
+    private eventThread() {
+        while (True) {
+            # get a message from the event queue; a hash is returned with at
+            # least the following keys: "event" with the event code, and
+            # "source" with the event source identifier
 
-        if (info.pre_processing || info.post_processing) {
-            p.parseCommit();
-        }
-        if (info.pre_processing) {
-            assertTrue(True, "pre processing: " + info.class_name);
-        }
-        if (info.post_processing) {
-            assertTrue(True, "post processing: " + info.class_name);
+            *hash<auto> e = queue.get();
+
+            # stop listening when empty event posted to queue in constructor()
+            if (!e)
+                return;
+
+            if (e.data.typeCode() == NT_BINARY) {
+                string str = e.data.toString();
+                delete e.data;
+                for (int i = 0, int end = str.length(); i < end; ++i) {
+                    string char = str[i];
+                    int uc = char.getUnicode();
+                    if (uc < 32 || uc >= 127) {
+                        e.data += sprintf("<%x>", uc);
+                    } else {
+                        e.data += char;
+                    }
+                }
+            }
+
+            e.id = sprintf("%x", e.id);
+
+            printf("%s %s: %y\n", EVENT_SOURCE_MAP.(e.source), EVENT_MAP.(e.event), e - ("event", "source"));
+            flush(); # flush output
         }
     }
 }

--- a/test/XmlRpcClient.qtest
+++ b/test/XmlRpcClient.qtest
@@ -42,28 +42,8 @@ class XmlRpcClientTest inherits QUnit::Test {
         yurl =~ s/^xmlrpc/http/;
         assertEq(yurl + "/RPC2", client.getURL());
 
-        hash<ConnectionConstructorInfo> info = conn.getConstructorInfo();
-        assertEq("xml", info.module);
-        assertEq("Qore::Xml::XmlRpcClient", info.class_name);
-        assertEq("https://localhost:8099", info.args[0].url);
-        checkPreAndPostProcessing(info);
-    }
-
-    private checkPreAndPostProcessing(hash<ConnectionConstructorInfo> info) {
-        Program p(PO_NEW_STYLE | PO_STRICT_ARGS | PO_REQUIRE_TYPES);
-        if (info.module)
-            p.loadModule(info.module);
-        if (info.pre_processing) {
-            string pre_processing = sprintf("sub pre_processing(reference<*softlist<auto>> args, bool connect, *hash rtopts) { %s }", info.pre_processing);
-            # ensure that the pre processing code can be parsed
-            p.parse(pre_processing, "pre processing");
-            assertTrue(True, "pre processing: " + info.class_name);
-        }
-        if (info.post_processing) {
-            string post_processing = sprintf("sub post_processing(%s obj, bool connect, *hash rtopts) { %s }", info.class_name, info.post_processing);
-            # ensure that the post processing code can be parsed
-            p.parse(post_processing, "post processing");
-            assertTrue(True, "post processing: " + info.class_name);
-        }
+        # issue #3696: test connection serialization
+        XmlRpcConnection conn2 = Serializable::deserialize(conn.serialize());
+        assertEq(conn.url, conn2.url);
     }
 }


### PR DESCRIPTION
…ed the obsolete and unused getConstructorInfo() methods

refs #3706 fixed a bug where the SoapClient class would attempt to force the receipt of a message body in the server response even if no output message exists