### PR TITLE
Correct license type for OBS and fdupes

### DIFF
--- a/qore-xml-module.spec
+++ b/qore-xml-module.spec
@@ -42,7 +42,7 @@ Summary: XML module for Qore
 Name: qore-xml-module
 Version: %{mod_ver}
 Release: 1%{dist}
-License: LGPL
+License: LGPL-2.1-or-later OR GPL-2.0-or-later OR MIT
 Group: Development/Languages/Other
 URL: http://qore.org
 Source: http://prdownloads.sourceforge.net/qore/%{name}-%{version}.tar.bz2

--- a/qore-xml-module.spec
+++ b/qore-xml-module.spec
@@ -54,6 +54,7 @@ BuildRequires: qore-devel >= 1.0
 BuildRequires: libxml2-devel
 BuildRequires: openssl-devel
 BuildRequires: qore
+BuildRequires: fdupes
 
 %description
 This package contains the xml module for the Qore Programming Language.
@@ -91,6 +92,7 @@ mkdir -p $RPM_BUILD_ROOT/%{module_dir}
 mkdir -p $RPM_BUILD_ROOT/%{user_module_dir}
 mkdir -p $RPM_BUILD_ROOT/usr/share/doc/qore-xml-module
 make install DESTDIR=$RPM_BUILD_ROOT
+%fdupes -s %{__builddir}/html
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
- Change license type to "LGPL-2.1-or-later OR GPL-2.0-or-later OR MIT"
- Add fdupes, that SLE can identify all required files